### PR TITLE
Added conditions to VR overlay notifications + refactor. (#764)

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -7915,6 +7915,10 @@ speechSynthesis.getVoices();
         'VRCX_afkDesktopToast',
         false
     );
+    $app.data.overlayToast = await configRepository.getString(
+        'VRCX_overlayToast',
+        'Game Running'
+    )
     $app.data.minimalFeed = await configRepository.getBool(
         'VRCX_minimalFeed',
         false
@@ -8128,6 +8132,10 @@ speechSynthesis.getVoices();
             'VRCX_afkDesktopToast',
             this.afkDesktopToast
         );
+        await configRepository.setString(
+            'VRCX_overlayToast',
+            this.overlayToast
+        )
         await configRepository.setBool(
             'VRCX_notificationTTSNickName',
             this.notificationTTSNickName

--- a/html/src/classes/vrcxNotifications.js
+++ b/html/src/classes/vrcxNotifications.js
@@ -184,48 +184,25 @@ export default class extends baseClass {
                 return;
             }
 
-            var playNotificationTTS = false;
-            if (
-                this.notificationTTS === 'Always' ||
-                (this.notificationTTS === 'Inside VR' &&
-                    !this.isGameNoVR &&
-                    this.isGameRunning) ||
-                (this.notificationTTS === 'Game Closed' &&
-                    !this.isGameRunning) ||
-                (this.notificationTTS === 'Game Running' && this.isGameRunning)
-            ) {
-                playNotificationTTS = true;
-            }
-            var playDesktopToast = false;
-            if (
-                this.desktopToast === 'Always' ||
-                (this.desktopToast === 'Outside VR' &&
-                    !this.isSteamVRRunning) ||
-                (this.desktopToast === 'Inside VR' && this.isSteamVRRunning) ||
-                (this.desktopToast === 'Game Closed' && !this.isGameRunning) ||
-                (this.desktopToast === 'Game Running' && this.isGameRunning) ||
-                (this.desktopToast === 'Desktop Mode' &&
-                    this.isGameNoVR &&
-                    this.isGameRunning) ||
-                (this.afkDesktopToast &&
-                    this.isHmdAfk &&
-                    this.isGameRunning &&
-                    !this.isGameNoVR)
-            ) {
-                // this if statement looks like it has seen better days
-                playDesktopToast = true;
-            }
-            var playXSNotification = this.xsNotifications;
-            var playOvrtHudNotifications = this.ovrtHudNotifications;
-            var playOvrtWristNotifications = this.ovrtWristNotifications;
-            var playOverlayNotification = false;
-            if (
-                this.overlayNotifications &&
-                !this.isGameNoVR &&
-                this.isGameRunning
-            ) {
-                playOverlayNotification = true;
-            }
+            const notiConditions = {
+                'Always': () => true,
+                'Inside VR': () => this.isSteamVRRunning,
+                'Outside VR': () => !this.isSteamVRRunning,
+                'Game Closed': () => !this.isGameRunning, // Also known as "Outside VRChat"
+                'Game Running': () => this.isGameRunning, // Also known as "Inside VRChat"
+                'Desktop Mode': () => this.isGameNoVR && this.isGameRunning,
+                'AFK': () => this.afkDesktopToast && this.isHmdAfk && this.isGameRunning && !this.isGameNoVR,
+            };
+
+            const playNotificationTTS = notiConditions[this.notificationTTS]?.();
+            const playDesktopToast = notiConditions[this.desktopToast]?.() || notiConditions['AFK']();
+
+            const playOverlayToast = notiConditions[this.overlayToast]?.();
+            const playOverlayNotification = this.overlayNotifications && playOverlayToast;
+            const playXSNotification = this.xsNotifications && playOverlayToast;
+            const playOvrtHudNotifications = this.ovrtHudNotifications && playOverlayToast;
+            const playOvrtWristNotifications = this.ovrtWristNotifications && playOverlayToast;
+
             var message = '';
             if (noty.title) {
                 message = `${noty.title}, ${noty.message}`;

--- a/html/src/localization/en/en.json
+++ b/html/src/localization/en/en.json
@@ -349,26 +349,23 @@
                         "user_images": "User Images (slower)",
                         "notification_timeout": "Notification Timeout"
                     },
+                    "conditions": {
+                        "never": "Never",
+                        "desktop": "Desktop Mode",
+                        "inside_vr": "Inside VR",
+                        "outside_vr": "Outside VR",
+                        "inside_vrchat": "Inside VRChat",
+                        "outside_vrchat": "Outside VRChat",
+                        "always": "Always"
+                    },
                     "desktop_notifications": {
                         "header": "Desktop Notifications",
                         "when_to_display": "When to display",
-                        "when_to_display_never": "Never",
-                        "when_to_display_desktop": "Desktop Mode",
-                        "when_to_display_inside_vr": "Inside VR",
-                        "when_to_display_outside_vr": "Outside VR",
-                        "when_to_display_game_closed": "Game Closed",
-                        "when_to_display_game_running": "Game Running",
-                        "when_to_display_always": "Always",
                         "desktop_notification_while_afk": "Desktop Notifications While AFK"
                     },
                     "text_to_speech": {
                         "header": "Text-To-Speech",
                         "when_to_play": "Notification TTS. When to play",
-                        "when_to_play_never": "Never",
-                        "when_to_play_inside_vr": "Inside VR",
-                        "when_to_play_game_closed": "Game Closed",
-                        "when_to_play_game_running": "Game Running",
-                        "when_to_play_always": "Always",
                         "tts_voice": "TTS Voice",
                         "use_memo_nicknames": "Use Memo Nicknames",
                         "play": "Play",

--- a/html/src/localization/es/en.json
+++ b/html/src/localization/es/en.json
@@ -344,26 +344,21 @@
                         "user_images": "Imágenes de usuarios (más lento)",
                         "notification_timeout": "Tiempo de espera de las notificaciones"
                     },
+                    "conditions": {
+                        "never": "Nunca",
+                        "desktop": "En modo escritorio",
+                        "inside_vr": "Dentro de VR",
+                        "outside_vr": "Fuera de VR",
+                        "always": "Siempre"
+                    },
                     "desktop_notifications": {
                         "header": "Notificaciones de Escritorio",
                         "when_to_display": "Cuándo mostrar",
-                        "when_to_display_never": "Nunca",
-                        "when_to_display_desktop": "En modo escritorio",
-                        "when_to_display_inside_vr": "Dentro de VR",
-                        "when_to_display_outside_vr": "Fuera de VR",
-                        "when_to_display_game_closed": "Juego cerrado",
-                        "when_to_display_game_running": "Juego abierto",
-                        "when_to_display_always": "Siempre",
                         "desktop_notification_while_afk": "Notificaciones de escritorio mientras se está AFK"
                     },
                     "text_to_speech": {
                         "header": "Text-To-Speech",
                         "when_to_play": "Notificaciones TTS. Cuándo se reproduce",
-                        "when_to_play_never": "Nunca",
-                        "when_to_play_inside_vr": "Dentro de VR",
-                        "when_to_play_game_closed": "Juego cerrado",
-                        "when_to_play_game_running": "Juego abierto",
-                        "when_to_play_always": "Siempre",
                         "tts_voice": "Voz TTS"
                     }
                 }

