### PR TITLE
fix(dbmerger): merge reserved table, Exception due null time in avatar_history

### DIFF
--- a/DBMerger/Merger.cs
+++ b/DBMerger/Merger.cs
@@ -306,7 +306,7 @@ namespace DBMerger
                         return oldDateTime > newDateTime ? old : existing;
                     }
 
-                    var oldAvatarTime = old.Length >= 3 ? (int)old[2] : 0;
+                    var oldAvatarTime = old.Length >= 3 && old[2] != null ? (int)old[2] : 0;
                     var newAvatarTime = existing[2] != null ? (int)existing[2] : 0;
 
                     if (oldDateTime <= newDateTime)

--- a/DBMerger/Merger.cs
+++ b/DBMerger/Merger.cs
@@ -258,8 +258,8 @@ namespace DBMerger
         private void MergeUsers()
         {
             MergeTable(
-                table => userIDRegex.IsMatch(table)
-                    && !table.EndsWith("_avatar_history")
+                table => userIDRegex.IsMatch(table) 
+                    && !table.EndsWith("_avatar_history") 
                     && (table.EndsWith("_notifications")
                         || table.EndsWith("_moderation")),
                 [0],
@@ -316,7 +316,7 @@ namespace DBMerger
                     existing[2] = oldAvatarTime + newAvatarTime;
 
                     logger.Trace(
-                        "Combined avatar time: {} + {} = {}",
+                        "Combined avatar time: {} + {} = {}", 
                         oldAvatarTime, newAvatarTime, oldAvatarTime + newAvatarTime
                     );
 
@@ -544,8 +544,7 @@ namespace DBMerger
             int[] colIndicesToMatch,
             Func<object[], object[], object[]> rowTransformer,
             Action<string> finalizer = null
-        )
-        {
+        ) {
             for (int i = 0; i < unMergedTables.Count; i++)
             {
                 // Find table that we want to merge

--- a/DBMerger/Merger.cs
+++ b/DBMerger/Merger.cs
@@ -67,6 +67,12 @@ namespace DBMerger
                     continue;
                 }
                 unMergedTables.RemoveAt(i);
+                if (table.StartsWith("sqlite_"))
+                {
+                    // Skip sqlite reserved tables
+                    logger.Debug($"Skipping sqlite reserved table: {table}");
+                    continue;
+                }
                 i--;
 
                 // Then just tack them on
@@ -252,8 +258,8 @@ namespace DBMerger
         private void MergeUsers()
         {
             MergeTable(
-                table => userIDRegex.IsMatch(table) 
-                    && !table.EndsWith("_avatar_history") 
+                table => userIDRegex.IsMatch(table)
+                    && !table.EndsWith("_avatar_history")
                     && (table.EndsWith("_notifications")
                         || table.EndsWith("_moderation")),
                 [0],
@@ -301,7 +307,7 @@ namespace DBMerger
                     }
 
                     var oldAvatarTime = old.Length >= 3 ? (int)old[2] : 0;
-                    var newAvatarTime = (int)existing[2];
+                    var newAvatarTime = existing[2] != null ? (int)existing[2] : 0;
 
                     if (oldDateTime <= newDateTime)
                     {
@@ -310,7 +316,7 @@ namespace DBMerger
                     existing[2] = oldAvatarTime + newAvatarTime;
 
                     logger.Trace(
-                        "Combined avatar time: {} + {} = {}", 
+                        "Combined avatar time: {} + {} = {}",
                         oldAvatarTime, newAvatarTime, oldAvatarTime + newAvatarTime
                     );
 
@@ -538,7 +544,8 @@ namespace DBMerger
             int[] colIndicesToMatch,
             Func<object[], object[], object[]> rowTransformer,
             Action<string> finalizer = null
-        ) {
+        )
+        {
             for (int i = 0; i < unMergedTables.Count; i++)
             {
                 // Find table that we want to merge


### PR DESCRIPTION
Thank you for developing this application.
This pull request contains changes to DBMerger.

Fix the following two problems:

1. Avoiding errors by merging reserved SQLite tables “sqlite_sequence”
2. Avoid NullPointerException due to newAvatarTime being null

## 1. Avoiding errors by merging reserved SQLite tables “sqlite_sequence”

When performing a merge, it tries to merge the sqlite_sequence table and therefore tries to create a reserved SQLite table (prefixed “sqlite_”), resulting in the following error

```
SQLite.SQLiteException: object name reserved for internal use: sqlite_sequence
```

Exclude tables beginning with "sqlite_" from the merge tables.
Also, to avoid appearing in “Found unmerged table”, skip it after removing it from `unMergedTables`.

## 2. Avoid NullPointerException due to newAvatarTime being null

When merging the "avatar_history" table, there seems to be a case where the time column in the new DB is NULL.

```
System.NullReferenceException: 'Object reference not set to an instance of an object.'
```

In this case, a NullPointerException will be raised and an error will occur, so the case of NULL will be handled as time=0 to avoid the error.