### PR TITLE
Improve friend list loading speed

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -5555,12 +5555,9 @@ console.log(`isLinux: ${LINUX}`);
         await $app.feedTableLookup();
         // eslint-disable-next-line require-atomic-updates
         $app.notificationTable.data = await database.getNotifications();
-        await this.refreshNotifications();
-        await $app.loadCurrentUserGroups(
-            args.json.id,
-            args.json?.presence?.groups
-        );
-        await $app.getCurrentUserGroups();
+        this.refreshNotifications();
+        $app.loadCurrentUserGroups(args.json.id, args.json?.presence?.groups);
+        $app.getCurrentUserGroups();
         try {
             if (
                 await configRepository.getBool(`friendLogInit_${args.json.id}`)

--- a/src/classes/groups.js
+++ b/src/classes/groups.js
@@ -2084,27 +2084,29 @@ export default class extends baseClass {
             }
 
             if (groups) {
-                for (var i = 0; i < groups.length; i++) {
-                    var groupId = groups[i];
-                    var groupRef = API.cachedGroups.get(groupId);
+                const promises = groups.map(async (groupId) => {
+                    const groupRef = API.cachedGroups.get(groupId);
+
                     if (
                         typeof groupRef !== 'undefined' &&
                         groupRef.myMember?.roleIds?.length > 0
                     ) {
-                        continue;
+                        return;
                     }
 
                     try {
-                        var args = await API.getGroup({
+                        const args = await API.getGroup({
                             groupId,
                             includeRoles: true
                         });
-                        var ref = API.applyGroup(args.json);
+                        const ref = API.applyGroup(args.json);
                         API.currentUserGroups.set(groupId, ref);
                     } catch (err) {
                         console.error(err);
                     }
-                }
+                });
+
+                await Promise.allSettled(promises);
             }
 
             this.currentUserGroupsInit = true;


### PR DESCRIPTION
1. This change improves the loading speed of the friend list when opening VRCX, making it show up much faster.

2. The speed at which the app loads the friend list is crucial for user experience. Currently, the loading time feels slow.

3. In the LOGIN event, the friend list loading process was blocking other operations.

   - I found that three methods `refreshNotifications`, `loadCurrentUserGroups`, and `getCurrentUserGroups` were slow, with `loadCurrentUserGroups` taking more than 2s.

   - These methods seemed not necessary for the initial screen rendering and can be executed later, so I made them run asynchronously by removing the await. 
   - I also checked the logic within `loadCurrentUserGroups` and decided that the async rewriting wasn't necessary, but I left it as is since it didn't seem to impact the following steps.
      - If don't change the await in `app.js`, just by rewriting `loadCurrentUserGroups`, can still reduce the loading time by over 1s.

4. I tested the changes, and the time from API.$on('LOGIN') _(Line 5536)_ to just before `getFriendLog` _(Line 5565)_ was reduced from around 3.5s to 0.6s in dev mode, almost instantly.

5. I wasn't able to fully analyze all related logic, as it's quite extensive, but the current changes don't seem to cause issues. More testing may be needed.