### PR TITLE
fix: Make userDialog group icon background transparent

### DIFF
--- a/src/mixins/dialogs/groupDialog.pug
+++ b/src/mixins/dialogs/groupDialog.pug
@@ -466,10 +466,8 @@ mixin groupDialog
                                                         br
                                                         span {{ $t('dialog.group.info.role_permissions') }}
                                                         br
-                                                        template(
-                                                            v-for='(permission, pIndex) in role.permissions'
-                                                            :key='pIndex')
-                                                            span {{ permission }}
+                                                        template(v-for='(permission, pIndex) in role.permissions')
+                                                            span(:key='pIndex') {{ permission }}
                                                             br
                                                     span {{ role.name }}{{ rIndex < groupDialog.memberRoles.length - 1 ? ', ' : '' }}
                 el-tab-pane(:label='$t("dialog.group.posts.header")')

--- a/src/mixins/dialogs/userDialog.pug
+++ b/src/mixins/dialogs/userDialog.pug
@@ -154,8 +154,8 @@ mixin userDialog
                                 :style='{ color: userDialog.ref.$customTagColour, "border-color": userDialog.ref.$customTagColour }'
                                 style='margin-right: 5px; margin-top: 5px')
                             br
-                            template(v-for='badge in userDialog.ref.badges' :key='badge.badgeId')
-                                el-tooltip(placement='top')
+                            template(v-for='badge in userDialog.ref.badges')
+                                el-tooltip(placement='top' :key='badge.badgeId')
                                     template(#content)
                                         span {{ badge.badgeName }}
                                         span(v-if='badge.hidden') &nbsp;(Hidden)
@@ -324,7 +324,7 @@ mixin userDialog
                                             divided
                                             style='color: #f56c6c') {{ $t('dialog.user.actions.unfriend') }}
             el-tabs(ref='userDialogTabs' @tab-click='userDialogTabClick')
-                el-tab-pane(:label='$t("dialog.user.info.header")' lazy)
+                el-tab-pane(:label='$t("dialog.user.info.header")')
                     template(v-if='isFriendOnline(userDialog.friend) || API.currentUser.id === userDialog.id')
                         div(
                             v-if='userDialog.ref.location'
@@ -453,7 +453,8 @@ mixin userDialog
                                                 slot='reference'
                                                 v-loading='userDialog.isRepresentedGroupLoading'
                                                 :src='userDialog.representedGroup.iconUrl'
-                                                style='flex: none; width: 60px; height: 60px; border-radius: 4px; object-fit: cover; background: #f5f7fa'
+                                                style='flex: none; width: 60px; height: 60px; border-radius: 4px; object-fit: cover'
+                                                :style='{ background: userDialog.isRepresentedGroupLoading ? "#f5f7fa" : "" }'
                                                 @load='userDialog.isRepresentedGroupLoading = false')
                                                 div(slot='error')
                                             img.x-link(
@@ -916,8 +917,8 @@ mixin userDialog
                         ref='favoriteWorlds'
                         v-loading='userDialog.isFavoriteWorldsLoading'
                         style='margin-top: 10px')
