### PR TITLE
Linux: Remove no-cef-sandbox flag from .desktop file

### DIFF
--- a/Linux/install-vrcx.sh
+++ b/Linux/install-vrcx.sh
@@ -76,7 +76,7 @@ rm vrcx.zip
 echo "#!/usr/bin/env bash
 export WINEPREFIX=$WINEPREFIX
 export WINEDLLOVERRIDES="libglesv2=d" # Workaround for https://bugs.winehq.org/show_bug.cgi?id=44985
-wine $WINEPREFIX/drive_c/vrcx/VRCX.exe -no-cef-sandbox" > $WINEPREFIX/drive_c/vrcx/vrcx
+wine $WINEPREFIX/drive_c/vrcx/VRCX.exe" > $WINEPREFIX/drive_c/vrcx/vrcx
 chmod +x $WINEPREFIX/drive_c/vrcx/vrcx
 
 if [[ -d $HOME/.local/bin ]]; then


### PR DESCRIPTION
Ben mentioned on Discord this might have been a workaround for GPU crashes. `-no-cef-sandbox` is meant to be a testing switch and not something ran regularly.

As per the ["Works on my machine" certification program](https://blog.codinghorror.com/the-works-on-my-machine-certification-program), the app runs fine without this flag, so let's restore sandboxing.