### PR TITLE
Material 3 Theme fixes.

### DIFF
--- a/html/src/index.pug
+++ b/html/src/index.pug
@@ -702,7 +702,7 @@ html
                                         span.name {{ $t('dialog.world.info.memo') }}
                                         el-input.extra(v-model="worldDialog.memo" type="textarea" :rows="2" :autosize="{ minRows: 1, maxRows: 20 }" :placeholder="$t('dialog.world.info.memo_placeholder')" size="mini" resize="none")
                                 div(style="width:100%;display:flex")
-                                    .x-friend-item(style="width:350px;cursor:default")
+                                    .x-friend-item(style="width:100%;cursor:default")
                                         .detail
                                             span.name {{ $t('dialog.world.info.id') }}
                                             span.extra {{ worldDialog.id }}

--- a/html/src/mixins/tabs/playerList.pug
+++ b/html/src/mixins/tabs/playerList.pug
@@ -45,7 +45,7 @@ mixin playerListTab()
                             span.name {{ $t('dialog.world.info.created_at') }}
                             span.extra {{ currentInstanceWorld.ref.created_at | formatDate('long') }}
             div.photon-event-table(v-if="photonLoggingEnabled")
-                div(style="position:absolute;width:600px;margin-left:195px;z-index:1")
+                div(style="position:absolute;width:600px;margin-left:215px;z-index:1")
                     el-select(v-model="photonEventTableTypeFilter" @change="photonEventTableFilterChange" multiple clearable collapse-tags style="flex:1;width:220px" :placeholder="$t('view.player_list.photon.filter_placeholder')")
                         el-option(v-once v-for="type in photonEventTableTypeFilterList" :key="type" :label="type" :value="type")
                     el-input(v-model="photonEventTableFilter" @input="photonEventTableFilterChange" :placeholder="$t('view.player_list.photon.search_placeholder')" clearable style="width:150px;margin-left:10px")

--- a/html/src/theme.material3.scss
+++ b/html/src/theme.material3.scss
@@ -1318,18 +1318,19 @@ img.x-link.el-popover__reference {
 *:not(.x-user-dialog, .x-world-dialog, .x-avatar-dialog, .x-group-dialog)
     > .el-dialog {
     width: auto !important;
+    max-width: 1125px !important;
 }
 *:not(.x-user-dialog, .x-world-dialog, .x-avatar-dialog, .x-group-dialog)
     > .el-dialog
     > .el-dialog__body {
     overflow-y: auto;
+    max-height: 825px;
 }
 .el-dialog {
     border-radius: 28px;
     padding: 24px;
     background: var(--md-sys-color-surface-3);
     margin: auto !important;
-    max-width: 1700px !important;
 }
 .el-dialog__body {
     padding: 0 !important;
@@ -1380,7 +1381,7 @@ img.x-link.el-popover__reference {
     font-weight: var(--md-sys-typescale-body-medium-weight);
     letter-spacing: var(--md-sys-typescale-body-medium-tracking);
     margin-bottom: 24px;
-    max-height: 825px;
+    max-height: 500px;
     scroll-margin-left: 8px;
 }
 .el-message-box__content > *,
@@ -1903,10 +1904,6 @@ i.x-user-status {
     font-size: var(--md-sys-typescale-label-large-size);
     font-weight: var(--md-sys-typescale-label-large-weight);
     letter-spacing: var(--md-sys-typescale-label-large-tracking);
-}
-
-.x-friend-item[style*='width: 350px;'] {
-    width: 200px !important;
 }
 .x-friend-list > .x-friend-group:first-child {
     color: rgb(var(--md-sys-color-on-surface));

--- a/html/src/theme.material3.scss
+++ b/html/src/theme.material3.scss
@@ -1329,6 +1329,7 @@ img.x-link.el-popover__reference {
     padding: 24px;
     background: var(--md-sys-color-surface-3);
     margin: auto !important;
+    max-width: 1700px !important;
 }
 .el-dialog__body {
     padding: 0 !important;
@@ -1338,6 +1339,8 @@ img.x-link.el-popover__reference {
     border: none;
     border-radius: 28px;
     padding: 24px;
+    width: 500px;
+    word-break: break-all;
 }
 .el-message-box > *,
 .el-dialog > * {
@@ -1377,7 +1380,7 @@ img.x-link.el-popover__reference {
     font-weight: var(--md-sys-typescale-body-medium-weight);
     letter-spacing: var(--md-sys-typescale-body-medium-tracking);
     margin-bottom: 24px;
-    max-height: 500px;
+    max-height: 825px;
     scroll-margin-left: 8px;
 }
 .el-message-box__content > *,
@@ -1903,7 +1906,7 @@ i.x-user-status {
 }
 
 .x-friend-item[style*='width: 350px;'] {
-    width: auto !important;
+    width: 200px !important;
 }
 .x-friend-list > .x-friend-group:first-child {
     color: rgb(var(--md-sys-color-on-surface));

--- a/html/src/theme.material3.scss
+++ b/html/src/theme.material3.scss
@@ -523,6 +523,7 @@ input[type='number'],
     border-radius: 24px;
     overflow-x: auto;
     white-space: normal;
+    user-select: text;
 }
 .el-table .el-table__body-wrapper table {
     width: 100%;
@@ -1123,7 +1124,7 @@ input[type='number'],
 }
 
 .el-tabs__header {
-    padding: 12px 0;
+    padding: 5px;
     border-bottom: 1px solid rgb(var(--md-sys-color-outline-variant));
 }
 


### PR DESCRIPTION
This PR fixes multiple issues with text overflowing and display flows being unaligned,
fixes

- Viewing images is no longer cut off
- Mass changing avatar tags is now arranged into 8 column grids
- Message text no longer overflows above 75 chars (SDK link dialogs)
- Allows selection of table texts