### PR TITLE
Rename quest references to android

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -1076,7 +1076,7 @@ speechSynthesis.getVoices();
             '<el-tooltip v-if="isValidInstance" placement="bottom">' +
             '<div slot="content">' +
             '<span><span style="color:#409eff">PC: </span>{{ platforms.standalonewindows }}</span></br>' +
-            '<span><span style="color:#67c23a">Quest: </span>{{ platforms.android }}</span></br>' +
+            '<span><span style="color:#67c23a">Android: </span>{{ platforms.android }}</span></br>' +
             '<span>{{ $t("dialog.user.info.instance_game_version") }} {{ gameServerVersion }}</span></br>' +
             '<span v-if="queueEnabled">{{ $t("dialog.user.info.instance_queuing_enabled") }}</br></span>' +
             '<span v-if="userList.length">{{ $t("dialog.user.info.instance_users") }}</br></span>' +
@@ -11371,7 +11371,7 @@ speechSynthesis.getVoices();
             platforms.length > 0 &&
             !platforms.includes('android')
         ) {
-            var text = 'User joined as Quest in PC only world';
+            var text = 'User joined as Android in PC only world';
         }
         if (text) {
             this.addEntryPhotonEvent({
@@ -11530,7 +11530,7 @@ speechSynthesis.getVoices();
         avatar.description = this.replaceBioSymbols(avatar.description);
         var platform = '';
         if (user.last_platform === 'android') {
-            platform = 'Quest';
+            platform = 'Android';
         } else if (user.last_platform === 'ios') {
             platform = 'iOS';
         } else if (user.inVRMode) {
@@ -16632,7 +16632,7 @@ speechSynthesis.getVoices();
         ref: {},
         instance: {},
         isPC: false,
-        isQuest: false,
+        isAndroid: false,
         isIos: false,
         avatarScalingDisabled: false,
         inCache: false,
@@ -16652,7 +16652,7 @@ speechSynthesis.getVoices();
                 ref: {},
                 instance: {},
                 isPC: false,
-                isQuest: false,
+                isAndroid: false,
                 isIos: false,
                 avatarScalingDisabled: false,
                 inCache: false,
@@ -16666,7 +16666,7 @@ speechSynthesis.getVoices();
                 ref: {},
                 instance: {},
                 isPC: false,
-                isQuest: false,
+                isAndroid: false,
                 isIos: false,
                 avatarScalingDisabled: false,
                 inCache: false,
@@ -16680,11 +16680,11 @@ speechSynthesis.getVoices();
                 worldId: L.worldId
             }).then((args) => {
                 this.currentInstanceWorld.ref = args.ref;
-                var { isPC, isQuest, isIos } = this.getAvailablePlatforms(
+                var { isPC, isAndroid, isIos } = this.getAvailablePlatforms(
                     args.ref.unityPackages
                 );
                 this.currentInstanceWorld.isPC = isPC;
-                this.currentInstanceWorld.isQuest = isQuest;
+                this.currentInstanceWorld.isAndroid = isAndroid;
                 this.currentInstanceWorld.isIos = isIos;
                 this.currentInstanceWorld.avatarScalingDisabled =
                     args.ref?.tags.includes('feature_avatar_scaling_disabled');
@@ -16709,11 +16709,11 @@ speechSynthesis.getVoices();
                 worldId: this.currentInstanceLocation.worldId
             }).then((args) => {
                 this.currentInstanceWorld.ref = args.ref;
-                var { isPC, isQuest, isIos } = this.getAvailablePlatforms(
+                var { isPC, isAndroid, isIos } = this.getAvailablePlatforms(
                     args.ref.unityPackages
                 );
                 this.currentInstanceWorld.isPC = isPC;
-                this.currentInstanceWorld.isQuest = isQuest;
+                this.currentInstanceWorld.isAndroid = isAndroid;
                 this.currentInstanceWorld.isIos = isIos;
                 this.checkVRChatCache(args.ref).then((cacheInfo) => {
                     if (cacheInfo.Item1 > 0) {
@@ -16743,20 +16743,20 @@ speechSynthesis.getVoices();
 
     $app.methods.getAvailablePlatforms = function (unityPackages) {
         var isPC = false;
-        var isQuest = false;
+        var isAndroid = false;
         var isIos = false;
         if (typeof unityPackages === 'object') {
             for (var unityPackage of unityPackages) {
                 if (unityPackage.platform === 'standalonewindows') {
                     isPC = true;
                 } else if (unityPackage.platform === 'android') {
-                    isQuest = true;
+                    isAndroid = true;
                 } else if (unityPackage.platform === 'ios') {
                     isIos = true;
                 }
             }
         }
-        return { isPC, isQuest, isIos };
+        return { isPC, isAndroid, isIos };
     };
 
     $app.methods.selectCurrentInstanceRow = function (val) {
@@ -17308,7 +17308,7 @@ speechSynthesis.getVoices();
         visitCount: 0,
         timeSpent: 0,
         isPC: false,
-        isQuest: false,
+        isAndroid: false,
         isIos: false
     };
 
@@ -17442,7 +17442,7 @@ speechSynthesis.getVoices();
         D.isFavorite = false;
         D.avatarScalingDisabled = false;
         D.isPC = false;
-        D.isQuest = false;
+        D.isAndroid = false;
         D.isIos = false;
         this.ignoreWorldMemoSave = true;
         D.memo = '';
@@ -17494,14 +17494,14 @@ speechSynthesis.getVoices();
                             D.id
                         );
                     }
-                    var { isPC, isQuest, isIos } = this.getAvailablePlatforms(
+                    var { isPC, isAndroid, isIos } = this.getAvailablePlatforms(
                         args.ref.unityPackages
                     );
                     D.avatarScalingDisabled = args.ref?.tags.includes(
                         'feature_avatar_scaling_disabled'
                     );
                     D.isPC = isPC;
-                    D.isQuest = isQuest;
+                    D.isAndroid = isAndroid;
                     D.isIos = isIos;
                     this.updateVRChatWorldCache();
                     if (args.cache) {
@@ -18004,7 +18004,7 @@ speechSynthesis.getVoices();
                 if (unityPackage.platform === 'standalonewindows') {
                     platform = 'PC';
                 } else if (unityPackage.platform === 'android') {
-                    platform = 'Quest';
+                    platform = 'Android';
                 } else if (unityPackage.platform) {
                     ({ platform } = unityPackage);
                 }
@@ -18025,7 +18025,7 @@ speechSynthesis.getVoices();
         ref: {},
         isFavorite: false,
         isBlocked: false,
-        isQuestFallback: false,
+        isAndroidFallback: false,
         treeData: [],
         fileSize: '',
         inCache: false,
@@ -18083,7 +18083,7 @@ speechSynthesis.getVoices();
         D.cacheSize = 0;
         D.cacheLocked = false;
         D.cachePath = '';
-        D.isQuestFallback = false;
+        D.isAndroidFallback = false;
         D.isFavorite = API.cachedFavoritesByObjectId.has(avatarId);
         D.isBlocked = API.cachedAvatarModerations.has(avatarId);
         this.ignoreAvatarMemoSave = true;
@@ -18112,7 +18112,7 @@ speechSynthesis.getVoices();
                     D.ref.assetUrl = API.currentUser.currentAvatarAssetUrl;
                 }
                 if (/quest/.test(ref.tags)) {
-                    D.isQuestFallback = true;
+                    D.isAndroidFallback = true;
                 }
                 var assetUrl = '';
                 for (let i = ref.unityPackages.length - 1; i > -1; i--) {
@@ -18380,7 +18380,7 @@ speechSynthesis.getVoices();
                 if (unityPackage.platform === 'standalonewindows') {
                     platform = 'PC';
                 } else if (unityPackage.platform === 'android') {
-                    platform = 'Quest';
+                    platform = 'Android';
                 } else if (unityPackage.platform) {
                     ({ platform } = unityPackage);
                 }

--- a/html/src/index.pug
+++ b/html/src/index.pug
@@ -250,7 +250,7 @@ html
                                     el-tag.x-tag-vip(v-if="userDialog.ref.$isModerator" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px")  {{ $t('dialog.user.tags.vrchat_team') }}
                                     el-tag.x-tag-vrcplus(v-if="userDialog.ref.$isVRCPlus" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") VRC+
                                     el-tag.x-tag-platform-pc(v-if="userDialog.ref.last_platform === 'standalonewindows'" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") PC
-                                    el-tag.x-tag-platform-quest(v-else-if="userDialog.ref.last_platform === 'android'" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") Quest
+                                    el-tag.x-tag-platform-quest(v-else-if="userDialog.ref.last_platform === 'android'" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") Android
                                     el-tag.x-tag-platform-ios(v-else-if="userDialog.ref.last_platform === 'ios'" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") iOS
                                     el-tag.x-tag-platform-other(v-else-if="userDialog.ref.last_platform" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") {{ userDialog.ref.last_platform }}
                                     el-tag.name(v-if="userDialog.ref.$customTag" type="info" effect="plain" size="mini" v-text="userDialog.ref.$customTag" :style="{'color':userDialog.ref.$customTagColour, 'border-color':userDialog.ref.$customTagColour}" style="margin-right:5px;margin-top:5px")
@@ -579,7 +579,7 @@ html
                                     el-tag(v-else-if="worldDialog.ref.releaseStatus === 'public'" type="success" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") {{ $t('dialog.world.tags.public') }}
                                     el-tag(v-else type="danger" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") {{ $t('dialog.world.tags.private') }}
                                     el-tag.x-tag-platform-pc(v-if="worldDialog.isPC" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") PC
-                                    el-tag.x-tag-platform-quest(v-if="worldDialog.isQuest" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") Quest
+                                    el-tag.x-tag-platform-quest(v-if="worldDialog.isAndroid" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") Android
                                     el-tag.x-tag-platform-ios(v-if="worldDialog.isIos" type="info" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") iOS
                                     el-tag(v-if="worldDialog.avatarScalingDisabled" type="warning" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") {{ $t('dialog.world.tags.avatar_scaling_disabled') }}
                                     el-tag(v-if="worldDialog.ref.unityPackageUrl" type="success" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") {{ $t('dialog.world.tags.future_proofing') }}
@@ -757,7 +757,7 @@ html
                                 div(style="margin-top:5px")
                                     el-tag(v-if="avatarDialog.ref.releaseStatus === 'public'" type="success" effect="plain" size="mini" style="margin-right:5px") {{ $t('dialog.avatar.tags.public') }}
                                     el-tag(v-else type="danger" effect="plain" size="mini" style="margin-right:5px") {{ $t('dialog.avatar.tags.private') }}
-                                    el-tag(v-if="avatarDialog.isQuestFallback" type="info" effect="plain" size="mini" style="margin-right:5px") {{ $t('dialog.avatar.tags.fallback') }}
+                                    el-tag(v-if="avatarDialog.isAndroidFallback" type="info" effect="plain" size="mini" style="margin-right:5px") {{ $t('dialog.avatar.tags.fallback') }}
                                     el-tag(v-if="avatarDialog.ref.unityPackageUrl" type="success" effect="plain" size="mini" style="margin-right:5px") {{ $t('dialog.avatar.tags.future_proofing') }}
                                     el-tag(v-if="avatarDialog.fileSize" type="info" effect="plain" size="mini" v-text="avatarDialog.fileSize" style="margin-right:5px")
                                     el-tag.x-link(v-if="avatarDialog.inCache" type="info" effect="plain" size="mini" @click="openFolderGeneric(avatarDialog.cachePath)")

--- a/html/src/mixins/tabs/playerList.pug
+++ b/html/src/mixins/tabs/playerList.pug
@@ -16,7 +16,7 @@ mixin playerListTab()
                         el-tag(v-else-if="currentInstanceWorld.ref.releaseStatus === 'public'" type="success" effect="plain" size="mini" style="margin-right:5px") {{ $t('dialog.world.tags.public') }}
                         el-tag(v-else-if="currentInstanceWorld.ref.releaseStatus === 'private'" type="danger" effect="plain" size="mini" style="margin-right:5px") {{ $t('dialog.world.tags.private') }}
                         el-tag.x-tag-platform-pc(v-if="currentInstanceWorld.isPC" type="info" effect="plain" size="mini" style="margin-right:5px") PC
-                        el-tag.x-tag-platform-quest(v-if="currentInstanceWorld.isQuest" type="info" effect="plain" size="mini" style="margin-right:5px") Quest
+                        el-tag.x-tag-platform-quest(v-if="currentInstanceWorld.isAndroid" type="info" effect="plain" size="mini" style="margin-right:5px") Android
                         el-tag.x-tag-platform-ios(v-if="currentInstanceWorld.isIOS" type="info" effect="plain" size="mini" style="margin-right:5px") iOS
                         el-tag(v-if="currentInstanceWorld.avatarScalingDisabled" type="warning" effect="plain" size="mini" style="margin-right:5px;margin-top:5px") {{ $t('dialog.world.tags.avatar_scaling_disabled') }}
                         el-tag(type="info" effect="plain" size="mini" v-text="currentInstanceWorld.fileSize" style="margin-right:5px")
@@ -112,7 +112,7 @@ mixin playerListTab()
                                     span(v-else-if="scope.row.type === 'OnPlayerJoined'")
                                         span(v-if="scope.row.platform === 'Desktop'" style="color:#409eff") Desktop&nbsp;
                                         span(v-else-if="scope.row.platform === 'VR'" style="color:#409eff") VR&nbsp;
-                                        span(v-else-if="scope.row.platform === 'Quest'" style="color:#67c23a") Quest&nbsp;
+                                        span(v-else-if="scope.row.platform === 'Android'" style="color:#67c23a") Android&nbsp;
                                         span.x-link(v-text="scope.row.avatar.name" @click="showAvatarDialog(scope.row.avatar.id)")
                                         | &nbsp;
                                         span(v-if="!scope.row.inCache" style="color:#aaa") #[i.el-icon-download]&nbsp;
@@ -183,7 +183,7 @@ mixin playerListTab()
                                     span(v-else-if="scope.row.type === 'OnPlayerJoined'")
                                         span(v-if="scope.row.platform === 'Desktop'" style="color:#409eff") Desktop&nbsp;
                                         span(v-else-if="scope.row.platform === 'VR'" style="color:#409eff") VR&nbsp;
-                                        span(v-else-if="scope.row.platform === 'Quest'" style="color:#67c23a") Quest&nbsp;
+                                        span(v-else-if="scope.row.platform === 'Android'" style="color:#67c23a") Android&nbsp;
                                         span.x-link(v-text="scope.row.avatar.name" @click="showAvatarDialog(scope.row.avatar.id)")
                                         | &nbsp;
                                         span(v-if="!scope.row.inCache" style="color:#aaa") #[i.el-icon-download]&nbsp;

--- a/html/src/vr.pug
+++ b/html/src/vr.pug
@@ -527,7 +527,7 @@ html
                                 span(style="margin-left:10px;color:#a3a3a3") has joined
                                 span(v-if="feed.platform === 'Desktop'" style="color:#409eff;margin-left:10px") Desktop
                                 span(v-else-if="feed.platform === 'VR'" style="color:#409eff;margin-left:10px") VR
-                                span(v-else-if="feed.platform === 'Quest'" style="color:#67c23a;margin-left:10px") Quest
+                                span(v-else-if="feed.platform === 'Android'" style="color:#67c23a;margin-left:10px") Android
                                 span(v-else-if="feed.platform === 'iOS'" style="color:#c7c7ce;margin-left:10px") iOS
                                 span(v-if="!feed.inCache" style="color:#aaa;margin-left:10px") #[i.el-icon-download]
                                 span(v-text="feed.avatar.name" style="margin-left:10px")


### PR DESCRIPTION
I suggest to rename the quest references to android so that it shows up correctly again.
This is because of the recent update which made the VRChat Android Beta publicly accessible: [Youtube](https://www.youtube.com/watch?v=YpyMVAcllYs) / [Play Store](https://play.google.com/apps/testing/com.vrchat.mobile.playstore)
This is how it would look:
![image](https://github.com/vrcx-team/VRCX/assets/58306774/7a16d9ad-df28-4a4c-8712-9ab7c727d6a6)
