### PR TITLE
Linux: Port ImageSaving to ImageSharp to fix Linux image uploads

### DIFF
--- a/Dotnet/VRCX-Cef.csproj
+++ b/Dotnet/VRCX-Cef.csproj
@@ -92,6 +92,8 @@
     <PackageReference Include="NLog" Version="5.4.0" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.5" />
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.119" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />

--- a/Dotnet/VRCX-Electron.csproj
+++ b/Dotnet/VRCX-Electron.csproj
@@ -100,6 +100,8 @@
     <PackageReference Include="NLog" Version="5.4.0" />
     <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.5" />
     <PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.119" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />


### PR DESCRIPTION
I think that the upload code should be sane-ish enough, so I'm throwing this in a PR to get it reviewed / tweaked. 
This ports ImageSaving.cs somewhat directly to ImageSharp, which fixes the exception when image uploading tries to call `System.Drawing` on non-Windows.

I don't really like the licensing situation but beggars can't be choosers I guess

***I'm unable to test the print code, I need someone else to verify that still works as intended for me.***