--- a/html/src/localization/fr/en.json
+++ b/html/src/localization/fr/en.json
@@ -343,26 +343,21 @@
                         "user_images": "Afficher les images d'utilisateur (plus lent)",
                         "notification_timeout": "Délai des notifications"
                     },
+                    "conditions": {
+                        "never": "Jamais",
+                        "desktop": "Mode bureau",
+                        "inside_vr": "Durant la VR",
+                        "outside_vr": "En dehors de la VR",
+                        "always": "En permanence"
+                    },
                     "desktop_notifications": {
                         "header": "Notifications sur le bureau",
                         "when_to_display": "Quand l'afficher",
-                        "when_to_display_never": "Jamais",
-                        "when_to_display_desktop": "Mode bureau",
-                        "when_to_display_inside_vr": "Durant la VR",
-                        "when_to_display_outside_vr": "En dehors de la VR",
-                        "when_to_display_game_closed": "Jeu fermé",
-                        "when_to_display_game_running": "Jeu en cours",
-                        "when_to_display_always": "En permanence",
                         "desktop_notification_while_afk": "Notification bureau en mode AFK"
                     },
                     "text_to_speech": {
                         "header": "Text-To-Speech",
                         "when_to_play": "Quand la jouer",
-                        "when_to_play_never": "Jamais",
-                        "when_to_play_inside_vr": "Durant la VR",
-                        "when_to_play_game_closed": "Jeu fermé",
-                        "when_to_play_game_running": "Jeu en cours",
-                        "when_to_play_always": "En permanence",
                         "tts_voice": "Voix de la synthèse vocale"
                     }
                 }

