### PR TITLE
Fixed Screenshot Metadata menu `Open Folder` button opening file on linux

### DIFF
--- a/Dotnet/AppApi/Electron/Folders.cs
+++ b/Dotnet/AppApi/Electron/Folders.cs
@@ -230,8 +230,7 @@ namespace VRCX
         
         public override void OpenFolderAndSelectItem(string path, bool isFolder = false)
         {
-            path = Path.GetFullPath(path);
-            path = path.Replace(Path.GetFileName(path), "");
+            path = Path.GetFullPath(path).Replace(Path.GetFileName(path), "");
             if (!File.Exists(path) && !Directory.Exists(path))
                 return;
             


### PR DESCRIPTION
Possibly jank solution to an issue where pressing `Open Folder` on a file in the Screenshot Metadata menu would make it open the screenshot instead of the containing folder, currently doesn't select the file as I am unsure on how to implement that but am actively looking into it.