### PR TITLE
Fix typo in repository URL

### DIFF
--- a/html/src/index.pug
+++ b/html/src/index.pug
@@ -1124,7 +1124,7 @@ html
                                         span.name {{ $t("view.settings.general.general.latest_app_version") }}
                                         span.extra(v-if="latestAppVersion" v-text="latestAppVersion")
                                         span.extra(v-else) {{ $t("view.settings.general.general.latest_app_version_refresh") }}
-                                .x-friend-item(@click="openExternalLink('https://github.com/pvrcx-team/VRCX')")
+                                .x-friend-item(@click="openExternalLink('https://github.com/vrcx-team/VRCX')")
                                     .detail
                                         span.name {{ $t("view.settings.general.general.repository_url") }}
                                         span.extra https://github.com/vrcx-team/VRCX


### PR DESCRIPTION
Hello!
I appreciate your great work on this project!

I noticed that the repository URL was incorrect, so I have made the necessary adjustments to fix it. To reproduce the issue, please go to the latest VRCX 2023.05.01, navigate to the settings, then general, and finally click on the repository URL. You will see that the link is broken.

Kind regards,