### PR TITLE
Fix group dialog not showing when user is traveling

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -991,10 +991,14 @@ speechSynthesis.getVoices();
                 }
             },
             showGroupDialog() {
-                if (!this.location || !this.link) {
+                var location = this.location;
+                if (this.isTraveling) {
+                    location = this.traveling;
+                }
+                if (!location || !this.link) {
                     return;
                 }
-                var L = API.parseLocation(this.location);
+                var L = API.parseLocation(location);
                 if (!L.groupId) {
                     return;
                 }


### PR DESCRIPTION
When viewing a profile of a user that is traveling to a group instance clicking the group name will not open the group dialog.