--- a/html/src/localization/hu/en.json
+++ b/html/src/localization/hu/en.json
@@ -343,26 +343,21 @@
                         "user_images": "User Images (slower)",
                         "notification_timeout": "Notification Timeout"
                     },
+                    "conditions": {
+                        "never": "Never",
+                        "desktop": "Desktop Mode",
+                        "inside_vr": "Inside VR",
+                        "outside_vr": "Outside VR",
+                        "always": "Always"
+                    },
                     "desktop_notifications": {
                         "header": "Desktop Notifications",
                         "when_to_display": "When to display",
-                        "when_to_display_never": "Never",
-                        "when_to_display_desktop": "Desktop Mode",
-                        "when_to_display_inside_vr": "Inside VR",
-                        "when_to_display_outside_vr": "Outside VR",
-                        "when_to_display_game_closed": "Game Closed",
-                        "when_to_display_game_running": "Game Running",
-                        "when_to_display_always": "Always",
                         "desktop_notification_while_afk": "Desktop Notifications While AFK"
                     },
                     "text_to_speech": {
                         "header": "Text-To-Speech",
                         "when_to_play": "Notification TTS. When to play",
-                        "when_to_play_never": "Never",
-                        "when_to_play_inside_vr": "Inside VR",
-                        "when_to_play_game_closed": "Game Closed",
-                        "when_to_play_game_running": "Game Running",
-                        "when_to_play_always": "Always",
                         "tts_voice": "TTS Voice"
                     }
                 }

--- a/html/src/localization/ja/en.json
+++ b/html/src/localization/ja/en.json
@@ -348,26 +348,21 @@
                         "user_images": "ユーザー画像を使用 (遅い)",
                         "notification_timeout": "通知のタイムアウト時間"
                     },
+                    "conditions": {
+                        "never": "表示しない",
+                        "desktop": "デスクトップモード",
+                        "inside_vr": "VRChat中",
+                        "outside_vr": "VRChat以外",
+                        "always": "常に表示する"
+                    },
                     "desktop_notifications": {
                         "header": "デスクトップの通知",
                         "when_to_display": "表示タイミング",
-                        "when_to_display_never": "表示しない",
-                        "when_to_display_desktop": "デスクトップモード",
-                        "when_to_display_inside_vr": "VR中",
-                        "when_to_display_outside_vr": "VR以外",
-                        "when_to_display_game_closed": "ゲーム終了時",
-                        "when_to_display_game_running": "ゲーム実行時",
-                        "when_to_display_always": "常に表示する",
                         "desktop_notification_while_afk": "AFK中でもデスクトップに通知"
                     },
                     "text_to_speech": {
                         "header": "Text-To-Speech",
                         "when_to_play": "読み上げタイミング",
-                        "when_to_play_never": "読み上げない",
-                        "when_to_play_inside_vr": "VR中",
-                        "when_to_play_game_closed": "ゲーム終了時",
-                        "when_to_play_game_running": "ゲーム実行時",
-                        "when_to_play_always": "常に読み上げる",
                         "tts_voice": "読み上げボイス",
                         "use_memo_nicknames": "メモのニックネームを使用"
                     }

--- a/html/src/localization/ko/en.json
+++ b/html/src/localization/ko/en.json
@@ -343,26 +343,21 @@
                         "user_images": "유저 이미지 표시 (느림)",
                         "notification_timeout": "알림 시간 설정"
                     },
