### PR TITLE
Far less jank fix to previous pr

### DIFF
--- a/Dotnet/AppApi/Electron/Folders.cs
+++ b/Dotnet/AppApi/Electron/Folders.cs
@@ -230,7 +230,7 @@ namespace VRCX
         
         public override void OpenFolderAndSelectItem(string path, bool isFolder = false)
         {
-            path = Path.GetFullPath(path).Replace(Path.GetFileName(path), "");
+            path = Path.GetDirectoryName(path);
             if (!File.Exists(path) && !Directory.Exists(path))
                 return;
             


### PR DESCRIPTION
Instead of replacing the file name, Natsumi pointed out the existence of a previously missed `GetDirectoryName` function, far less jank now. Simply a fix to the Open Folder button opening the file instead.