-                        template(v-for='(list, index) in userFavoriteWorlds' :key='index')
-                            el-tab-pane(lazy)
+                        template(v-for='(list, index) in userFavoriteWorlds')
+                            el-tab-pane(:key='index' lazy)
                                 span(slot='label')
                                     span(v-text='list[0]' style='font-weight: bold; font-size: 16px')
                                     i.x-status-icon(

--- a/src/mixins/tabs/favorites.pug
+++ b/src/mixins/tabs/favorites.pug
@@ -89,9 +89,9 @@ mixin favoritesTab
                                                 el-dropdown-menu(#default='dropdown')
                                                     template(
                                                         v-if='groupAPI.name !== group.name'
-                                                        v-for='groupAPI in API.favoriteFriendGroups'
-                                                        :key='groupAPI.name')
+                                                        v-for='groupAPI in API.favoriteFriendGroups')
                                                         el-dropdown-item(
+                                                            :key='groupAPI.name'
                                                             style='display: block; margin: 10px 0'
                                                             @click.native='moveFavorite(favorite.ref, groupAPI, "friend")'
                                                             :disabled='groupAPI.count >= groupAPI.capacity') {{ groupAPI.displayName }} ({{ groupAPI.count }} / {{ groupAPI.capacity }})
@@ -245,9 +245,9 @@ mixin favoritesTab
                                                 el-dropdown-menu(#default='dropdown')
                                                     template(
                                                         v-if='groupAPI.name !== group.name'
-                                                        v-for='groupAPI in API.favoriteWorldGroups'
-                                                        :key='groupAPI.name')
+                                                        v-for='groupAPI in API.favoriteWorldGroups')
                                                         el-dropdown-item(
+                                                            :key='groupAPI.name'
                                                             style='display: block; margin: 10px 0'
                                                             @click.native='moveFavorite(favorite.ref, groupAPI, "world")'
                                                             :disabled='groupAPI.count >= groupAPI.capacity') {{ groupAPI.displayName }} ({{ groupAPI.count }} / {{ groupAPI.capacity }})
@@ -378,10 +378,9 @@ mixin favoritesTab
                                                     :disabled='hideTooltips')
                                                     el-button(type='default' icon='el-icon-back' size='mini' circle)
                                                 el-dropdown-menu(#default='dropdown')
-                                                    template(
-                                                        v-for='groupAPI in API.favoriteWorldGroups'
-                                                        :key='groupAPI.name')
+                                                    template(v-for='groupAPI in API.favoriteWorldGroups')
                                                         el-dropdown-item(
+                                                            :key='groupAPI.name'
                                                             style='display: block; margin: 10px 0'
                                                             @click.native='addFavoriteWorld(favorite, groupAPI, true)'
                                                             :disabled='groupAPI.count >= groupAPI.capacity') {{ groupAPI.displayName }} ({{ groupAPI.count }} / {{ groupAPI.capacity }})
@@ -521,9 +520,9 @@ mixin favoritesTab
                                                 el-dropdown-menu(#default='dropdown')
                                                     template(
                                                         v-if='groupAPI.name !== group.name'
-                                                        v-for='groupAPI in API.favoriteAvatarGroups'
-                                                        :key='groupAPI.name')
+                                                        v-for='groupAPI in API.favoriteAvatarGroups')
                                                         el-dropdown-item(
+                                                            :key='groupAPI.name'
                                                             style='display: block; margin: 10px 0'
                                                             @click.native='moveFavorite(favorite.ref, groupAPI, "avatar")'
                                                             :disabled='groupAPI.count >= groupAPI.capacity') {{ groupAPI.displayName }} ({{ groupAPI.count }} / {{ groupAPI.capacity }})
@@ -709,10 +708,9 @@ mixin favoritesTab
                                                     :disabled='hideTooltips')
                                                     el-button(type='default' icon='el-icon-back' size='mini' circle)
                                                 el-dropdown-menu(#default='dropdown')
-                                                    template(
-                                                        v-for='groupAPI in API.favoriteAvatarGroups'
-                                                        :key='groupAPI.name')
+                                                    template(v-for='groupAPI in API.favoriteAvatarGroups')
                                                         el-dropdown-item(
+                                                            :key='groupAPI.name'
                                                             style='display: block; margin: 10px 0'
                                                             @click.native='addFavoriteAvatar(favorite, groupAPI, true)'
                                                             :disabled='groupAPI.count >= groupAPI.capacity') {{ groupAPI.displayName }} ({{ groupAPI.count }} / {{ groupAPI.capacity }})

--- a/src/mixins/tabs/playerList.pug
+++ b/src/mixins/tabs/playerList.pug
@@ -80,17 +80,13 @@ mixin playerListTab
                             effect='plain'
                             size='mini'
                             style='margin-right: 5px')
