### PR TITLE
Display All Friends When Grouped by Instance

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -23301,24 +23301,29 @@ console.log(`isLinux: ${LINUX}`);
 
     //  - SidebarGroupByInstance
 
-    $app.methods.handleSwitchGroupByInstance = async function () {
-        this.isSidebarGroupByInstance = !this.isSidebarGroupByInstance;
-        await configRepository.setBool(
-            'VRCX_sidebarGroupByInstance',
-            this.isSidebarGroupByInstance
-        );
-    };
-
     $app.data.isSidebarGroupByInstance = await configRepository.getBool(
         'VRCX_sidebarGroupByInstance',
         true
     );
 
-    $app.methods.handleSwitchGroupByInstance = function () {
+    $app.methods.toggleGroupByInstance = function () {
         this.isSidebarGroupByInstance = !this.isSidebarGroupByInstance;
         configRepository.setBool(
             'VRCX_sidebarGroupByInstance',
             this.isSidebarGroupByInstance
+        );
+    };
+
+    $app.data.isHideFriendsInSameInstance = await configRepository.getBool(
+        'VRCX_hideFriendsInSameInstance',
+        false
+    );
+
+    $app.methods.toggleHideFriendsInSameInstance = function () {
+        this.isHideFriendsInSameInstance = !this.isHideFriendsInSameInstance;
+        configRepository.setBool(
+            'VRCX_hideFriendsInSameInstance',
+            this.isHideFriendsInSameInstance
         );
     };
 
@@ -23366,7 +23371,10 @@ console.log(`isLinux: ${LINUX}`);
     };
 
     $app.computed.onlineFriendsByGroupStatus = function () {
-        if (!this.isSidebarGroupByInstance) {
+        if (
+            !this.isSidebarGroupByInstance ||
+            (this.isSidebarGroupByInstance && !this.isHideFriendsInSameInstance)
+        ) {
             return this.onlineFriends;
         }
 
@@ -23382,7 +23390,10 @@ console.log(`isLinux: ${LINUX}`);
     };
 
     $app.computed.vipFriendsByGroupStatus = function () {
-        if (!this.isSidebarGroupByInstance) {
+        if (
+            !this.isSidebarGroupByInstance ||
+            (this.isSidebarGroupByInstance && !this.isHideFriendsInSameInstance)
+        ) {
             return this.vipFriends;
         }
 

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -386,6 +386,8 @@
                     "width": "Width",
                     "group_by_instance": "Group by Instance",
                     "group_by_instance_tooltip": "Enabling this will group friends by instance when there is more than one friend in the same instance.",
+                    "hide_friends_in_same_instance": "Hide Friends in Same Instance",
+                    "hide_friends_in_same_instance_tooltip": "Hide Friends from Friend List When They Are in the Same Instance.",
                     "split_favorite_friends": "Split Favorite Friends",
                     "split_favorite_friends_tooltip": "Separate favorite friends into their individual groups."
                 },
@@ -635,7 +637,7 @@
         "friends": "Friends",
         "me": "ME",
         "favorite": "FAVORITES",
-        "same_instance": "Same Instance",
+        "same_instance": "SAME INSTANCE",
         "online": "ONLINE",
         "active": "ACTIVE",
         "offline": "OFFLINE",

--- a/src/mixins/tabs/settings.pug
+++ b/src/mixins/tabs/settings.pug
@@ -414,18 +414,22 @@ mixin settingsTab
                             :min='200'
                             :max='500'
                             style='display: inline-block; width: 300px')
-                    .options-container-item
-                        simple-switch(
-                            :label='$t("view.settings.appearance.side_panel.group_by_instance")'
-                            :value='isSidebarGroupByInstance'
-                            @change='handleSwitchGroupByInstance'
-                            :tooltip='$t("view.settings.appearance.side_panel.group_by_instance_tooltip")')
-                    .options-container-item
-                        simple-switch(
-                            :label='$t("view.settings.appearance.side_panel.split_favorite_friends")'
-                            :value='isSidebarDivideByFriendGroup'
-                            @change='handleSwitchDivideByFriendGroup'
-                            :tooltip='$t("view.settings.appearance.side_panel.split_favorite_friends_tooltip")')
+                    simple-switch(
+                        :label='$t("view.settings.appearance.side_panel.group_by_instance")'
+                        :value='isSidebarGroupByInstance'
+                        @change='toggleGroupByInstance'
+                        :tooltip='$t("view.settings.appearance.side_panel.group_by_instance_tooltip")')
+                    simple-switch(
+                        v-if='isSidebarGroupByInstance'
+                        :label='$t("view.settings.appearance.side_panel.hide_friends_in_same_instance")'
+                        :value='isHideFriendsInSameInstance'
+                        @change='toggleHideFriendsInSameInstance'
+                        :tooltip='$t("view.settings.appearance.side_panel.hide_friends_in_same_instance_tooltip")')
+                    simple-switch(
+                        :label='$t("view.settings.appearance.side_panel.split_favorite_friends")'
+                        :value='isSidebarDivideByFriendGroup'
+                        @change='handleSwitchDivideByFriendGroup'
+                        :tooltip='$t("view.settings.appearance.side_panel.split_favorite_friends_tooltip")')
                 //- Appearance | User Dialog
                 .options-container
                     span.header {{ $t('view.settings.appearance.user_dialog.header') }}


### PR DESCRIPTION
- Display all friends when the **Group by instance** option is on.
  - This feature is enabled by default.
  - Add a toggle option to hide friends from the friend list when they are in the same instance.
    - This toggle option only displays when the **Group by instance** option is on

- Convert friend list column **Same Instance** to uppercase.