### PR TITLE
Merge multiple joining of the same player into a single series in the instance activity details chart

### DIFF
--- a/src/components/charts/InstanceActivityDetail.vue
+++ b/src/components/charts/InstanceActivityDetail.vue
@@ -125,10 +125,6 @@
 
                 setTimeout(() => {
                     this.isLoading = false;
-                    this.echartsInstance.dispatchAction({
-                        type: 'highlight',
-                        seriesIndex: 3 //  对于 seriesLayoutBy: 'row'，seriesIndex 对应行索引
-                    });
                 }, 200);
             },
             handleClickYAxisLabel(params) {

--- a/src/components/charts/InstanceActivityDetail.vue
+++ b/src/components/charts/InstanceActivityDetail.vue
@@ -48,6 +48,7 @@
             return {
                 isLoading: true,
                 echartsInstance: null,
+                usersFirstActivity: null,
                 resizeObserver: null
             };
         },
@@ -128,7 +129,7 @@
                 }, 200);
             },
             handleClickYAxisLabel(params) {
-                const userData = this.activityDetailData[params.dataIndex];
+                const userData = this.usersFirstActivity[params.dataIndex];
                 if (userData?.user_id) {
                     this.showUserDialog(userData.user_id);
                 }
@@ -153,6 +154,7 @@
                     const element = { offset: offset, time: entry.time, tail: tail, entry: entry };
                     elements.push(element);
                 }
+                this.usersFirstActivity = uniqueUserEntries;
 
                 const generateSeries = () => {
                     const maxEntryCount = Math.max(...Array.from(userGroupedEntries.values()).map((entries) => entries.length));
@@ -227,18 +229,19 @@
                 const getTooltip = (params) => {
                     const activityDetailData = this.activityDetailData;
                     const param = params;
+                    const userData = uniqueUserEntries[param.dataIndex];
                     const isTimeSeries = params.seriesIndex % 2 === 1;
                     if (!isTimeSeries) {
                         return '';
                     }
                     const targetEntryIndex = Math.floor(params.seriesIndex / 2);
 
-                    if (!activityDetailData || !activityDetailData[param.dataIndex]) {
+                    if (!activityDetailData || !userData) {
                         return '';
                     }
 
                     // first, find the user's entries, then get the focused entry
-                    const instanceData = userGroupedEntries.get(activityDetailData[param.dataIndex].user_id)[targetEntryIndex].entry;
+                    const instanceData = userGroupedEntries.get(userData.user_id)[targetEntryIndex].entry;
 
                     const format = this.dtHour12 ? 'hh:mm:ss A' : 'HH:mm:ss';
                     const formattedLeftDateTime = dayjs(instanceData.leaveTime).format(format);


### PR DESCRIPTION
## Overview
This PR merges the activities of the players who joined the same instance multiple times into a single series in the instance activity details chart.
This reduces the number of rows, even if some players rejoin the instance.

## Changes

This update processes the activities by the following steps:

* Grouping activities by user ID
* Converting the grouped activities into chart series
  * Generating multiple (more than two) series if a player rejoins the instance (typically, a series consists of two components: a placeholder and time)

This also includes the following changes:

* Show the tooltip when hovering over the each element in the chart.

## Screenshots

### Before

* Players who rejoined the instance are displayed in multiple rows (highlighted with a pink box).

![image](https://github.com/user-attachments/assets/5cbf28aa-2878-4e72-81e8-2919a78b95c0)


### After

* Players who rejoined the instance are displayed in a single row (highlighted with a pink box).

![image](https://github.com/user-attachments/assets/2ebc591f-4156-4a03-b2e0-1dc2b6859663)


## Remarks
I noticed that the activity chart is being improved in PR vrcx-team#1144.
Once PR vrcx-team#1144 is merged, the following updates will be required in this PR:
* [x] Resolving conflicts in this PR
* [x] Adjusting the `barWidth` parameter in the instance activity details chart.

Please let me know if you have any questions or suggestions!