### PR TITLE
Update JP Translation to VRCX Latest Nightly Release

### DIFF
--- a/html/src/localization/ja/en.json
+++ b/html/src/localization/ja/en.json
@@ -219,11 +219,11 @@
                     "auto_state_change": "自動ステータス変更",
                     "auto_state_change_tooltip": "自身のいるインスタンスに他のプレイヤーがいる場合、自動的にステータスを変更します。 (1人/複数人)",
                     "auto_state_change_off": "無効",
-                    "auto_state_change_active_or_ask_me": "アクティブ / 現在地を非表示",
-                    "auto_state_change_active_or_busy": "アクティブ / 取り込み中",
-                    "auto_state_change_join_me_or_ask_me": "参加歓迎 / 現在地を非表示",
-                    "auto_state_change_join_me_or_busy": "参加歓迎 / 取り込み中",
-                    "auto_state_change_ask_me_or_busy": "現在地を非表示 / 取り込み中"
+                    "auto_state_change_active_or_ask_me": "Active / Ask Me",
+                    "auto_state_change_active_or_busy": "Active / Busy",
+                    "auto_state_change_join_me_or_ask_me": "Join Me / Ask Me",
+                    "auto_state_change_join_me_or_busy": "Join Me / Busy",
+                    "auto_state_change_ask_me_or_busy": "Ask Me / Busy"
                 },
                 "legal_notice": {
                     "header": "法律上の注意事項",
@@ -420,7 +420,7 @@
                     "screenshot_helper": {
                         "header": "スクリーンショット ヘルパー",
                         "description": "ゲーム内で撮影した写真のメタデータに「ワールドID」「ワールド名」「インスタンス内のプレイヤー」を保存します",
-                        "description_tooltip": "残念ながら、Windowsは (ごく一部を除く) PNGテキストチャンクの表示をサポートしていないため、表示するにはEXIFToolのようなコマンドラインツールや、PNGチャンクインスペクター、またはHEX エディタを使用して表示することができます",
+                        "description_tooltip": "残念ながら、Windowsは (ごく一部を除いた) PNGテキストチャンクの表示をサポートしていません。表示するにはEXIFToolのようなコマンドラインツールや、PNGチャンクインスペクター、またはHEX エディタを使用して表示することができます",
                         "enable": "有効化",
                         "modify_filename": "ファイル名を変更",
                         "modify_filename_tooltip": "スクリーンショットのファイル名にワールドIDを追加"
@@ -513,9 +513,9 @@
     "dialog": {
         "user": {
             "status": {
-                "active": "アクティブ",
-                "offline": "オフライン",
-                "online": "オンライン",
+                "active": "Active",
+                "offline": "Offline",
+                "online": "Online",
                 "join_me": "Join Me",
                 "ask_me": "Ask Me",
                 "busy": "Do Not Disturb"
@@ -562,7 +562,7 @@
                 "header": "情報",
                 "launch_invite_tooltip": "起動/招待",
                 "self_invite_tooltip": "自分を招待",
-                "refresh_instance_info": "Refresh Instance Info",
+                "refresh_instance_info": "インスタンス情報を更新",
                 "instance_queue": "待機列:",
                 "instance_users": "ユーザー数:",
                 "instance_game_version": "ゲームバージョン:",
@@ -574,7 +574,7 @@
                 "memo_placeholder": "クリックしてメモを追加",
                 "avatar_info": "アバター情報",
                 "avatar_info_last_seen": "最後に見たアバター情報",
-                "represented_group": "代表しているグループ",
+                "represented_group": "ネームプレートに表示中のグループ",
                 "bio": "自己紹介",
                 "last_seen": "最後に見た日時",
                 "join_count": "Joinした回数",
@@ -703,6 +703,7 @@
                 "last_updated": "最終更新日時",
                 "publication_date": "公開日",
                 "labs_publication_date": "ラボへの公開日",
+                "time_in_labs": "ラボにいた時間:",
                 "version": "バージョン",
                 "platform": "プラットフォーム",
                 "last_visited": "最後に参加した日時",
@@ -780,14 +781,14 @@
                 "closed": "参加不可能",
                 "joined": "参加済み",
                 "banned": "BAN",
-                "visible": "可視性: 全員",
-                "friends": "可視性: フレンドのみ",
-                "hidden": "可視性: 自分のみ",
+                "visible": "表示範囲: 全員",
+                "friends": "表示範囲: フレンドのみ",
+                "hidden": "表示範囲: 自分のみ",
                 "subscribed": "お知らせ受信可能"
             },
             "actions": {
-                "represent_tooltip": "代表グループに設定",
-                "unrepresent_tooltip": "代表グループでなくする",
+                "represent_tooltip": "ネームプレートに表示",
+                "unrepresent_tooltip": "ネームプレートから外す",
                 "cancel_join_request_tooltip": "参加リクエストをキャンセル",
                 "pending_request_tooltip": "保留中の招待",
                 "request_join_tooltip": "参加リクエストを送信",
@@ -797,9 +798,9 @@
                 "unsubscribe": "お知らせの受信を停止",
                 "subscribe": "お知らせを受信可能に設定",
                 "invite_to_group": "グループに招待",
-                "visibility_everyone": "可視性: 全員",
-                "visibility_friends": "可視性: フレンドのみ",
-                "visibility_hidden": "可視性: 自分のみ",
+                "visibility_everyone": "表示範囲: 全員",
+                "visibility_friends": "表示範囲: フレンドのみ",
+                "visibility_hidden": "表示範囲: 自分のみ",
                 "leave": "グループから抜ける"
             },
             "info": {
@@ -822,6 +823,13 @@
                 "role_updated_at": "更新日:",
                 "role_created_at": "作成日:",
                 "role_permissions": "権限:"
+                },
+            "posts": {
+                "header": "アナウンス",
+                "visibility": "表示範囲:",
+                "edited_by": "編集者:",
+                "search_placeholder": "検索",
+                "posts_count": "投稿数: "
             },
             "members": {
                 "header": "メンバー",
@@ -832,7 +840,7 @@
                 "sorting": {
                     "user_id": "ユーザーID (登順)",
                     "joined_at_asc": "参加順 (昇順)",
-                    "joined_at_desc": "Joined 参加順 (降順)"
+                    "joined_at_desc": "参加順 (降順)"
                 },
                 "filter": "フィルター:",
                 "filters": {
@@ -883,19 +891,19 @@
         "new_instance": {
             "header": "新しいインスタンス",
             "access_type": "アクセスタイプ",
-            "access_type_public": "パブリック",
+            "access_type_public": "Public",
             "access_type_group": "グループ",
-            "access_type_friend_plus": "フレンド＋",
-            "access_type_friend": "フレンド",
-            "access_type_invite_plus": "招待+",
-            "access_type_invite": "招待",
+            "access_type_friend_plus": "Friends+",
+            "access_type_friend": "Friend",
+            "access_type_invite_plus": "Invite+",
+            "access_type_invite": "Invite",
             "group_access_type": "グループアクセス",
             "group_access_type_members": "メンバー",
             "group_access_type_plus": "プラス",
             "group_access_type_public": "パブリック",
             "region": "地域",
-            "region_usw": "US West",
-            "region_use": "US East",
+            "region_usw": "アメリカ西",
+            "region_use": "アメリカ東",
             "region_eu": "ヨーロッパ",
             "region_jp": "日本",
             "world_id": "ワールドID",
@@ -1380,7 +1388,7 @@
             "description": "ワールドの推奨人数を入力してください。 (ソフトキャップ)",
             "cancel": "キャンセル",
             "ok": "OK",
-            "input_error": "友好な数字を入力してください。",
+            "input_error": "有効な数字を入力してください。",
             "message": {
                 "success": "ワールドの推奨人数を変更しました。"
             }
@@ -1498,7 +1506,7 @@
             "action": "アクション"
         },
         "friendList": {
-            "no": "いいえ。",
+            "no": "No.",
             "avatar": "アバター",
             "displayName": "表示名",
             "rank": "ランク",
@@ -1526,7 +1534,7 @@
             }
         },
         "social_status": {
-            "no": "いいえ。",
+            "no": "No.",
             "status": "ステータス"
         },
         "download_history": {


### PR DESCRIPTION
Currently, Japanese translation is not implemented in VRChat, so commonly used words in VRChat, etc. will not be translated accordingly. (Status, Instance Type, etc.)
This is to prevent any misrecognition that may occur because VRCX is in Japanese while VRChat is in English.

As soon as the Japanese translation is released by the official VRChat, the VRCX translation will be adjusted to the Japanese one.