### PR TITLE
perf: Reduce image load size by adjusting resolution

### DIFF
--- a/src/components/charts/InstanceActivity.vue
+++ b/src/components/charts/InstanceActivity.vue
@@ -164,7 +164,7 @@
                 );
             },
             isNextDayBtnDisabled() {
-                return dayjs(this.selectedDate).isSame(this.allDateOfActivityArray[0], 'day');
+                return dayjs(this.selectedDate).isSameOrAfter(this.allDateOfActivityArray[0], 'day');
             },
             isPrevDayBtnDisabled() {
                 return dayjs(this.selectedDate).isSame(

--- a/src/components/favorites/FavoritesAvatarItem.vue
+++ b/src/components/favorites/FavoritesAvatarItem.vue
@@ -3,7 +3,7 @@
         <div class="x-friend-item">
             <template v-if="isLocalFavorite ? favorite.name : favorite.ref">
                 <div class="avatar">
-                    <img v-lazy="localFavFakeRef.thumbnailImageUrl" />
+                    <img v-lazy="smallThumbnail" />
                 </div>
                 <div class="detail">
                     <span class="name" v-text="localFavFakeRef.name"></span>
@@ -158,9 +158,14 @@
                 // local favorite no "ref" property
                 return this.isLocalFavorite ? this.favorite : this.favorite.ref;
             },
-
             tooltipContent() {
                 return $t(this.isLocalFavorite ? 'view.favorite.copy_tooltip' : 'view.favorite.move_tooltip');
+            },
+            smallThumbnail() {
+                return (
+                    this.localFavFakeRef.thumbnailImageUrl.replace('256', '64') ||
+                    this.localFavFakeRef.thumbnailImageUrl
+                );
             }
         },
         methods: {

--- a/src/components/favorites/FavoritesAvatarLocalHistoryItem.vue
+++ b/src/components/favorites/FavoritesAvatarLocalHistoryItem.vue
@@ -2,7 +2,7 @@
     <div @click="$emit('click')">
         <div class="x-friend-item">
             <div class="avatar">
-                <img v-lazy="favorite.thumbnailImageUrl" />
+                <img v-lazy="smallThumbnail" />
             </div>
             <div class="detail">
                 <span class="name" v-text="favorite.name"></span>
@@ -53,6 +53,11 @@
                 required: true
             },
             hideTooltips: Boolean
