### PR TITLE
Fix a small error in Japanese translation

### DIFF
--- a/html/src/localization/ja/en.json
+++ b/html/src/localization/ja/en.json
@@ -1677,7 +1677,7 @@
             "action": "アクション"
         },
         "friendList": {
-            "no": "いいえ。",
+            "no": "No.",
             "avatar": "アバター",
             "displayName": "表示名",
             "rank": "ランク",
@@ -1705,7 +1705,7 @@
             }
         },
         "social_status": {
-            "no": "いいえ。",
+            "no": "No.",
             "status": "ステータス"
         },
         "download_history": {


### PR DESCRIPTION
These words represent the numbers in the table headings and do not need to be translated, but the Japanese translation has been mistakenly translated as "No" in "Yes/No."