### PR TITLE
Improve login page user experience

### DIFF
--- a/html/src/mixins/loginPage.pug
+++ b/html/src/mixins/loginPage.pug
@@ -22,8 +22,8 @@ mixin loginPage()
                         el-form-item(v-if="enableCustomEndpoint" :label="$t('view.login.field.websocket')" prop="endpoint" style="margin-top:10px")
                             el-input(v-model="loginForm.websocket" name="websocket" :placeholder="API.websocketDomainVrchat" clearable)
                         el-form-item(style="margin-top:15px")
-                            el-button(native-type="submit" type="primary" :loading="loginForm.loading" style="width:100%") {{ $t("view.login.login") }}
-                    el-button(type="primary" @click="openExternalLink('https://vrchat.com/register')" :loading="loginForm.loading" style="width:100%") {{ $t("view.login.register") }}
+                            el-button(native-type="submit" type="primary" style="width:100%") {{ $t("view.login.login") }}
+                    el-button(type="primary" @click="openExternalLink('https://vrchat.com/register')" style="width:100%") {{ $t("view.login.register") }}
                 
                 hr.x-vertical-divider(v-if="Object.keys(loginForm.savedCredentials).length !== 0")/
 


### PR DESCRIPTION
The login page has an overall loading overlay, which activates whenever the loading value changes.
This renders the loading states of the login and registration buttons useless and creates a strange appearance.
Unnecessary loading states should be removed.

![image](https://github.com/user-attachments/assets/a469a72e-b25a-4298-8008-e25927e1d143)
