### PR TITLE
Linux: Use NSIS installer

### DIFF
--- a/Dotnet/Program.cs
+++ b/Dotnet/Program.cs
@@ -178,6 +178,7 @@ namespace VRCX
             Application.SetCompatibleTextRenderingDefault(false);
 
             logger.Info("{0} Starting...", Version);
+            logger.Debug("Wine support detection: {0}", Wine.GetIfWine());
             
             ProcessMonitor.Instance.Init();
             SQLiteLegacy.Instance.Init();

--- a/Dotnet/Update.cs
+++ b/Dotnet/Update.cs
@@ -35,6 +35,9 @@ namespace VRCX
 
         private static void Install()
         {
+            var setupArguments = "/S";
+            if (Wine.GetIfWine()) setupArguments += " /DISABLE_SHORTCUT=true";
+            
             try
             {
                 File.Move(Update_Executable, VRCX_Setup_Executable);
@@ -43,7 +46,7 @@ namespace VRCX
                     StartInfo = new ProcessStartInfo
                     {
                         FileName = VRCX_Setup_Executable,
-                        Arguments = "/S",
+                        Arguments = setupArguments,
                         UseShellExecute = true,
                         WorkingDirectory = Program.AppDataDirectory
                     }

--- a/Dotnet/Wine.cs
+++ b/Dotnet/Wine.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace VRCX;
+
+public static class Wine
+{
+    [DllImport("ntdll.dll")]
+    private static extern IntPtr wine_get_version();
+
+    public static bool GetIfWine()
+    {
+        // wine_get_version should be guaranteed to exist exclusively in Wine envs,
+        // unlike some other suggestions like checking Wine registry keys 
+        try
+        {
+            wine_get_version();
+            return true;
+        }
+        catch { return false; }
+    }
+}
+

--- a/Installer/installer.nsi
+++ b/Installer/installer.nsi
@@ -160,6 +160,9 @@ Section "Install" SecInstall
     IntFmt $0 "0x%08X" $0
     WriteRegDWORD HKLM  "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "EstimatedSize" "$0"
 
+    ${GetParameters} $R2
+    ${GetOptions} $R2 /SKIP_SHORTCUT= $3
+    StrCmp $3 "true" +3
     CreateShortCut "$SMPROGRAMS\VRCX.lnk" "$INSTDIR\VRCX.exe"
     ApplicationID::Set "$SMPROGRAMS\VRCX.lnk" "VRCX"
 

--- a/Linux/install-vrcx.sh
+++ b/Linux/install-vrcx.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 steamapps=$HOME/.local/share/Steam/steamapps/compatdata
-stable="https://api0.vrcx.app/releases/stable/latest/download?type=zip"
-nightly="https://api0.vrcx.app/releases/nightly/latest/download?type=zip"
+stable="https://api0.vrcx.app/releases/stable/latest/download"
+nightly="https://api0.vrcx.app/releases/nightly/latest/download"
 download_url=$stable
 XDG_DATA_HOME=${XDG_DATA_HOME:=$HOME/.local/share}
 
-export WINEPREFIX="$XDG_DATA_HOME"/vrcx
+export WINEPREFIX="$HOME/Downloads/vrcxtesting"
 export WINEARCH=win64
 
 set -e
@@ -61,22 +61,19 @@ fi
 winetricks --force -q corefonts # Workaround for https://bugs.winehq.org/show_bug.cgi?id=32342
 
 echo "Download VRCX"
+INSTALL_LOCATION="$WINEPREFIX/drive_c/Program Files/VRCX"
 
-if [[ ! -d $WINEPREFIX/drive_c/vrcx ]]; then
-	mkdir -p $WINEPREFIX/drive_c/vrcx
+if [[ ! -d $INSTALL_LOCATION ]]; then
+	mkdir -p "$INSTALL_LOCATION"
 else
-   rm -r $WINEPREFIX/drive_c/vrcx/*
+   rm -r "${INSTALL_LOCATION:?}/"*
 fi
 
-cd $WINEPREFIX/drive_c/vrcx
-curl -L $download_url -o vrcx.zip
-unzip -uq vrcx.zip
-rm vrcx.zip
+cd INSTALL_LOCATION
+curl -L $download_url -o vrcx_setup.exe
+WINEPREFIX=$WINEPREFIX wine vrcx_setup.exe /S /SKIP_SHORTCUT=true
+rm vrcx_setup.exe
 
-echo "#!/usr/bin/env bash
-export WINEPREFIX=$WINEPREFIX
-wine $WINEPREFIX/drive_c/vrcx/VRCX.exe" > $WINEPREFIX/drive_c/vrcx/vrcx
-chmod +x $WINEPREFIX/drive_c/vrcx/vrcx
 
 echo "Install VRCX.png to $XDG_DATA_HOME/icons"
 curl -L https://raw.githubusercontent.com/vrcx-team/VRCX/master/VRCX.png -o "$XDG_DATA_HOME/icons/VRCX.png"
@@ -86,7 +83,7 @@ echo "[Desktop Entry]
 Type=Application
 Name=VRCX
 Categories=Utility;
-Exec=$WINEPREFIX/drive_c/vrcx/vrcx
+Exec=WINEPREFIX=$WINEPREFIX wine '$INSTALL_LOCATION/VRCX.exe'
 Icon=VRCX
 " > $XDG_DATA_HOME/applications/vrcx.exe.desktop
 

--- a/Linux/install-vrcx.sh
+++ b/Linux/install-vrcx.sh
@@ -66,7 +66,7 @@ INSTALL_LOCATION="$WINEPREFIX/drive_c/Program Files/VRCX"
 if [[ ! -d $INSTALL_LOCATION ]]; then
 	mkdir -p "$INSTALL_LOCATION"
 else
-   rm -r "${INSTALL_LOCATION:?}/"*
+   rm -rf "${INSTALL_LOCATION:?}/"*
 fi
 
 cd $INSTALL_LOCATION

--- a/Linux/install-vrcx.sh
+++ b/Linux/install-vrcx.sh
@@ -6,7 +6,7 @@ nightly="https://api0.vrcx.app/releases/nightly/latest/download"
 download_url=$stable
 XDG_DATA_HOME=${XDG_DATA_HOME:=$HOME/.local/share}
 
-export WINEPREFIX="$HOME/Downloads/vrcxtesting"
+export WINEPREFIX="$XDG_DATA_HOME"/vrcx
 export WINEARCH=win64
 
 set -e

--- a/Linux/install-vrcx.sh
+++ b/Linux/install-vrcx.sh
@@ -69,7 +69,7 @@ else
    rm -rf "${INSTALL_LOCATION:?}/"*
 fi
 
-cd $INSTALL_LOCATION
+cd "$INSTALL_LOCATION"
 curl -L $download_url -o vrcx_setup.exe
 WINEPREFIX=$WINEPREFIX wine vrcx_setup.exe /S /SKIP_SHORTCUT=true
 rm vrcx_setup.exe

--- a/Linux/install-vrcx.sh
+++ b/Linux/install-vrcx.sh
@@ -69,7 +69,7 @@ else
    rm -r "${INSTALL_LOCATION:?}/"*
 fi
 
-cd INSTALL_LOCATION
+cd $INSTALL_LOCATION
 curl -L $download_url -o vrcx_setup.exe
 WINEPREFIX=$WINEPREFIX wine vrcx_setup.exe /S /SKIP_SHORTCUT=true
 rm vrcx_setup.exe


### PR DESCRIPTION
Okay, this PR is mostly minor changes with bigger implications.

I implemented the `SKIP_SHORTCUT` option for the Setup:
- When Wine notices that a shortcut has been installed, it helpfully creates a `.desktop` file for us so that shortcuts are accessible from Linux.
- We provide our own `.desktop` file (partially because I don't think DEs like the autogenerated one?), so this isn't very helpful to us, hence why you can now pass `/SKIP_SHORTCUT=true` to the silent installer and it'll skip making the shortcuts.

I also changed the install script to now use the setup instead of unzipping ourselves, cutting out the `vrcx` script in the process since it's mostly a remnant of when vrcx was still getting added to PATH.

Next up, I added Wine detection in dotnet by calling `wine_get_version` per a `ntdll` extern, that should only exist through Wine.

Tying this all together, the Updater passes `DISABLE_SHORTCUT` if we're on Wine.
 
The rationale for this is that Linux users can use the auto updater now. Not having any way to tell the updater to stop is a big pain point since it can create a second shortcut to VRCX in another install location, that points directly to the executable instead of our script. 

I think this is a very weird UX and I honestly didn't have a good answer on how well that works up until now.

I'm pretty sure that making a special mode for this would be more pain than it's worth, so this also aligns Linux environments more with Windows.