### PR TITLE
Refresh the avatar dialog when impostor is deleted

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -12019,6 +12019,7 @@ speechSynthesis.getVoices();
                                         message: 'Imposter deleted',
                                         type: 'success'
                                     });
+                                    this.showAvatarDialog(D.id);
                                     return args;
                                 });
                                 break;


### PR DESCRIPTION
This will refresh the avatar dialog when you delete an impostor to stop the page from showing the "Delete Impostor" button and that the avatar still has impostor