### PR TITLE
Fix Image name not detecting at times

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -23376,7 +23376,7 @@ speechSynthesis.getVoices();
         var fileId = args.params.fileId;
         var avatarName = '';
         var imageName = args.json.name;
-        var avatarNameRegex = /Avatar - (.*) - Image -/g.exec(imageName);
+        var avatarNameRegex = /(?:A|a)vatar - (.*) - (?:I|i)mage -/g.exec(imageName);
         if (avatarNameRegex) {
             avatarName = this.replaceBioSymbols(avatarNameRegex[1]);
         }


### PR DESCRIPTION
The image name may sometimes be lowercase, modify regex to account for this.