### PR TITLE
Linux: Fix .desktop to match WM_CLASS

### DIFF
--- a/Linux/install-vrcx.sh
+++ b/Linux/install-vrcx.sh
@@ -82,14 +82,14 @@ chmod +x $WINEPREFIX/drive_c/vrcx/vrcx
 echo "Install VRCX.png to $XDG_DATA_HOME/icons"
 curl -L https://raw.githubusercontent.com/vrcx-team/VRCX/master/VRCX.png -o "$XDG_DATA_HOME/icons/VRCX.png"
 
-echo "Install vrcx.desktop to $XDG_DATA_HOME/applications"
+echo "Install vrcx.exe.desktop to $XDG_DATA_HOME/applications"
 echo "[Desktop Entry]
 Type=Application
 Name=VRCX
 Categories=Utility;
 Exec=$WINEPREFIX/drive_c/vrcx/vrcx
 Icon=VRCX
-" > $XDG_DATA_HOME/applications/vrcx.desktop
+" > $XDG_DATA_HOME/applications/vrcx.exe.desktop
 
 
 echo "Done! Check your menu for VRCX."


### PR DESCRIPTION
Renamed the name of the .desktop file from `vrcx.desktop` to `vrcx.exe.desktop` as the WM_CLASS of VRCX used is `WM_CLASS(STRING) = "vrcx.exe", "vrcx.exe"` as per xprop.

This means that now instead of the VRCX showing up as 
![image](https://github.com/user-attachments/assets/2a96136e-8ab4-4e6b-81d3-b0968f974d53)

It now shows up as
![image](https://github.com/user-attachments/assets/8dc45e5b-0772-4764-a281-8d98a6616214)

Only tested on Fedora 40 on Wayland and X11 for now