### PR TITLE
Detect WiVRn when looking for if VR is running

### DIFF
--- a/Dotnet/AppApi/Electron/GameHandler.cs
+++ b/Dotnet/AppApi/Electron/GameHandler.cs
@@ -50,7 +50,7 @@ namespace VRCX
             var processes = Process.GetProcesses();
             foreach (var process in processes)
             {
-                if (process.ProcessName == "vrmonitor" || process.ProcessName == "monado-service")
+                if (process.ProcessName == "vrmonitor" || process.ProcessName == "monado-service" || process.ProcessName.EndsWith("wivrn-server"))
                 {
                     isSteamVRRunning = true;
                     break;


### PR DESCRIPTION
Currently, VRCX determines if VR is running by looking for `vrmonitor` or `monado-server`, but WiVRn does not create a `monado-server` process. This fix will detect if the WiVRn server is running in addition to the previous two cases. Using `EndWith` is needed because, at least with Envision, you end up with process name like this: `/home/antiapple/.local/share/envision/prefixes/wivrn_default/bin/wivrn-server` This is my first PR in a while, and I am still relatively new to coding, so sorry if I messed anything up!