### PR TITLE
Cuts off everything but actual discord name in the discord names dialog, it's toggleable!

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -22496,6 +22496,7 @@ speechSynthesis.getVoices();
 
     $app.data.discordNamesDialogVisible = false;
     $app.data.discordNamesContent = '';
+    $app.data.discordNamesExtraFiltering = true;
 
     $app.methods.showDiscordNamesDialog = function () {
         var { friends } = API.currentUser;
@@ -22536,7 +22537,12 @@ speechSynthesis.getVoices();
                 continue;
             }
             discord = discord.trim();
-            lines.push(`${_(name)},${_(discord)}`);
+            if (this.discordNamesExtraFiltering) {
+                var discordNameSelection = /[a-z0-9#._-]{3,32}/gi.exec(discord);
+                if (discordNameSelection.length > 0) lines.push(`${_(name)},${_(discordNameSelection[0])}`);
+            } else {
+                lines.push(`${_(name)},${_(discord)}`);
+            }
         }
         this.discordNamesContent = lines.join('\n');
         this.discordNamesDialogVisible = true;

--- a/html/src/index.pug
+++ b/html/src/index.pug
@@ -1707,10 +1707,12 @@ html
             el-dialog.x-dialog(:before-close="beforeDialogClose" @mousedown.native="dialogMouseDown" @mouseup.native="dialogMouseUp" :visible.sync="exportAvatarsListDialog" :title="$t('dialog.export_own_avatars.header')" width="650px")
                 el-input(type="textarea" v-if="exportAvatarsListDialog" v-model="exportAvatarsListCsv" size="mini" rows="15" resize="none" readonly style="margin-top:15px" @click.native="$event.target.tagName === 'TEXTAREA' && $event.target.select()")
 
-            //- dialog: Discord username list
             el-dialog.x-dialog(:before-close="beforeDialogClose" @mousedown.native="dialogMouseDown" @mouseup.native="dialogMouseUp" :visible.sync="discordNamesDialogVisible" :title="$t('dialog.discord_names.header')" width="650px")
                 div(style='font-size:12px;')
                     | {{ $t('dialog.discord_names.description') }}
+                div.options-container-item
+                    span.name {{ $t('dialog.discord_names.extra_filtering') }}
+                    el-switch(v-model="discordNamesExtraFiltering", @change="showDiscordNamesDialog")
                 el-input(type="textarea" v-if="discordNamesDialogVisible" v-model="discordNamesContent" size="mini" rows="15" resize="none" readonly style="margin-top:15px")
 
             //- dialog: Notification position

--- a/html/src/localization/en/en.json
+++ b/html/src/localization/en/en.json
@@ -1045,7 +1045,8 @@
         },
         "discord_names": {
             "header": "Discord Names",
-            "description": "Click load missing entries in the Friends List tab to search entire friends list"
+            "description": "Click load missing entries in the Friends List tab to search entire friends list",
+            "extra_filtering": "Extra Name Filtering"
         },
         "notification_position": {
             "header": "Notification Position",


### PR DESCRIPTION
The discord names dialog is very messy, because my friend's bio don't have their discord name on it's own line. Which means everything after the discord name is also shown.
In this pull request, if extra filtering is enabled (in the discord names dialog) extra regex is used on the discord name before it's pushed to the lines, in order to cut off any extra things that aren't the username.