### PR TITLE
Get True Home Path from possible symbolic link (Important for Atomic Distros like Fedora Silverblue or Bazzite)

### DIFF
--- a/src-electron/main.js
+++ b/src-electron/main.js
@@ -284,6 +284,8 @@ async function installVRCXappImageLauncher() {
 */
 
 async function installVRCX() {
+    let homePath = getHomePath();
+    console.log('True Home path:', homePath);
     console.log('AppImage path:', appImagePath);
     if (!appImagePath) {
         console.error('AppImage path is not available!');
@@ -300,9 +302,9 @@ async function installVRCX() {
         appImageLauncherInstalled = true;
     }
     */
-
+    
     if (
-        appImagePath.startsWith(path.join(app.getPath('home'), 'Applications'))
+        appImagePath.startsWith(path.join(homePath, 'Applications'))
     ) {
         /*
         if (appImageLauncherInstalled) {
@@ -331,7 +333,7 @@ async function installVRCX() {
 
     if (
         process.env.APPIMAGE.startsWith(
-            path.join(app.getPath('home'), 'Applications')
+            path.join(homePath, 'Applications')
         ) &&
         path.basename(process.env.APPIMAGE) === 'VRCX.AppImage'
     ) {
@@ -340,7 +342,7 @@ async function installVRCX() {
         return;
     }
 
-    const targetPath = path.join(app.getPath('home'), 'Applications');
+    const targetPath = path.join(homePath, 'Applications');
     console.log('Target Path:', targetPath);
 
     // Create target directory if it doesn't exist
@@ -368,7 +370,7 @@ async function installVRCX() {
     const iconUrl =
         'https://raw.githubusercontent.com/vrcx-team/VRCX/master/VRCX.png';
     const iconPath = path.join(
-        app.getPath('home'),
+        homePath,
         '.local/share/icons/VRCX.png'
     );
     await downloadIcon(iconUrl, iconPath)
@@ -386,7 +388,7 @@ StartupWMClass=VRCX
 `;
 
             const desktopFilePath = path.join(
-                app.getPath('home'),
+                homePath,
                 '.local/share/applications/VRCX.desktop'
             );
             try {
@@ -443,6 +445,20 @@ function getVRCXPath() {
         return path.join(process.env.HOME, 'Library/Application Support/VRCX');
     }
     return '';
+}
+
+function getHomePath() {
+    let relativeHomePath = path.join(app.getPath('home'));
+    // console.log('Relative Home Path: ' + relativeHomePath);
+    try {
+        let absoluteHomePath = fs.realpathSync(relativeHomePath);
+        // console.log('readlink output: ' + absoluteHomePath);
+        return absoluteHomePath;        
+    }
+    catch (err) {
+        return relativeHomePath;
+    }
+    
 }
 
 function getVersion() {


### PR DESCRIPTION
By default Distributions based on Fedora Silverblue (like Bazzite) have home mounted under "/var/home/username". But the path for Home that can be retrieved through environment variables returns "/home/username". This confuses the install function for VRCX as when it checks the location of the AppImage it finds it under "/var/home/username/Applications/VRCX.AppImage" and not "/home/username/Applications/VRCX.AppImage".

The installation in this case would work on first run but on a second run it breaks

 I adjusted the code in the installVRCX() function to first get the actual Path of the users home directory and then use that going forward, I tested it on my local system and inside a distrobox (to test if it can deal with both, home under /var/home and under /home) and it worked in both cases, it should work on other distributions aswell that mount home under a weird path

![error message](https://github.com/user-attachments/assets/f43ec733-06ba-45a2-b468-026558ccd328)


It fixes this error