+        },
+        computed: {
+            smallThumbnail() {
+                return this.favorite.thumbnailImageUrl.replace('256', '64') || this.favorite.thumbnailImageUrl;
+            }
         },
         methods: {
             selectAvatarWithConfirmation() {

--- a/src/components/favorites/FavoritesFriendItem.vue
+++ b/src/components/favorites/FavoritesFriendItem.vue
@@ -3,7 +3,7 @@
         <div class="x-friend-item">
             <template v-if="favorite.ref">
                 <div class="avatar" :class="userStatusClass(favorite.ref)">
-                    <img v-lazy="userImage(favorite.ref)" />
+                    <img v-lazy="userImage(favorite.ref, true)" />
                 </div>
                 <div class="detail">
                     <span

--- a/src/components/favorites/FavoritesWorldItem.vue
+++ b/src/components/favorites/FavoritesWorldItem.vue
@@ -3,7 +3,7 @@
         <div class="x-friend-item">
             <template v-if="isLocalFavorite ? favorite.name : favorite.ref">
                 <div class="avatar">
-                    <img v-lazy="localFavFakeRef.thumbnailImageUrl" />
+                    <img v-lazy="smallThumbnail" />
                 </div>
                 <div class="detail">
                     <span class="name">{{ localFavFakeRef.name }}</span>
@@ -154,6 +154,12 @@
             localFavFakeRef() {
                 // local favorite no "ref" property
                 return this.isLocalFavorite ? this.favorite : this.favorite.ref;
+            },
+            smallThumbnail() {
+                return (
+                    this.localFavFakeRef.thumbnailImageUrl.replace('256', '64') ||
+                    this.localFavFakeRef.thumbnailImageUrl
+                );
             }
         },
         methods: {

--- a/src/mixins/dialogs/userDialog.pug
+++ b/src/mixins/dialogs/userDialog.pug
@@ -17,19 +17,19 @@ mixin userDialog
                     trigger='click')
                     img.x-link(
                         slot='reference'
-                        v-lazy='userDialog.ref.profilePicOverrideThumbnail || userDialog.ref.profilePicOverride'
+                        :src='userDialog.ref.profilePicOverrideThumbnail || userDialog.ref.profilePicOverride'
                         style='flex: none; height: 120px; width: 213.33px; border-radius: 12px; object-fit: cover')
                     img.x-link(
-                        :src='userDialog.ref.profilePicOverride'
+                        v-lazy='userDialog.ref.profilePicOverride'
                         style='height: 400px'
                         @click='showFullscreenImageDialog(userDialog.ref.profilePicOverride)')
                 el-popover(v-else placement='right' width='500px' trigger='click')
                     img.x-link(
                         slot='reference'
-                        v-lazy='userDialog.ref.currentAvatarThumbnailImageUrl'
+                        :src='userDialog.ref.currentAvatarThumbnailImageUrl'
                         style='flex: none; height: 120px; width: 160px; border-radius: 12px; object-fit: cover')
                     img.x-link(
-                        :src='userDialog.ref.currentAvatarImageUrl'
+                        v-lazy='userDialog.ref.currentAvatarImageUrl'
                         style='height: 500px'
                         @click='showFullscreenImageDialog(userDialog.ref.currentAvatarImageUrl)')
                 div(style='flex: 1; display: flex; align-items: center; margin-left: 15px')
@@ -166,7 +166,7 @@ mixin userDialog
                                             style='flex: none; height: 32px; width: 32px; border-radius: 3px; object-fit: cover; margin-top: 5px; margin-right: 5px'
                                             :class='{ "x-user-badge-hidden": badge.hidden }')
                                         img.x-link(
-                                            :src='badge.badgeImageUrl'
+                                            v-lazy='badge.badgeImageUrl'
                                             style='width: 300px'
                                             @click='showFullscreenImageDialog(badge.badgeImageUrl)')
                                         br
@@ -198,7 +198,7 @@ mixin userDialog
                                 :src='userImage(userDialog.ref, true, "256")'
                                 style='flex: none; width: 120px; height: 120px; border-radius: 12px; object-fit: cover')
                             img.x-link(
-                                :src='userDialog.ref.userIcon'
+                                v-lazy='userDialog.ref.userIcon'
                                 style='height: 500px'
                                 @click='showFullscreenImageDialog(userDialog.ref.userIcon)')
                     div(style='flex: none')
@@ -368,7 +368,7 @@ mixin userDialog
                                     @click='showUserDialog(userDialog.$location.userId)')
                                     template(v-if='userDialog.$location.user')
                                         .avatar(:class='userStatusClass(userDialog.$location.user)')
-                                            img(:src='userImage(userDialog.$location.user)')
+                                            img(:src='userImage(userDialog.$location.user, true)')
                                         .detail
                                             span.name(
                                                 v-text='userDialog.$location.user.displayName'
@@ -380,7 +380,7 @@ mixin userDialog
                                     :key='user.id'
                                     @click='showUserDialog(user.id)')
                                     .avatar(:class='userStatusClass(user)')
-                                        img(:src='userImage(user)')
+                                        img(:src='userImage(user, true)')
                                     .detail
                                         span.name(v-text='user.displayName' :style='{ color: user.$userColour }')
                                         span.extra(v-if='user.location === "traveling"')
@@ -454,7 +454,7 @@ mixin userDialog
                                             el-image.x-link(
                                                 slot='reference'
                                                 v-loading='userDialog.isRepresentedGroupLoading'
-                                                :src='userDialog.representedGroup.iconUrl'
+                                                :src='userDialog.representedGroup.$thumbnailUrl'
                                                 style='flex: none; width: 60px; height: 60px; border-radius: 4px; object-fit: cover'
                                                 :style='{ background: userDialog.isRepresentedGroupLoading ? "#f5f7fa" : "" }'
                                                 @load='userDialog.isRepresentedGroupLoading = false')

