### PR TITLE
refactor: Replace UUID dependency with window.crypto.randomUUID()

### DIFF
--- a/html/package-lock.json
+++ b/html/package-lock.json
@@ -30,7 +30,6 @@
         "raw-loader": "^4.0.2",
         "sass": "^1.63.4",
         "sass-loader": "^13.3.2",
-        "uuid": "^9.0.0",
         "vue": "^2.6.14",
         "vue-data-tables": "^3.4.5",
         "vue-i18n": "^8.28.2",
@@ -6061,15 +6060,6 @@
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -10836,12 +10826,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
-      "dev": true
-    },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "dev": true
     },
     "void-elements": {

--- a/html/package.json
+++ b/html/package.json
@@ -46,7 +46,6 @@
     "raw-loader": "^4.0.2",
     "sass": "^1.63.4",
     "sass-loader": "^13.3.2",
-    "uuid": "^9.0.0",
     "vue": "^2.6.14",
     "vue-data-tables": "^3.4.5",
     "vue-i18n": "^8.28.2",

--- a/html/src/app.js
+++ b/html/src/app.js
@@ -13,7 +13,6 @@ import VueLazyload from 'vue-lazyload';
 import VueI18n from 'vue-i18n';
 import { DataTables } from 'vue-data-tables';
 import ElementUI from 'element-ui';
-import { v4 as uuidv4 } from 'uuid';
 import * as workerTimers from 'worker-timers';
 import VueMarkdown from 'vue-markdown';
 import 'default-passive-events';
@@ -18548,7 +18547,7 @@ speechSynthesis.getVoices();
             tags.push(`~region(jp)`);
         }
         if (D.accessType !== 'public' && D.accessType !== 'group') {
-            tags.push(`~nonce(${uuidv4()})`);
+            tags.push(`~nonce(${window.crypto.randomUUID()})`);
         }
         if (D.accessType !== 'invite' && D.accessType !== 'friends') {
             D.strict = false;

--- a/html/webpack.config.js
+++ b/html/webpack.config.js
@@ -11,8 +11,7 @@ module.exports = {
             'noty',
             'vue',
             'vue-data-tables',
-            'vue-lazyload',
-            'uuid'
+            'vue-lazyload'
         ],
         app: {
             import: ['./src/app.js', './src/app.scss'],


### PR DESCRIPTION
Remove the UUID dependency and replaces it with
the `window.crypto.randomUUID()` method. By utilizing the native browser function, we eliminate the need for an external library.

Using randomUUID() as a replacement for the uuid dependency is feasible since both of them implement UUID v4.
https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID