### PR TITLE
Move libraryPath variable out of foreach

### DIFF
--- a/Dotnet/AppApi/Electron/Folders.cs
+++ b/Dotnet/AppApi/Electron/Folders.cs
@@ -49,10 +49,10 @@ namespace VRCX
         {
             if (!File.Exists(libraryFoldersVdfPath))
                 return null;
-            
+
+            string? libraryPath = null;
             foreach (var line in File.ReadLines(libraryFoldersVdfPath))
-            {
-                string? libraryPath = null;
+            {                
                 // Assumes line will be \t\t"path"\t\t"pathToLibrary"
                 if (line.Contains("\"path\""))
                 {


### PR DESCRIPTION
I moved the libraryPath variable out of the foreach loop because it would be assigned null every iteration even when we still need the previously saved value from it, resulting in an empty string and breaking the library folder resolution from the libraryfolders.vdf file

The path and the AppId are in different lines of the libraryfolders.vdf file