### PR TITLE
Fix filter reset + split them (#1038)

### DIFF
--- a/html/src/classes/sharedFeed.js
+++ b/html/src/classes/sharedFeed.js
@@ -579,17 +579,18 @@ export default class extends baseClass {
             this.updateSharedFeed(true);
         },
 
-        async resetSharedFeedFilters() {
-            if (await configRepository.getString('sharedFeedFilters')) {
-                this.sharedFeedFilters = JSON.parse(
-                    await configRepository.getString(
-                        'sharedFeedFilters',
-                        JSON.stringify(this.sharedFeedFiltersDefaults)
-                    )
-                );
-            } else {
-                this.sharedFeedFilters = this.sharedFeedFiltersDefaults;
-            }
+        async resetNotyFeedFilters(){
+            this.sharedFeedFilters.noty = {
+                ...this.sharedFeedFiltersDefaults.noty
+            };
+            await configRepository.setString('sharedFeedFilters', JSON.stringify(this.sharedFeedFiltersDefaults));
+        },
+
+        async resetWristFeedFilters(){
+            this.sharedFeedFilters.wrist = {
+                ...this.sharedFeedFiltersDefaults.wrist
+            };
+            await configRepository.setString('sharedFeedFilters', JSON.stringify(this.sharedFeedFiltersDefaults));
         }
     };
 }

--- a/html/src/mixins/dialogs/feedFilters.pug
+++ b/html/src/mixins/dialogs/feedFilters.pug
@@ -245,7 +245,7 @@ mixin feedFilters()
                         el-radio-button(label="Off") {{ $t('dialog.shared_feed_filters.off') }}
                         el-radio-button(label="On") {{ $t('dialog.shared_feed_filters.on') }}
         template(#footer)
-            el-button(type="small" @click="resetSharedFeedFilters") {{ $t('dialog.shared_feed_filters.reset') }}
+            el-button(size="small" @click="resetNotyFeedFilters") {{ $t('dialog.shared_feed_filters.reset') }}
             el-button(size="small" type="primary" style="margin-left:10px" @click="notyFeedFiltersDialog.visible = false") {{ $t('dialog.shared_feed_filters.close') }}
 
     //- dialog: wrist feed filters
@@ -499,5 +499,5 @@ mixin feedFilters()
                         el-radio-button(label="Off") {{ $t('dialog.shared_feed_filters.off') }}
                         el-radio-button(label="On") {{ $t('dialog.shared_feed_filters.on') }}
         template(#footer)
-            el-button(size="small" @click="resetSharedFeedFilters") {{ $t('dialog.shared_feed_filters.reset') }}
+            el-button(size="small" @click="resetWristFeedFilters") {{ $t('dialog.shared_feed_filters.reset') }}
             el-button(size="small" type="primary" @click="wristFeedFiltersDialog.visible = false") {{ $t('dialog.shared_feed_filters.close') }}


### PR DESCRIPTION
Fixes the notification feed filter and wrist feed filter reset buttons, and also prevent reset from affecting both.

Closes (#1038)