### PR TITLE
style: alignment issue of el-table header

### DIFF
--- a/html/src/app.scss
+++ b/html/src/app.scss
@@ -94,6 +94,15 @@
     -webkit-line-clamp: 1;
 }
 
+.el-table th.is-sortable .cell {
+    display: flex;
+    align-items: center;
+}
+
+.el-table .caret-wrapper {
+    margin-top: 4.5px;
+}
+
 .notification-table .el-table .cell {
     -webkit-line-clamp: 2;
 }


### PR DESCRIPTION
Correct the alignment issue with the table header (element-ui).
sort-enabled table header and regular table header are not aligned.
fix the style problem.

before:
![image](https://github.com/user-attachments/assets/c07d5529-6dcc-4cd9-a64d-f247b6da56b5)

after:
![image](https://github.com/user-attachments/assets/0fec2703-1659-42ee-a71b-2dec26277952)
