### PR TITLE
Add image resizing to LegacyImageUpload

### DIFF
--- a/Dotnet/WebApi.cs
+++ b/Dotnet/WebApi.cs
@@ -156,7 +156,7 @@ namespace VRCX
                 }
             }
             var imageData = options["imageData"] as string;
-            byte[] fileToUpload = Convert.FromBase64CharArray(imageData.ToCharArray(), 0, imageData.Length);
+            byte[] fileToUpload = AppApi.Instance.ResizeImageToFitLimits(Convert.FromBase64String(imageData));
             string fileFormKey = "image";
             string fileName = "image.png";
             string fileMimeType = "image/png";


### PR DESCRIPTION
Image resizing was missing in the LegacyImageUpload method inside WebApi, this PR adds it.