--- a/src/mixins/tabs/notifications.pug
+++ b/src/mixins/tabs/notifications.pug
@@ -87,7 +87,7 @@ mixin notificationsTab
                         el-popover(placement='right' width='500px' trigger='click')
                             img.x-link(
                                 slot='reference'
-                                v-lazy='scope.row.details.imageUrl'
+                                :src='getSmallThumbnailUrl(scope.row.details.imageUrl)'
                                 style='flex: none; height: 50px; border-radius: 4px')
                             img.x-link(
                                 v-lazy='scope.row.details.imageUrl'
@@ -97,7 +97,7 @@ mixin notificationsTab
                         el-popover(placement='right' width='500px' trigger='click')
                             img.x-link(
                                 slot='reference'
-                                v-lazy='scope.row.imageUrl'
+                                :src='getSmallThumbnailUrl(scope.row.imageUrl)'
                                 style='flex: none; height: 50px; border-radius: 4px')
                             img.x-link(
                                 v-lazy='scope.row.imageUrl'

--- a/src/mixins/tabs/search.pug
+++ b/src/mixins/tabs/search.pug
@@ -24,7 +24,7 @@ mixin searchTab
                     .x-friend-item(v-for='user in searchUserResults' :key='user.id' @click='showUserDialog(user.id)')
                         template
                             .avatar
-                                img(v-lazy='userImage(user)')
+                                img(v-lazy='userImage(user, true)')
                             .detail
                                 span.name(v-text='user.displayName')
                                 span.extra(
@@ -184,7 +184,7 @@ mixin searchTab
                         @click='showGroupDialog(group.id)')
                         template
                             .avatar
-                                img(v-lazy='group.iconUrl')
+                                img(v-lazy='getSmallThumbnailUrl(group.iconUrl)')
                             .detail
                                 span.name
                                     span(v-text='group.name')

--- a/src/views/dialogs/WorldDialog.vue
+++ b/src/views/dialogs/WorldDialog.vue
@@ -10,7 +10,7 @@
                 <el-popover placement="right" width="500px" trigger="click">
                     <img
                         slot="reference"
-                        v-lazy="worldDialog.ref.thumbnailImageUrl"
+                        :src="worldDialog.ref.thumbnailImageUrl"
                         class="x-link"
                         style="flex: none; width: 160px; height: 120px; border-radius: 12px" />
                     <img
@@ -392,7 +392,7 @@
                                     @click="showUserDialog(room.$location.userId)">
                                     <template v-if="room.$location.user">
                                         <div class="avatar" :class="userStatusClass(room.$location.user)">
-                                            <img v-lazy="userImage(room.$location.user)" />
+                                            <img v-lazy="userImage(room.$location.user, true)" />
                                         </div>
                                         <div class="detail">
                                             <span
@@ -412,7 +412,7 @@
                                     class="x-friend-item x-friend-item-border"
                                     @click="showUserDialog(user.id)">
                                     <div class="avatar" :class="userStatusClass(user)">
-                                        <img v-lazy="userImage(user)" />
+                                        <img v-lazy="userImage(user, true)" />
                                     </div>
                                     <div class="detail">
                                         <span


### PR DESCRIPTION
Improved version of #1179 

VRCX currently fetches images at unnecessarily high resolutions.
Adjusting the resolution to save network usage and improve loading speed also could help users with _poor network_ connections.

> In the prod environment works well, seems a bit uncertain in a dev environment

including

1. Friends list sidebar
   - User icon
2. User dialog
   - Avatar image
   - VRC+ icon
   - Group icon
   - Instance info
      - User icon
3. World dialog
   - Instance info
      - User icon
4. Favorites
   - User icon
   - World icon
   - Avatar icon
5. Search
   - User icon
   - Group icon
6. Notifications
   - Group icon
7. Friend list
   - User icon
8. Profile
   - Current user icon

fixed a Next Day button bug in the charts.