+                    "conditions": {
+                        "never": "안함",
+                        "desktop": "데스크톱 모드",
+                        "inside_vr": "VR을 쓰고 있을 때",
+                        "outside_vr": "VR을 벗고 있을 때",
+                        "always": "항상"
+                    },
                     "desktop_notifications": {
                         "header": "데스크톱 알림",
                         "when_to_display": "표시 조건",
-                        "when_to_display_never": "안함",
-                        "when_to_display_desktop": "데스크톱 모드",
-                        "when_to_display_inside_vr": "VR을 쓰고 있을 때",
-                        "when_to_display_outside_vr": "VR을 벗고 있을 때",
-                        "when_to_display_game_closed": "VRChat을 하지 않을 때",
-                        "when_to_display_game_running": "VRChat을 할 때",
-                        "when_to_display_always": "항상",
                         "desktop_notification_while_afk": "Desktop Notifications While AFK"
                     },
                     "text_to_speech": {
                         "header": "Text-To-Speech",
                         "when_to_play": "알림 TTS 재생 조건",
-                        "when_to_play_never": "안함",
-                        "when_to_play_inside_vr": "VR을 쓰고 있을 때",
-                        "when_to_play_game_closed": "VRChat을 하지 않을 때",
-                        "when_to_play_game_running": "VRChat을 할 때",
-                        "when_to_play_always": "항상",
                         "tts_voice": "TTS 목소리"
                     }
                 }

--- a/html/src/localization/pl/en.json
+++ b/html/src/localization/pl/en.json
@@ -343,26 +343,21 @@
                         "user_images": "Obrazki użytkowników (wolniejsze)",
                         "notification_timeout": "Czas trwania powiadomień"
                     },
+                    "conditions": {
+                        "never": "Nigdy",
+                        "desktop": "Tryb PC",
+                        "inside_vr": "W VR",
+                        "outside_vr": "Poza VR",
+                        "always": "Zawsze"
+                    },
                     "desktop_notifications": {
                         "header": "Powiadomienia na pulpicie",
                         "when_to_display": "Kiedy wyświetlać",
-                        "when_to_display_never": "Nigdy",
-                        "when_to_display_desktop": "Tryb PC",
-                        "when_to_display_inside_vr": "W VR",
-                        "when_to_display_outside_vr": "Poza VR",
-                        "when_to_display_game_closed": "Gra wyłączona",
-                        "when_to_display_game_running": "Gra uruchomiona",
-                        "when_to_display_always": "Zawsze",
                         "desktop_notification_while_afk": "Powiadomienia na pulpicie podczas AFK"
                     },
                     "text_to_speech": {
                         "header": "Text-To-Speech",
                         "when_to_play": "Kiedy odtwarzać powiadomienia jako tekst-na-mowę",
-                        "when_to_play_never": "Nigdy",
-                        "when_to_play_inside_vr": "W VR",
-                        "when_to_play_game_closed": "Gra wyłączona",
-                        "when_to_play_game_running": "Gra uruchomiona",
-                        "when_to_play_always": "Zawsze",
                         "tts_voice": "Głos tekstu-na-mowę"
                     }
                 }

--- a/html/src/localization/pt/en.json
+++ b/html/src/localization/pt/en.json
@@ -343,26 +343,21 @@
                         "user_images": "Imagens do Usuário (mais lento)",
                         "notification_timeout": "Tempo limite da Notificação"
                     },
+                    "conditions": {
+                        "never": "Nunca",
+                        "desktop": "Modo Desktop",
+                        "inside_vr": "Dentro do VR",
+                        "outside_vr": "Fora do VR",
+                        "always": "Sempre"
+                    },
                     "desktop_notifications": {
                         "header": "Notificações do Desktop",
                         "when_to_display": "Quando mostrar",
-                        "when_to_display_never": "Nunca",
-                        "when_to_display_desktop": "Modo Desktop",
-                        "when_to_display_inside_vr": "Dentro do VR",
-                        "when_to_display_outside_vr": "Fora do VR",
-                        "when_to_display_game_closed": "Jogo Fechado",
-                        "when_to_display_game_running": "Jogo em Execução",
-                        "when_to_display_always": "Sempre",
                         "desktop_notification_while_afk": "Notificações no Desktop Enquanto AFK"
                     },
                     "text_to_speech": {
                         "header": "Texto-Para-Fala",
                         "when_to_play": "Nitificação TTS. Quando deseja reproduzir",
-                        "when_to_play_never": "Nunca",
-                        "when_to_play_inside_vr": "Dentro do VR",
-                        "when_to_play_game_closed": "Jogo Fechado",
-                        "when_to_play_game_running": "Jogo em Execução",
-                        "when_to_play_always": "Sempre",
                         "tts_voice": "Voz TTS"
                     }
                 }

