### PR TITLE
feat: Add new request types, world param, better error handling

### DIFF
--- a/WorldDBManager.cs
+++ b/WorldDBManager.cs
@@ -345,6 +345,12 @@ namespace VRCX
             return ConstructSuccessResponse(JsonConvert.SerializeObject(data), connectionKey);
         }
 
+        /// <summary>
+        /// Attempts to initialize a world with the given ID by generating a connection key and adding it to the world database if it does not already exist.
+        /// </summary>
+        /// <param name="worldId">The ID of the world to initialize.</param>
+        /// <param name="connectionKey">The connection key generated for the world.</param>
+        /// <returns>True if the world was successfully initialized, false otherwise.</returns>
         private bool TryInitializeWorld(string worldId, out string connectionKey)
         {
             if (String.IsNullOrEmpty(worldId))
@@ -593,13 +599,12 @@ namespace VRCX
             }
         }
 
-        private void LogWarning(string message, params object[] args)
-        {
-            logger.Warn("World {0} - " + message, args);
-            this.lastError = String.Format(message, args);
-        }
-
-
+        /// <summary>
+        /// Sets a property for a given world in the world database.
+        /// </summary>
+        /// <param name="worldId">The ID of the world to set the property for.</param>
+        /// <param name="key">The key of the property to set.</param>
+        /// <param name="value">The value to set the property to.</param>
         public void SetWorldProperty(string worldId, string key, string value)
         {
             switch (key)
@@ -619,6 +624,12 @@ namespace VRCX
             }
         }
 
+        /// <summary>
+        /// Stores a data entry for a given world in the world database.
+        /// </summary>
+        /// <param name="worldId">The ID of the world to store the data entry for.</param>
+        /// <param name="key">The key of the data entry to store.</param>
+        /// <param name="value">The value of the data entry to store.</param>
         public void StoreWorldData(string worldId, string key, string value)
         {
             // Get/calculate the old and new data sizes for this key/the world
@@ -642,6 +653,11 @@ namespace VRCX
             logger.Debug("{0} : {1}", key, value);
         }
 
+        /// <summary>
+        /// Deletes a data entry for a given world from the world database.
+        /// </summary>
+        /// <param name="worldId">The ID of the world to delete the data entry from.</param>
+        /// <param name="key">The key of the data entry to delete.</param>
         public void DeleteWorldData(string worldId, string key)
         {
             int oldTotalDataSize = worldDB.GetWorldDataSize(worldId);

--- a/WorldDatabase.cs
+++ b/WorldDatabase.cs
@@ -164,6 +164,13 @@ END;";
             sqlite.Execute("UPDATE worlds SET allow_external_read = ? WHERE world_id = ?", allowExternalRead, worldId);
         }
 
+        public bool GetWorldAllowExternalRead(string worldId)
+        {
+            var query = sqlite.Table<World>().Where(w => w.WorldId == worldId).Select(w => w.AllowExternalRead);
+
+            return query.FirstOrDefault();
+        }
+
         /// <summary>
         /// Adds a new world to the database.
         /// </summary>

--- a/WorldDatabase.cs
+++ b/WorldDatabase.cs
@@ -164,6 +164,11 @@ END;";
             sqlite.Execute("UPDATE worlds SET allow_external_read = ? WHERE world_id = ?", allowExternalRead, worldId);
         }
 
+        /// <summary>
+        /// Gets the value of the allow_external_read field for the world with the specified ID from the database.
+        /// </summary>
+        /// <param name="worldId">The ID of the world to get the allow_external_read field for.</param>
+        /// <returns>The value of the allow_external_read field for the specified world.</returns>
         public bool GetWorldAllowExternalRead(string worldId)
         {
             var query = sqlite.Table<World>().Where(w => w.WorldId == worldId).Select(w => w.AllowExternalRead);
@@ -290,11 +295,20 @@ END;";
             return query.FirstOrDefault();
         }
 
+        /// <summary>
+        /// Deletes the data entry with the specified world ID and key from the database.
+        /// </summary>
+        /// <param name="worldId">The ID of the world to delete the data entry from.</param>
+        /// <param name="key">The key of the data entry to delete.</param>
         public void DeleteDataEntry(string worldId, string key)
         {
             sqlite.Execute("DELETE FROM data WHERE world_id = ? AND key = ?", worldId, key);
         }
 
+        /// <summary>
+        /// Deletes all data entries for the world with the specified ID from the database.
+        /// </summary>
+        /// <param name="worldId">The ID of the world to delete all data entries for.</param>
         public void DeleteAllDataEntriesForWorld(string worldId)
         {
             sqlite.Execute("DELETE FROM data WHERE world_id = ?", worldId);


### PR DESCRIPTION
Changes:
- Add the following new request types to log requests:
     - delete - Delete a given key from the database
     - delete-all - Delete all keys for the current world
     - set-setting - Set a given setting for the current world. Currently only supports externalReads
- Improve error handling for requests. Less chance of VRCX dying if something, or someone, is being screwy.
- Add docs for new methods