### PR TITLE
Changes to getCurrentUser

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -5568,7 +5568,6 @@ speechSynthesis.getVoices();
     var $app = {
         data: {
             API,
-            nextCurrentUserRefresh: 0,
             nextFriendsRefresh: 0,
             nextGroupInstanceRefresh: 0,
             nextAppUpdateCheck: 7200,
@@ -5646,7 +5645,6 @@ speechSynthesis.getVoices();
                                     this.loginForm.loading = false;
                                 })
                                 .catch((err) => {
-                                    this.nextCurrentUserRefresh = 120; // 1min
                                     console.error(err);
                                 });
                             return args;
@@ -5761,16 +5759,11 @@ speechSynthesis.getVoices();
             if (API.isLoggedIn === true) {
                 if (--this.nextFriendsRefresh <= 0) {
                     this.nextFriendsRefresh = 7200; // 1hour
-                    this.nextCurrentUserRefresh = 840; // 7mins
                     this.refreshFriendsList();
                     this.updateStoredUser(API.currentUser);
                     if (this.isGameRunning) {
                         API.refreshPlayerModerations();
                     }
-                }
-                if (--this.nextCurrentUserRefresh <= 0) {
-                    this.nextCurrentUserRefresh = 840; // 7mins
-                    API.getCurrentUser();
                 }
                 if (--this.nextGroupInstanceRefresh <= 0) {
                     if (this.friendLogInitStatus) {
@@ -9113,7 +9106,6 @@ speechSynthesis.getVoices();
         await API.getCurrentUser().catch((err) => {
             console.error(err);
         });
-        this.nextCurrentUserRefresh = 840; // 7mins
         await API.refreshFriends();
         API.reconnectWebSocket();
     };


### PR DESCRIPTION
This removes the individual refresh loop of getting the current user.
In the loop, getting the current user will be grabbed along with refreshing the friends list, which has a cooldown of an hour.

This is waiting on the following to be implemented/tested
- The addition of `user-location` WebSocket event firing when the user is `traveling` or `offline`.
  - [ ] VRChat's Implementation.
  - [ ] VRCX's Test/Implementation.
- The addition of `instance-queue-left` WebSocket event.
  - [x] VRChat's Implementation.
  - [x] VRCX's Test/Implementation. (https://github.com/vrcx-team/VRCX/commit/06dad59796aa82fc64f1f0e0e2dd45b7244329ae)
- [OPTIONAL] The addition of the `presence` object being sent over the WebSocket.
  - [ ] VRChat's Implementation.
  - [ ] VRCX's Test/Implementation.