### PR TITLE
Set EnableWindowsTargeting to true / Allow linux development

### DIFF
--- a/VRCX.csproj
+++ b/VRCX.csproj
@@ -18,6 +18,7 @@
     <RepositoryUrl>https://github.com/vrcx-team/VRCX</RepositoryUrl>
     <ResourceLanguages>en</ResourceLanguages>
     <SatelliteResourceLanguages>en-US;en</SatelliteResourceLanguages>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">


### PR DESCRIPTION
Verbatim from commit:

This permits .NET to download the Windows targeting packs, which enables VRCX development on Linux.

It's not recommended to build the Windows apps with Linux though, so actual release builds should likely stick with Windows CI/CD, as per Microsoft:
> This property is currently recommended to allow development on non-Windows platforms. But when the application is ready to be released, it should be built on Windows. When building on a non-Windows platform, the output may not be the same as when building on Windows. In particular, the executable is not marked as a Windows application (which means that it will always launch a console window) and won't have an icon embedded.

https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#enablewindowstargeting