### PR TITLE
Correction of VRChat Credit terminology

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -22412,26 +22412,26 @@ speechSynthesis.getVoices();
     };
 
     // #endregion
-    // #region | V-Bucks
+    // #region | VRChat Credits
 
-    API.$on('VBUCKS', function (args) {
-        this.currentUser.$vbucks = args.json?.balance;
+    API.$on('VRCCREDITS', function (args) {
+        this.currentUser.$getVRChatCredits = args.json?.balance;
     });
 
-    API.getVbucks = function () {
+    API.getVRChatCredits = function () {
         return this.call(`user/${this.currentUser.id}/balance`, {
             method: 'GET'
         }).then((json) => {
             var args = {
                 json
             };
-            this.$emit('VBUCKS', args);
+            this.$emit('VRCCREDITS', args);
             return args;
         });
     };
 
-    $app.methods.getVbucks = function () {
-        API.getVbucks();
+    $app.methods.getVRChatCredits = function () {
+        API.getVRChatCredits();
     };
 
     // #endregion

--- a/html/src/app.js
+++ b/html/src/app.js
@@ -22415,7 +22415,7 @@ speechSynthesis.getVoices();
     // #region | VRChat Credits
 
     API.$on('VRCCREDITS', function (args) {
-        this.currentUser.$getVRChatCredits = args.json?.balance;
+        this.currentUser.$vrchatcredits = args.json?.balance;
     });
 
     API.getVRChatCredits = function () {

--- a/html/src/classes/currentUser.js
+++ b/html/src/classes/currentUser.js
@@ -289,7 +289,7 @@ export default class extends baseClass {
                     $languages: [],
                     $locationTag: '',
                     $travelingToLocation: '',
-                    $vbucks: null,
+                    $vrchatcredits: null,
                     ...json
                 };
                 ref.$homeLocation = $app.parseLocation(ref.homeLocation);

--- a/html/src/localization/en/en.json
+++ b/html/src/localization/en/en.json
@@ -157,7 +157,7 @@
                 "two_factor": "Two-Factor Auth (2FA)",
                 "two_factor_enabled": "Enabled",
                 "two_factor_disabled": "Disabled",
-                "v_bucks": "V-Bucks",
+                "vrchat_credits": "VRChat Credits",
                 "refresh": "Click to refresh",
                 "logout": "Logout",
                 "manage_gallery_icon": "Manage Photos/Icons/Emojis/Stickers",

--- a/html/src/localization/es/en.json
+++ b/html/src/localization/es/en.json
@@ -156,7 +156,7 @@
                 "two_factor": "Autenticación de doble factor (2FA)",
                 "two_factor_enabled": "Habilitado",
                 "two_factor_disabled": "Deshabilitado",
-                "v_bucks": "V-Bucks",
+                "vrchat_credits": "Créditos de VRChat",
                 "refresh": "Clic para actualizar",
                 "logout": "Cerrar sesión",
                 "manage_gallery_icon": "Administrar Fotos/Iconos/Emojis",

--- a/html/src/localization/fr/en.json
+++ b/html/src/localization/fr/en.json
@@ -149,7 +149,7 @@
                 "two_factor": "Authentification à double facteurs (2FA)",
                 "two_factor_enabled": "Activé",
                 "two_factor_disabled": "Désactivé",
-                "v_bucks": "Crédits VRChat",
+                "vrchat_credits": "Crédits VRChat",
                 "refresh": "Cliquez pour actualiser",
                 "logout": "Se déconnecter",
                 "manage_gallery_icon": "Gérer les Photos/Icônes/Emojis",

--- a/html/src/localization/hu/en.json
+++ b/html/src/localization/hu/en.json
@@ -149,7 +149,7 @@
                 "two_factor": "Kétlépcsős hitelesítés (2FA)",
                 "two_factor_enabled": "Bekapcsolva",
                 "two_factor_disabled": "Kikapcsolva",
-                "v_bucks": "V-Buckok",
+                "vrchat_credits": "VRChat-kreditek",
                 "refresh": "Kattints ide a frissítéshez",
                 "logout": "Kijelentkezés",
                 "manage_gallery_icon": "Képek/ikonok/emojik kezelése",

--- a/html/src/localization/ja/en.json
+++ b/html/src/localization/ja/en.json
@@ -158,7 +158,7 @@
                 "two_factor": "2段階認証 (2FA)",
                 "two_factor_enabled": "有効",
                 "two_factor_disabled": "無効",
-                "v_bucks": "V-Bucks",
+                "vrchat_credits": "VRChatクレジット",
                 "refresh": "クリックして更新",
                 "logout": "ログアウト",
                 "manage_gallery_icon": "写真/アイコン/絵文字を管理",

--- a/html/src/localization/ko/en.json
+++ b/html/src/localization/ko/en.json
@@ -149,7 +149,7 @@
                 "two_factor": "2단계 인증 (2FA)",
                 "two_factor_enabled": "사용",
                 "two_factor_disabled": "사용 안 함",
-                "v_bucks": "V-Bucks",
+                "vrchat_credits": "VRChat 크레딧",
                 "refresh": "새로고침",
                 "logout": "로그아웃",
                 "manage_gallery_icon": "Manage Photos/Icons/Emojis",

--- a/html/src/localization/pl/en.json
+++ b/html/src/localization/pl/en.json
@@ -149,7 +149,7 @@
                 "two_factor": "Autoryzacja dwuetapowa (2FA)",
                 "two_factor_enabled": "Włączona",
                 "two_factor_disabled": "Wyłączona",
-                "v_bucks": "Kredyty VRChat",
+                "vrchat_credits": "Kredyty VRChat",
                 "refresh": "Kliknij, aby odświeżyć",
                 "logout": "Wyloguj się",
                 "manage_gallery_icon": "Zarządzaj obrazkami/ikonami/emoji",

--- a/html/src/localization/pt/en.json
+++ b/html/src/localization/pt/en.json
@@ -149,7 +149,7 @@
                 "two_factor": "Autenticação de Dois Fatores (2FA)",
                 "two_factor_enabled": "Ativado",
                 "two_factor_disabled": "Desativado",
-                "v_bucks": "V-Bucks",
+                "vrchat_credits": "Créditos do VRChat",
                 "refresh": "Clique para atualizar",
                 "logout": "Encerrar Sessão",
                 "manage_gallery_icon": "Gerenciar Fotos/Icones/Emojis",

--- a/html/src/localization/ru/en.json
+++ b/html/src/localization/ru/en.json
@@ -156,7 +156,7 @@
                 "two_factor": "Двухфакторная аутентификация (2FA)",
                 "two_factor_enabled": "Включена",
                 "two_factor_disabled": "Выключено",
-                "v_bucks": "VRChat Кредиты",
+                "vrchat_credits": "VRChat Кредиты",
                 "refresh": "Нажмите, чтобы обновить",
                 "logout": "Выйти",
                 "manage_gallery_icon": "Управление Фото/Иконки/Эмодзи",

--- a/html/src/localization/vi/en.json
+++ b/html/src/localization/vi/en.json
@@ -149,7 +149,7 @@
                 "two_factor": "Xác thực 2 bưới (2FA)",
                 "two_factor_enabled": "Bật",
                 "two_factor_disabled": "Tắt",
-                "v_bucks": "V-Bucks",
+                "vrchat_credits": "Tín dụng VRChat",
                 "refresh": "Bấm để làm mới",
                 "logout": "Đăng xuất",
                 "manage_gallery_icon": "Quản lý Ảnh/Icons/Emojis",

--- a/html/src/localization/zh-CN/en.json
+++ b/html/src/localization/zh-CN/en.json
@@ -157,7 +157,7 @@
                 "two_factor": "双重认证 (2FA)",
                 "two_factor_enabled": "已启用",
                 "two_factor_disabled": "已停用",
-                "v_bucks": "拥有的 VRChat 点数",
+                "vrchat_credits": "拥有的 VRChat 点数",
                 "refresh": "点击以刷新",
                 "logout": "退出登录",
                 "manage_gallery_icon": "管理上传的图片/图标/表情",

--- a/html/src/localization/zh-TW/en.json
+++ b/html/src/localization/zh-TW/en.json
@@ -157,7 +157,7 @@
                 "two_factor": "雙重認證 (2FA)",
                 "two_factor_enabled": "已啟用",
                 "two_factor_disabled": "已停用",
-                "v_bucks": "V-Bucks",
+                "vrchat_credits": "擁有的 VRChat 點數",
                 "refresh": "點擊以重新整理",
                 "logout": "登出",
                 "manage_gallery_icon": "管理相簿 / 圖示 / 表情符號",

--- a/html/src/mixins/tabs/profile.pug
+++ b/html/src/mixins/tabs/profile.pug
@@ -17,10 +17,10 @@ mixin profileTab()
                     .detail
                         span.name {{ $t('view.profile.profile.two_factor') }}
                         span.extra {{ API.currentUser.twoFactorAuthEnabled ? $t('view.profile.profile.two_factor_enabled') : $t('view.profile.profile.two_factor_disabled') }}
-                .x-friend-item(@click="getVbucks()")
+                .x-friend-item(@click="getVRChatCredits()")
                     .detail
-                        span.name {{ $t('view.profile.profile.v_bucks') }}
-                        span.extra {{ API.currentUser.$vbucks ?? $t('view.profile.profile.refresh') }}
+                        span.name {{ $t('view.profile.profile.vrchat_credits') }}
+                        span.extra {{ API.currentUser.$vrchatcredits ?? $t('view.profile.profile.refresh') }}
             div(style="margin-top:10px")
                 el-button(size="small" type="danger" plain icon="el-icon-switch-button" @click="logout()" style="margin-left:0;margin-right:5px;margin-top:10px;") {{ $t('view.profile.profile.logout') }}
                 el-button(size="small" icon="el-icon-picture-outline" @click="showGalleryDialog()" style="margin-left:0;margin-right:5px;margin-top:10px") {{ $t('view.profile.profile.manage_gallery_icon') }}


### PR DESCRIPTION
I've corrected misnamed terminology for the VRChat currency across the codebase. VRChat's currency is called "[VRChat Credits](https://wiki.vrchat.com/wiki/Creator_Economy#VRChat_Credits)", not V-Bucks. [V-Bucks are a registered trademark of Epic Games.](https://trademarks.justia.com/879/53/v-87953190.html)

These changes were applied both to user-facing UI as well as internal variable names.

I provided localization for languages that were using the English string "V-Bucks". Please feel free to criticize these -- I utilized a combination of GPT, DeepL, and Google Translate to come to and confirm a "best effort" conclusion.

Any localization that had existing translations that were determined to be derived from "VRChat Credits" (via aforementioned MTL services) were untouched.

A test build passed smoke tests without issue. @Natsumi-sama , thanks for correcting a dumb mistake I made!