### PR TITLE
Fix DirectoryNotFoundException in ImageSaving.cs:CropAllPrints

### DIFF
--- a/Dotnet/AppApi/Common/ImageSaving.cs
+++ b/Dotnet/AppApi/Common/ImageSaving.cs
@@ -177,6 +177,11 @@ namespace VRCX
         public async Task CropAllPrints(string ugcFolderPath)
         {
             var folder = Path.Join(GetUGCPhotoLocation(ugcFolderPath), "Prints");
+
+            if (!Directory.Exists(folder))
+            {
+                Directory.CreateDirectory(folder);
+            }
             var files = Directory.GetFiles(folder, "*.png", SearchOption.AllDirectories);
             foreach (var file in files)
             {

--- a/Dotnet/AppApi/Common/ImageSaving.cs
+++ b/Dotnet/AppApi/Common/ImageSaving.cs
@@ -180,7 +180,7 @@ namespace VRCX
 
             if (!Directory.Exists(folder))
             {
-                Directory.CreateDirectory(folder);
+                return;
             }
             var files = Directory.GetFiles(folder, "*.png", SearchOption.AllDirectories);
             foreach (var file in files)


### PR DESCRIPTION
Fixes a DirectoryNotFoundException when the path "Prints" doesn't exist