### PR TITLE
Linux: Fix AssetBundleManager.GetAssetVersion only working sometimes

### DIFF
--- a/Dotnet/AssetBundleManager.cs
+++ b/Dotnet/AssetBundleManager.cs
@@ -54,7 +54,7 @@ namespace VRCX
                 versionHex += b.ToString("X2");
             }
 
-            return versionHex.PadLeft(32, '0');
+            return versionHex.PadLeft(32, '0').ToLowerInvariant();
         }
 
         public (int, int) ReverseHexToDecimal(string hexString)


### PR DESCRIPTION
On Linux, the cache version directories are lowercase but `versionHex` here is completely uppercase. This would be fine on case insensitive systems but ext4 isn't, hence it will fail the existence check later on in `CheckVRChatCache`.

The annoying part is that if the version hexadecimal does not create letters, the check can work as intended :))))

You don't know how much """"""fun""""""" this was to debug this without a project.

Untested on Windows so please check