### PR TITLE
Adds a regenerate impostor button

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -12019,6 +12019,7 @@ speechSynthesis.getVoices();
                                         message: 'Imposter deleted',
                                         type: 'success'
                                     });
+                                    this.showAvatarDialog(D.id);
                                     return args;
                                 });
                                 break;

--- a/html/src/app.js
+++ b/html/src/app.js
@@ -12034,6 +12034,21 @@ speechSynthesis.getVoices();
                                     return args;
                                 });
                                 break;
+                            case 'Regenerate Imposter':
+                                API.deleteImposter({
+                                    avatarId: D.id
+                                }).then((args) => {return args;});
+                                this.showAvatarDialog(D.id);
+                                API.createImposter({
+                                    avatarId: D.id
+                                }).then((args) => {
+                                    this.$message({
+                                        message: 'Imposter deleted and queued for creation',
+                                        type: 'success'
+                                    });
+                                    return args;
+                                });
+                                break;
                         }
                     }
                 });

--- a/html/src/localization/en/en.json
+++ b/html/src/localization/en/en.json
@@ -842,6 +842,7 @@
                 "download_package": "Download Unity Package",
                 "delete": "Delete",
                 "delete_impostor": "Delete Impostor",
+                "regenerate_impostor": "Regenerate Impostor",
                 "create_impostor": "Create Impostor"
             },
             "info": {

--- a/html/src/localization/es/en.json
+++ b/html/src/localization/es/en.json
@@ -802,6 +802,7 @@
                 "download_package": "Descargar paquete de Unity",
                 "delete": "Eliminar",
                 "delete_impostor": "Eliminar Impostor",
+                "regenerate_impostor": "Recrear Impostor",
                 "create_impostor": "Crear impostor"
             },
             "info": {

--- a/html/src/localization/fr/en.json
+++ b/html/src/localization/fr/en.json
@@ -794,6 +794,7 @@
                 "download_package": "Télécharger le package Unity",
                 "delete": "Supprimer",
                 "delete_impostor": "Supprimer l'imposteur",
+                "regenerate_impostor": "Recréer un imposteur",
                 "create_impostor": "Créer un imposteur"
             },
             "info": {

--- a/html/src/localization/hu/en.json
+++ b/html/src/localization/hu/en.json
@@ -794,6 +794,7 @@
                 "download_package": "Download Unity Package",
                 "delete": "Törlés",
                 "delete_impostor": "Delete Impostor",
+                "regenerate_impostor": "Regenerate Impostor",
                 "create_impostor": "Create Impostor"
             },
             "info": {

--- a/html/src/localization/ja/en.json
+++ b/html/src/localization/ja/en.json
@@ -817,6 +817,7 @@
                 "download_package": "Unity Packageをダウンロード",
                 "delete": "削除",
                 "delete_impostor": "インポスターを削除",
+                "regenerate_impostor": "Regenerate Impostor",
                 "create_impostor": "インポスターを作成"
             },
             "info": {

--- a/html/src/localization/ko/en.json
+++ b/html/src/localization/ko/en.json
@@ -794,6 +794,7 @@
                 "download_package": "유니티 패키지 다운로드",
                 "delete": "삭제",
                 "delete_impostor": "Delete Impostor",
+                "regenerate_impostor": "Regenerate Impostor",
                 "create_impostor": "Create Impostor"
             },
             "info": {

--- a/html/src/localization/pl/en.json
+++ b/html/src/localization/pl/en.json
@@ -794,6 +794,7 @@
                 "download_package": "Pobierz paczkę Unity",
                 "delete": "Usuń",
                 "delete_impostor": "Usuń Impostora",
+                "regenerate_impostor": "Odtwórz Impostora",
                 "create_impostor": "Stwórz Impostora"
             },
             "info": {

--- a/html/src/localization/pt/en.json
+++ b/html/src/localization/pt/en.json
@@ -794,6 +794,7 @@
                 "download_package": "Baixar Pacote Unity",
                 "delete": "Excluir",
                 "delete_impostor": "Excluir Impostor",
+                "regenerate_impostor": "Recriar Impostor",
                 "create_impostor": "Criar Impostor"
             },
             "info": {

--- a/html/src/localization/ru/en.json
+++ b/html/src/localization/ru/en.json
@@ -826,6 +826,7 @@
                 "download_package": "Скачать пакет Unity",
                 "delete": "Удалить",
                 "delete_impostor": "Удалить импостора",
+                "regenerate_impostor": "Воссоздать импостора",
                 "create_impostor": "Создать импостора"
             },
             "info": {

--- a/html/src/localization/vi/en.json
+++ b/html/src/localization/vi/en.json
@@ -794,6 +794,7 @@
                 "download_package": "Tải về Unity Package",
                 "delete": "Xóa",
                 "delete_impostor": "Delete Impostor",
+                "regenerate_impostor": "Regenerate Impostor",
                 "create_impostor": "Create Impostor"
             },
             "info": {

--- a/html/src/localization/zh-CN/en.json
+++ b/html/src/localization/zh-CN/en.json
@@ -832,6 +832,7 @@
                 "download_package": "下载 Unity Package",
                 "delete": "删除",
                 "delete_impostor": "删除模型替身",
+                "regenerate_impostor": "Regenerate Impostor",
                 "create_impostor": "创建模型替身"
             },
             "info": {

--- a/html/src/localization/zh-TW/en.json
+++ b/html/src/localization/zh-TW/en.json
@@ -794,6 +794,7 @@
                 "download_package": "下載 Unity Package",
                 "delete": "刪除",
                 "delete_impostor": "Delete Impostor",
+                "regenerate_impostor": "Regenerate Impostor",
                 "create_impostor": "Create Impostor"
             },
             "info": {

--- a/html/src/mixins/dialogs/avatarDialog.pug
+++ b/html/src/mixins/dialogs/avatarDialog.pug
@@ -67,6 +67,7 @@ mixin avatarDialog()
                                     el-dropdown-item(icon="el-icon-picture-outline" command="Change Image") {{ $t('dialog.avatar.actions.change_image') }}
                                     el-dropdown-item(v-if="avatarDialog.ref.unityPackageUrl" icon="el-icon-download" command="Download Unity Package") {{ $t('dialog.avatar.actions.download_package') }}
                                     el-dropdown-item(v-if="avatarDialog.hasImposter" icon="el-icon-delete" command="Delete Imposter" style="color:#F56C6C") {{ $t('dialog.avatar.actions.delete_impostor') }}
+                                    el-dropdown-item(v-if="avatarDialog.hasImposter" icon="el-icon-delete" command="Regenerate Imposter" style="color:#F56C6C") {{ $t('dialog.avatar.actions.regenerate_impostor') }}
                                     el-dropdown-item(v-else icon="el-icon-user" command="Create Imposter") {{ $t('dialog.avatar.actions.create_impostor') }}
                                     el-dropdown-item(icon="el-icon-delete" command="Delete" style="color:#F56C6C" divided) {{ $t('dialog.avatar.actions.delete') }}
             el-tabs


### PR DESCRIPTION
This feature adds a button to regenerate an impostor, to save a few clicks
It deletes the impostor, refreshes the avatar dialog and queues the creation for a new one
![Screenshot 2024-12-27 151243](https://github.com/user-attachments/assets/3d850aad-0cd3-4c10-b5f6-dc9f517d53ae)