--- a/html/src/localization/ru/en.json
+++ b/html/src/localization/ru/en.json
@@ -347,26 +347,21 @@
                         "user_images": "Иконка пользователя (медленнее)",
                         "notification_timeout": "Время показа уведомлений"
                     },
+                    "conditions": {
+                        "never": "Никогда",
+                        "desktop": "Режим настольного ПК",
+                        "inside_vr": "В VR",
+                        "outside_vr": "Вне VR",
+                        "always": "Всегда"
+                    },
                     "desktop_notifications": {
                         "header": "Уведомления на рабочем столе",
                         "when_to_display": "Когда отображать",
-                        "when_to_display_never": "Никогда",
-                        "when_to_display_desktop": "Режим настольного ПК",
-                        "when_to_display_inside_vr": "В VR",
-                        "when_to_display_outside_vr": "Вне VR",
-                        "when_to_display_game_closed": "Игра закрыта",
-                        "when_to_display_game_running": "Игра запущена",
-                        "when_to_display_always": "Всегда",
                         "desktop_notification_while_afk": "Уведомления на рабочем столе при AFK"
                     },
                     "text_to_speech": {
                         "header": "Преобразование текста в речь",
                         "when_to_play": "TTS уведомления во время игры",
-                        "when_to_play_never": "Никогда",
-                        "when_to_play_inside_vr": "В VR",
-                        "when_to_play_game_closed": "Игра закрыта",
-                        "when_to_play_game_running": "Игра запущена",
-                        "when_to_play_always": "Всегда",
                         "tts_voice": "Синтезатор голоса",
                         "use_memo_nicknames": "Использовать прозвища из заметок"
                     }

--- a/html/src/localization/vi/en.json
+++ b/html/src/localization/vi/en.json
@@ -343,26 +343,21 @@
                         "user_images": "Ảnh người chơi (chậm hơn)",
                         "notification_timeout": "Thời gian chờ thông báo tối đa (Timeout)"
                     },
+                    "conditions": {
+                        "never": "Không bao giờ",
+                        "desktop": "Trên chế độ Desktop",
+                        "inside_vr": "Trong VR",
+                        "outside_vr": "Ngoài VR",
+                        "always": "Luôn luôn"
+                    },
                     "desktop_notifications": {
                         "header": "Thông báo Desktop",
                         "when_to_display": "Khi nào hiển thị",
-                        "when_to_display_never": "Không bao giờ",
-                        "when_to_display_desktop": "Trên chế độ Desktop",
-                        "when_to_display_inside_vr": "Trong VR",
-                        "when_to_display_outside_vr": "Ngoài VR",
-                        "when_to_display_game_closed": "Đóng trò chơi",
-                        "when_to_display_game_running": "Khi trò chơi đang chạy",
-                        "when_to_display_always": "Luôn luôn",
                         "desktop_notification_while_afk": "Desktop Notifications While AFK"
                     },
                     "text_to_speech": {
                         "header": "Text-To-Speech",
                         "when_to_play": "Thông báo TTS. khi nào báo",
-                        "when_to_play_never": "Không bao giờ",
-                        "when_to_play_inside_vr": "Trong VR",
-                        "when_to_play_game_closed": "Đóng trò chơi",
-                        "when_to_play_game_running": "Khi trò chơi đang chạy",
-                        "when_to_play_always": "Luôn luôn",
                         "tts_voice": "Giọng TTS"
                     }
                 }

--- a/html/src/localization/zh-CN/en.json
+++ b/html/src/localization/zh-CN/en.json
@@ -349,26 +349,21 @@
                         "user_images": "显示用户头像（较慢）",
                         "notification_timeout": "通知时长"
                     },
