### PR TITLE
[feat] Make user list sorting match the website's sorting

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -9582,28 +9582,12 @@ speechSynthesis.getVoices();
 
     // ascending
     var compareByName = function (a, b) {
-        var A = String(a.name).toUpperCase();
-        var B = String(b.name).toUpperCase();
-        if (A < B) {
-            return -1;
-        }
-        if (A > B) {
-            return 1;
-        }
-        return 0;
+        return a.name.localeCompare(b.name);
     };
 
     // ascending
     var compareByDisplayName = function (a, b) {
-        var A = String(a.displayName).toUpperCase();
-        var B = String(b.displayName).toUpperCase();
-        if (A < B) {
-            return -1;
-        }
-        if (A > B) {
-            return 1;
-        }
-        return 0;
+        return a.displayName.localeCompare(b.displayName);
     };
 
     // descending


### PR DESCRIPTION
While this pr was originally meant to fix #704, the sorting done by the VRChat client is a whole can of worms I don't want to ever touch again. This means my commit message is wrong. However, I did confirm that the website uses `localeCompare`, so I am certain that this change will make the sorting match with the website.

As a result, this pr will improve the handling of unicode characters while sorting and hopefully make it a little easier to find people.