-                            span(v-text='currentInstanceWorld.cacheSize')
-                            |
-                            | {{ $t('dialog.world.tags.cache') }}
+                            span(v-text='currentInstanceWorld.cacheSize') {{ $t('dialog.world.tags.cache') }}
                         div(style='margin-top: 5px')
                             location-world(
                                 :locationobject='currentInstanceLocation'
                                 :currentuserid='API.currentUser.id')
-                            span(v-if='lastLocation.playerList.size > 0' style='margin-left: 5px')
-                                | {{ lastLocation.playerList.size }}
-                                |                                     #[template(v-if='lastLocation.friendList.size > 0') ({{ lastLocation.friendList.size }})]
-                            | &nbsp;&horbar; #[timer(v-if='lastLocation.date' :epoch='lastLocation.date')]
+                            span(v-if='lastLocation.playerList.size > 0' style='margin: 0 5px') {{ lastLocation.playerList.size }} {{ `(${lastLocation.friendList.size})` }}
+                            timer(v-if='lastLocation.date' :epoch='lastLocation.date')
                     div(style='margin-top: 5px')
                         span(
                             v-show='currentInstanceWorld.ref.name !== currentInstanceWorld.ref.description'
@@ -173,9 +169,7 @@ mixin playerListTab
                                         span.avatar-info-public(v-if='scope.row.avatar.releaseStatus === "public"') {{ $t('dialog.avatar.labels.public') }}
                                         span.avatar-info-own(v-else-if='scope.row.avatar.releaseStatus === "private"') {{ $t('dialog.avatar.labels.private') }}
                                         template(
-                                            v-if='scope.row.avatar.description && scope.row.avatar.name !== scope.row.avatar.description')
-                                            |
-                                            | - {{ scope.row.avatar.description }}
+                                            v-if='scope.row.avatar.description && scope.row.avatar.name !== scope.row.avatar.description') {{ scope.row.avatar.description }}
                                     template(v-else-if='scope.row.type === "ChangeStatus"')
                                         template(v-if='scope.row.status !== scope.row.previousStatus')
                                             el-tooltip(placement='top')
@@ -285,9 +279,7 @@ mixin playerListTab
                                         span.avatar-info-public(v-if='scope.row.avatar.releaseStatus === "public"') {{ $t('dialog.avatar.labels.public') }}
                                         span.avatar-info-own(v-else-if='scope.row.avatar.releaseStatus === "private"') {{ $t('dialog.avatar.labels.private') }}
                                         template(
-                                            v-if='scope.row.avatar.description && scope.row.avatar.name !== scope.row.avatar.description')
-                                            |
-                                            | - {{ scope.row.avatar.description }}
+                                            v-if='scope.row.avatar.description && scope.row.avatar.name !== scope.row.avatar.description') {{ scope.row.avatar.description }}
                                     template(v-else-if='scope.row.type === "ChangeStatus"')
                                         template(v-if='scope.row.status !== scope.row.previousStatus')
                                             el-tooltip(placement='top')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,13 +115,20 @@ module.exports = {
                     to: './images/'
                 }
             ]
-        })
+        }),
+        new webpack.ProgressPlugin({})
     ],
     optimization: {
         minimizer: [
             new TerserPlugin({
-                extractComments: false
+                extractComments: false,
+                terserOptions: {
+                    ecma: 2020
+                }
             })
         ]
+    },
+    watchOptions: {
+        ignored: /node_modules/
     }
 };


### PR DESCRIPTION
1. userDialog group icon

   - Fixed the problem that the background of transparent group icon cannot be displayed transparently.

2. Vue error

   - Fixed all the current error reports for vue in console, they were so annoying to refresh and debug, so I fixed them first.

3. webpack.config.js

   - In addition webpack config add `terserOptions.ecma = 2020` standard, match `target = es2020`

   - also add a process progress bar `webpack.ProgressPlugin`, add visualization.

   - And the `watchOptions.ignored` ignores `/node_modules/`