### PR TITLE
fix: adjust width style of Contributors panel and switch provider to contributors.svg

### DIFF
--- a/html/src/mixins/tabs/settings.pug
+++ b/html/src/mixins/tabs/settings.pug
@@ -101,7 +101,7 @@ mixin settingsTab()
                 div.options-container
                     span.header {{ $t("view.settings.general.contributors.header" )}}
                     div.options-container-item
-                        img(src="https://contrib.rocks/image?repo=vrcx-team/VRCX", alt="Contributors" @click="openExternalLink('https://github.com/vrcx-team/VRCX/graphs/contributors')" style="cursor: pointer")
+                        img(src="https://contributors-svg.deno.dev/vrcx-team/VRCX/contributors.svg", alt="Contributors" @click="openExternalLink('https://github.com/vrcx-team/VRCX/graphs/contributors')" style="max-width: 100%; cursor: pointer;")
                 //- General | Legal Notice
                 div.options-container(style="margin-top:45px;border-top:1px solid #eee;padding-top:30px")
                     span.header {{ $t("view.settings.general.legal_notice.header" )}}

--- a/html/src/mixins/tabs/settings.pug
+++ b/html/src/mixins/tabs/settings.pug
@@ -101,7 +101,7 @@ mixin settingsTab()
                 div.options-container
                     span.header {{ $t("view.settings.general.contributors.header" )}}
                     div.options-container-item
-                        img(src="https://contributors-svg.deno.dev/vrcx-team/VRCX/contributors.svg", alt="Contributors" @click="openExternalLink('https://github.com/vrcx-team/VRCX/graphs/contributors')" style="max-width: 100%; cursor: pointer;")
+                        img(src="https://contributors-svg.deno.dev/vrcx-team/VRCX/contributors.svg?align=left", alt="Contributors" @click="openExternalLink('https://github.com/vrcx-team/VRCX/graphs/contributors')" style="max-width: 100%; cursor: pointer;")
                 //- General | Legal Notice
                 div.options-container(style="margin-top:45px;border-top:1px solid #eee;padding-top:30px")
                     span.header {{ $t("view.settings.general.legal_notice.header" )}}


### PR DESCRIPTION
Changes:

- Updated the Contributors panel style, ensuring it displays correctly in various window sizes.
- Replaced the previously used private hosting service with the [contributors.svg](https://github.com/gizmo-ds/contributors.svg) serverless service for rendering the Contributors panel.
