### PR TITLE
Fixed window will never show up again if the window is closed when minimized

### DIFF
--- a/Dotnet/MainForm.cs
+++ b/Dotnet/MainForm.cs
@@ -25,6 +25,20 @@ namespace VRCX
         private int LastSizeWidth;
         private int LastSizeHeight;
 
+        private FormWindowState _LastWindowStateToRestore = FormWindowState.Normal;
+        private FormWindowState LastWindowStateToRestore
+        {
+            get => _LastWindowStateToRestore;
+            set
+            {
+                // Used to restore window state after minimized
+                if (FormWindowState.Minimized != value)
+                {
+                    _LastWindowStateToRestore = value;
+                }
+            }
+        }
+
         public MainForm()
         {
             Instance = this;
@@ -129,12 +143,16 @@ namespace VRCX
                 jslogger.Error(ex);
             }
 
+            LastWindowStateToRestore = WindowState;
+
             // 가끔 화면 위치가 안맞음.. 이걸로 해결 될지는 모르겠음
             Browser.Invalidate();
         }
 
         private void MainForm_Resize(object sender, System.EventArgs e)
         {
+            LastWindowStateToRestore = WindowState;
+
             if (WindowState != FormWindowState.Normal)
             {
                 return;
@@ -206,7 +224,7 @@ namespace VRCX
             Show();
             if (WindowState == FormWindowState.Minimized)
             {
-                WindowState = FormWindowState.Normal;
+                WindowState = LastWindowStateToRestore;
             }
             // Focus();
             Activate();

--- a/Dotnet/MainForm.cs
+++ b/Dotnet/MainForm.cs
@@ -29,7 +29,7 @@ namespace VRCX
         {
             Instance = this;
             InitializeComponent();
-            
+
             // adding a 5s delay here to avoid excessive writes to disk
             _saveTimer = new Timer();
             _saveTimer.Interval = 5000;
@@ -141,16 +141,16 @@ namespace VRCX
             }
             LastSizeWidth = Size.Width;
             LastSizeHeight = Size.Height;
-            
+
             _saveTimer?.Start();
         }
-        
+
         private void SaveTimer_Tick(object sender, EventArgs e)
         {
             SaveWindowState();
             _saveTimer?.Stop();
         }
-        
+
         private void MainForm_Move(object sender, System.EventArgs e)
         {
             if (WindowState != FormWindowState.Normal)
@@ -159,7 +159,7 @@ namespace VRCX
             }
             LastLocationX = Location.X;
             LastLocationY = Location.Y;
-            
+
             _saveTimer?.Start();
         }
 
@@ -172,7 +172,7 @@ namespace VRCX
                 Hide();
             }
         }
-        
+
         private void SaveWindowState()
         {
             VRCXStorage.Instance.Set("VRCX_LocationX", LastLocationX.ToString());
@@ -203,11 +203,11 @@ namespace VRCX
 
         public void Focus_Window()
         {
+            Show();
             if (WindowState == FormWindowState.Minimized)
             {
                 WindowState = FormWindowState.Normal;
             }
-            Show();
             // Focus();
             Activate();
         }


### PR DESCRIPTION
`Show()` must be called before changing `WindowState`, otherwise the internal state of the window will be messed up.

If you don't do this, if the window is closed when minimized, even if you click the tray menu icon, it will never show up on Windows 10.