### PR TITLE
Fix auto launch for applications after invalid shortcut

### DIFF
--- a/AutoAppLaunchManager.cs
+++ b/AutoAppLaunchManager.cs
@@ -217,8 +217,12 @@ namespace VRCX
         /// <param name="path">The path.</param>
         internal void StartChildProcess(string path)
         {
-            using (var process = Process.Start(path))
-                startedProcesses.Add(path, new HashSet<int>() { process.Id });
+            try
+            {
+                using (var process = Process.Start(path))
+                    if (process != null)
+                        startedProcesses.Add(path, new HashSet<int>() { process.Id });
+            } catch { }
         }
 
         /// <summary>


### PR DESCRIPTION
When there are any invalid shortcut files in the auto launch folder any application that is in the list after the invalid shortcut will not start.

This PR addresses that issue.