### PR TITLE
fix: Bad path combining causing custom resources not to load

### DIFF
--- a/Dotnet/AppApi/Cef/AppApiVr.cs
+++ b/Dotnet/AppApi/Cef/AppApiVr.cs
@@ -75,7 +75,8 @@ namespace VRCX
         public string CustomVrScriptPath()
         {
             var output = string.Empty;
-            var filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VRCX\\customvr.js");
+            var filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VRCX",
+                "customvr.js");
             if (File.Exists(filePath))
                 output = filePath;
             return output;

--- a/Dotnet/AppApi/Common/AppApiCommon.cs
+++ b/Dotnet/AppApi/Common/AppApiCommon.cs
@@ -83,7 +83,8 @@ namespace VRCX
         public string CustomCssPath()
         {
             var output = string.Empty;
-            var filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VRCX\\custom.css");
+            var filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VRCX",
+                "custom.css");
             if (File.Exists(filePath))
                 output = filePath;
             return output;
@@ -92,7 +93,8 @@ namespace VRCX
         public string CustomScriptPath()
         {
             var output = string.Empty;
-            var filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VRCX\\custom.js");
+            var filePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VRCX",
+                "custom.js");
             if (File.Exists(filePath))
                 output = filePath;
             return output;


### PR DESCRIPTION
Mostly a Linux fix, `\\` causes the File.Exists() check for custom resources to fail, we should just be able to let .NET handle what the system wants for us.