+                    "conditions": {
+                        "never": "永不",
+                        "desktop": "在桌面模式时",
+                        "inside_vr": "在 VR 里时",
+                        "outside_vr": "在 VR 外时",
+                        "always": "总是"
+                    },
                     "desktop_notifications": {
                         "header": "桌面通知",
                         "when_to_display": "何时显示",
-                        "when_to_display_never": "永不",
-                        "when_to_display_desktop": "在桌面模式时",
-                        "when_to_display_inside_vr": "在 VR 里时",
-                        "when_to_display_outside_vr": "在 VR 外时",
-                        "when_to_display_game_closed": "游戏关闭时",
-                        "when_to_display_game_running": "游戏运行时",
-                        "when_to_display_always": "总是",
                         "desktop_notification_while_afk": "当处于 AFK 状态时显示桌面通知"
                     },
                     "text_to_speech": {
                         "header": "文字转语音选项",
                         "when_to_play": "何时使用文字转语音",
-                        "when_to_play_never": "永不",
-                        "when_to_play_inside_vr": "在 VR 里时",
-                        "when_to_play_game_closed": "游戏关闭时",
-                        "when_to_play_game_running": "游戏运行时",
-                        "when_to_play_always": "总是",
                         "tts_voice": "TTS 语音样式",
                         "use_memo_nicknames": "使用备忘录昵称",
                         "play": "播放",

--- a/html/src/localization/zh-TW/en.json
+++ b/html/src/localization/zh-TW/en.json
@@ -343,26 +343,21 @@
                         "user_images": "玩家照片（較慢）",
                         "notification_timeout": "通知時長"
                     },
+                    "conditions": {
+                        "never": "永不",
+                        "desktop": "在桌面模式時",
+                        "inside_vr": "在 VR 裡時",
+                        "outside_vr": "在 VR 外時",
+                        "always": "總是"
+                    },
                     "desktop_notifications": {
                         "header": "桌面通知",
                         "when_to_display": "顯示時機",
-                        "when_to_display_never": "永不",
-                        "when_to_display_desktop": "在桌面模式時",
-                        "when_to_display_inside_vr": "在 VR 裡時",
-                        "when_to_display_outside_vr": "在 VR 外時",
-                        "when_to_display_game_closed": "遊戲關閉時",
-                        "when_to_display_game_running": "遊戲執行中",
-                        "when_to_display_always": "總是",
                         "desktop_notification_while_afk": "在 AFK 時顯示桌面通知"
                     },
                     "text_to_speech": {
                         "header": "文字轉語音",
                         "when_to_play": "通知文字轉語音播放時機",
-                        "when_to_play_never": "永不",
-                        "when_to_play_inside_vr": "在 VR 裡時",
-                        "when_to_play_game_closed": "遊戲關閉時",
-                        "when_to_play_game_running": "遊戲執行中",
-                        "when_to_play_always": "總是",
                         "tts_voice": "語音樣式"
                     }
                 }

--- a/html/src/mixins/tabs/settings.pug
+++ b/html/src/mixins/tabs/settings.pug
@@ -321,6 +321,14 @@ mixin settingsTab()
                 div.options-container
                     span.sub-header {{ $t('view.settings.notifications.notifications.steamvr_notifications.header') }}
                     div.options-container-item
+                        span.name {{ $t('view.settings.notifications.notifications.desktop_notifications.when_to_display') }}
+                        br
+                        el-radio-group(v-model="overlayToast" @change="saveOpenVROption" size="mini" :disabled="(!overlayNotifications || !openVR) && !xsNotifications && !ovrtHudNotifications && !ovrtWristNotifications" style="margin-top:5px")
+                            el-radio-button(label="Never") {{ $t('view.settings.notifications.notifications.conditions.never') }}
+                            el-radio-button(label="Game Running") {{ $t('view.settings.notifications.notifications.conditions.inside_vrchat') }}
+                            el-radio-button(label="Game Closed") {{ $t('view.settings.notifications.notifications.conditions.outside_vrchat') }}
+                            el-radio-button(label="Always") {{ $t('view.settings.notifications.notifications.conditions.always') }}
+                    div.options-container-item
                         +simpleSwitch("view.settings.notifications.notifications.steamvr_notifications.steamvr_overlay", "openVR", "saveOpenVROption")
                     div.options-container-item
                         span.name {{ $t('view.settings.notifications.notifications.steamvr_notifications.overlay_notifications') }}
@@ -344,13 +352,13 @@ mixin settingsTab()
                         span.name {{ $t('view.settings.notifications.notifications.desktop_notifications.when_to_display') }}
                         br
                         el-radio-group(v-model="desktopToast" @change="saveOpenVROption" size="mini" style="margin-top:5px")
