### PR TITLE
Enable compression for http requests

### DIFF
--- a/Dotnet/WebApi.cs
+++ b/Dotnet/WebApi.cs
@@ -181,7 +181,8 @@ namespace VRCX
         {
             if (ProxySet)
                 request.Proxy = Proxy;
-            
+
+            request.AutomaticDecompression = DecompressionMethods.All;
             request.Method = "POST";
             string boundary = "---------------------------" + DateTime.Now.Ticks.ToString("x");
             request.ContentType = "multipart/form-data; boundary=" + boundary;
@@ -228,7 +229,8 @@ namespace VRCX
         {
             if (ProxySet)
                 request.Proxy = Proxy;
-            
+
+            request.AutomaticDecompression = DecompressionMethods.All;
             request.Method = "PUT";
             request.ContentType = options["fileMIME"] as string;
             var fileData = options["fileData"] as string;
@@ -245,7 +247,8 @@ namespace VRCX
         {
             if (ProxySet)
                 request.Proxy = Proxy;
-            
+
+            request.AutomaticDecompression = DecompressionMethods.All;
             request.Method = "POST";
             string boundary = "---------------------------" + DateTime.Now.Ticks.ToString("x");
             request.ContentType = "multipart/form-data; boundary=" + boundary;
@@ -307,6 +310,7 @@ namespace VRCX
                 request.CookieContainer = _cookieContainer;
                 request.KeepAlive = true;
                 request.UserAgent = Program.Version;
+                request.AutomaticDecompression = DecompressionMethods.All;
 
                 if (options.TryGetValue("headers", out object headers))
                 {

--- a/html/src/app.js
+++ b/html/src/app.js
@@ -23522,21 +23522,6 @@ speechSynthesis.getVoices();
         }
     });
 
-    API.setWorldImage = function (params) {
-        return this.call(`worlds/${params.id}`, {
-            method: 'PUT',
-            params
-        }).then((json) => {
-            var args = {
-                json,
-                params
-            };
-            this.$emit('WORLDIMAGE:SET', args);
-            this.$emit('WORLD', args);
-            return args;
-        });
-    };
-
     API.$on('WORLDIMAGE:SET', function (args) {
         $app.worldDialog.loading = false;
         $app.changeWorldImageDialogLoading = false;


### PR DESCRIPTION
Enable compression for http requests made by VRCX to improve bandwidth usage and speed. (This should reduce bandwidth usage of text responses by [~40-60%](https://blog.cloudflare.com/en-en/this-is-brotli-from-origin/#:~:text=Testing))
Also removed duplicate setWorldImage assigning.