### PR TITLE
Update UI to match VRChats Cache Expiry range

### DIFF
--- a/html/src/localization/en/en.json
+++ b/html/src/localization/en/en.json
@@ -946,7 +946,7 @@
             "delete_old_cache": "Delete old versions from cache",
             "sweep_cache": "Sweep Cache",
             "max_cache_size": "Max Cache Size [GB] (min 20)",
-            "cache_expiry_delay": "Cache Expiry [Days] (30 - 150)",
+            "cache_expiry_delay": "Cache Expiry [Days] (min 30)",
             "cache_directory": "Custom Cache Folder Location",
             "picture_directory": "Custom Picture Folder Location",
             "fpv_steadycam_fov": "First-Person Steadycam FOV",

--- a/html/src/localization/fr/en.json
+++ b/html/src/localization/fr/en.json
@@ -938,7 +938,7 @@
             "delete_old_cache": "Supprimer les anciennes versions du cache",
             "sweep_cache": "Balayer le cache",
             "max_cache_size": "Taille maximale du cache [Go] (min 20)",
-            "cache_expiry_delay": "Expiration du cache [jours] (30 - 150)",
+            "cache_expiry_delay": "Expiration du cache [jours] (min 30)",
             "cache_directory": "Emplacement du dossier de cache personnalisé",
             "picture_directory": "Emplacement du dossier de photos personnalisé",
             "fpv_steadycam_fov": "Angle de vue à la première personne",

--- a/html/src/localization/ja/en.json
+++ b/html/src/localization/ja/en.json
@@ -938,7 +938,7 @@
             "delete_old_cache": "旧バージョンのキャッシュを削除",
             "sweep_cache": "掃除",
             "max_cache_size": "最大キャッシュサイズ [GB] (最小 20)",
-            "cache_expiry_delay": "キャッシュの有効期限 [日] (30 - 150)",
+            "cache_expiry_delay": "キャッシュの有効期限 [日] (最小 30)",
             "cache_directory": "カスタムキャッシュフォルダー",
             "picture_directory": "カスタム写真フォルダー",
             "fpv_steadycam_fov": "一人称Steadycamの視野角",

--- a/html/src/localization/ko/en.json
+++ b/html/src/localization/ko/en.json
@@ -938,7 +938,7 @@
             "delete_old_cache": "오래된 버전 캐시 삭제",
             "sweep_cache": "캐시 정리",
             "max_cache_size": "최대 캐시 크기 [GB] (최소 20)",
-            "cache_expiry_delay": "캐시 만료 일수 [Days] (30 - 150)",
+            "cache_expiry_delay": "캐시 만료 일수 [Days] (최소 30)",
             "cache_directory": "캐시 폴더 위치",
             "picture_directory": "Custom Picture Folder Location",
             "fpv_steadycam_fov": "1인칭 스테디캠 시야각",

--- a/html/src/localization/vi/en.json
+++ b/html/src/localization/vi/en.json
@@ -938,7 +938,7 @@
             "delete_old_cache": "Xóa Cache cũ",
             "sweep_cache": "Lưu Cache đè",
             "max_cache_size": "Max Cache Size [GB] (min 20)",
-            "cache_expiry_delay": "Cache Expiry [Days] (30 - 150)",
+            "cache_expiry_delay": "Cache Expiry [Days] (min 30)",
             "cache_directory": "Đặt thư mục lưu cache",
             "picture_directory": "Đặt thư mục lưu ảnh",
             "fpv_steadycam_fov": "First-Person Steadycam FOV",

--- a/html/src/localization/zh-CN/en.json
+++ b/html/src/localization/zh-CN/en.json
@@ -938,7 +938,7 @@
             "delete_old_cache": "从缓存中删除无效数据",
             "sweep_cache": "清理缓存",
             "max_cache_size": "最大缓存大小 [GB] （最小 20GB）",
-            "cache_expiry_delay": "缓存保存时长 [日] （30 - 150）",
+            "cache_expiry_delay": "缓存保存时长 [日] （最小 30）",
             "cache_directory": "缓存文件夹位置",
             "picture_directory": "截图文件夹位置",
             "fpv_steadycam_fov": "第一人称镜头FOV度数",

--- a/html/src/localization/zh-TW/en.json
+++ b/html/src/localization/zh-TW/en.json
@@ -938,7 +938,7 @@
             "delete_old_cache": "從快取中刪除舊版本",
             "sweep_cache": "清理快取",
             "max_cache_size": "最大快取大小 [GB] （最小 20GB）",
-            "cache_expiry_delay": "快取保存時長 [日] （30 - 150）",
+            "cache_expiry_delay": "快取保存時長 [日] （最小 30）",
             "cache_directory": "覆蓋快取資料夾位置",
             "picture_directory": "覆蓋圖片資料夾位置",
             "fpv_steadycam_fov": "第一人稱平滑鏡頭視野範圍",


### PR DESCRIPTION
Update all language files to match the range for Cache Expiry that VRChat allows.
As mentioned in [VRChat docs](https://docs.vrchat.com/docs/configuration-file#size-and-expiry-time) there is no upper limit for Cache Expiry, all language files were updated to reflect this.
I copied the "min" part from the Max Cache Size entry for every language for this.