-                            el-radio-button(label="Never") {{ $t('view.settings.notifications.notifications.desktop_notifications.when_to_display_never') }}
-                            el-radio-button(label="Desktop Mode") {{ $t('view.settings.notifications.notifications.desktop_notifications.when_to_display_desktop') }}
-                            el-radio-button(label="Inside VR") {{ $t('view.settings.notifications.notifications.desktop_notifications.when_to_display_inside_vr') }}
-                            el-radio-button(label="Outside VR") {{ $t('view.settings.notifications.notifications.desktop_notifications.when_to_display_outside_vr') }}
-                            el-radio-button(label="Game Closed") {{ $t('view.settings.notifications.notifications.desktop_notifications.when_to_display_game_closed') }}
-                            el-radio-button(label="Game Running") {{ $t('view.settings.notifications.notifications.desktop_notifications.when_to_display_game_running') }}
-                            el-radio-button(label="Always") {{ $t('view.settings.notifications.notifications.desktop_notifications.when_to_display_always') }}
+                            el-radio-button(label="Never") {{ $t('view.settings.notifications.notifications.conditions.never') }}
+                            el-radio-button(label="Desktop Mode") {{ $t('view.settings.notifications.notifications.conditions.desktop') }}
+                            el-radio-button(label="Inside VR") {{ $t('view.settings.notifications.notifications.conditions.inside_vr') }}
+                            el-radio-button(label="Outside VR") {{ $t('view.settings.notifications.notifications.conditions.outside_vr') }}
+                            el-radio-button(label="Game Running") {{ $t('view.settings.notifications.notifications.conditions.inside_vrchat') }}
+                            el-radio-button(label="Game Closed") {{ $t('view.settings.notifications.notifications.conditions.outside_vrchat') }}
+                            el-radio-button(label="Always") {{ $t('view.settings.notifications.notifications.conditions.always') }}
                     div.options-container-item
                         span.name(style="min-width:225px") {{ $t('view.settings.notifications.notifications.desktop_notifications.desktop_notification_while_afk') }}
                         el-switch(v-model="afkDesktopToast" @change="saveOpenVROption")
@@ -361,11 +369,11 @@ mixin settingsTab()
                         span.name {{ $t('view.settings.notifications.notifications.text_to_speech.when_to_play') }}
                         br
                         el-radio-group(v-model="notificationTTS" @change="saveNotificationTTS" size="mini" style="margin-top:5px")
-                            el-radio-button(label="Never") {{ $t('view.settings.notifications.notifications.text_to_speech.when_to_play_never') }}
-                            el-radio-button(label="Inside VR") {{ $t('view.settings.notifications.notifications.text_to_speech.when_to_play_inside_vr') }}
-                            el-radio-button(label="Game Closed") {{ $t('view.settings.notifications.notifications.text_to_speech.when_to_play_game_closed') }}
-                            el-radio-button(label="Game Running") {{ $t('view.settings.notifications.notifications.text_to_speech.when_to_play_game_running') }}
-                            el-radio-button(label="Always") {{ $t('view.settings.notifications.notifications.text_to_speech.when_to_play_always') }}
+                            el-radio-button(label="Never") {{ $t('view.settings.notifications.notifications.conditions.never') }}
+                            el-radio-button(label="Inside VR") {{ $t('view.settings.notifications.notifications.conditions.inside_vr') }}
+                            el-radio-button(label="Game Running") {{ $t('view.settings.notifications.notifications.conditions.inside_vrchat') }}
+                            el-radio-button(label="Game Closed") {{ $t('view.settings.notifications.notifications.conditions.outside_vrchat') }}
+                            el-radio-button(label="Always") {{ $t('view.settings.notifications.notifications.conditions.always') }}
                     div.options-container-item
                         span.name {{ $t('view.settings.notifications.notifications.text_to_speech.tts_voice') }}
                         el-dropdown(@command="(voice) => changeTTSVoice(voice)" trigger="click" size="small")


### PR DESCRIPTION
Adds conditions for displaying VR overlay notifications.
'Never', 'Inside VRChat', 'Outside VRChat', 'Always'.

In addition, slight refactor on the condition checks for notifications in general.

'Game Running' has been renamed to 'Inside VRChat'
'Game Closed' has been renamed to 'Outside VRChat'

Internally however, the names remain to retain settings.

Closes (#764)