### PR TITLE
Swap search and filter bar sizes to improve usability.

### DIFF
--- a/src/views/Feed/Feed.vue
+++ b/src/views/Feed/Feed.vue
@@ -1,26 +1,18 @@
 <template>
     <div v-show="menuActiveIndex === 'feed'" class="x-container feed">
         <div style="margin: 0 0 10px; display: flex; align-items: center">
-            <div style="flex: none; margin-right: 10px; display: flex; align-items: center">
-                <el-tooltip
-                    placement="bottom"
-                    :content="t('view.feed.favorites_only_tooltip')"
-                    :disabled="hideTooltips">
-                    <el-switch v-model="feedTable.vip" active-color="#13ce66" @change="feedTableLookup"></el-switch>
-                </el-tooltip>
-            </div>
             <el-input
                 v-model="feedTable.search"
                 :placeholder="t('view.feed.search_placeholder')"
                 clearable
-                style="flex: 1 1 60%; margin-right: 10px"
+                style="flex: 1 1 30%; margin-right: 10px"
                 @keyup.native.13="feedTableLookup"
                 @change="feedTableLookup"></el-input>
             <el-select
                 v-model="feedTable.filter"
                 multiple
                 clearable
-                style="flex: 1 1 40%"
+                style="flex: 1 1 70%; margin-right: 10px"
                 :placeholder="t('view.feed.filter_placeholder')"
                 @change="feedTableLookup">
                 <el-option
@@ -29,6 +21,14 @@
                     :label="t('view.feed.filters.' + type)"
                     :value="type"></el-option>
             </el-select>
+            <div style="flex: none; display: flex; align-items: center">
+                <el-tooltip
+                    placement="bottom"
+                    :content="t('view.feed.favorites_only_tooltip')"
+                    :disabled="hideTooltips">
+                    <el-switch v-model="feedTable.vip" active-color="#13ce66" @change="feedTableLookup"></el-switch>
+                </el-tooltip>
+            </div>
         </div>
 
         <data-tables v-loading="feedTable.loading" v-bind="feedTable" lazy>

--- a/src/views/Feed/Feed.vue
+++ b/src/views/Feed/Feed.vue
@@ -9,11 +9,18 @@
                     <el-switch v-model="feedTable.vip" active-color="#13ce66" @change="feedTableLookup"></el-switch>
                 </el-tooltip>
             </div>
+            <el-input
+                v-model="feedTable.search"
+                :placeholder="t('view.feed.search_placeholder')"
+                clearable
+                style="flex: 1 1 60%; margin-right: 10px"
+                @keyup.native.13="feedTableLookup"
+                @change="feedTableLookup"></el-input>
             <el-select
                 v-model="feedTable.filter"
                 multiple
                 clearable
-                style="flex: 1; height: 40px"
+                style="flex: 1 1 40%"
                 :placeholder="t('view.feed.filter_placeholder')"
                 @change="feedTableLookup">
                 <el-option
@@ -22,13 +29,6 @@
                     :label="t('view.feed.filters.' + type)"
                     :value="type"></el-option>
             </el-select>
-            <el-input
-                v-model="feedTable.search"
-                :placeholder="t('view.feed.search_placeholder')"
-                clearable
-                style="flex: none; width: 150px; margin: 0 10px"
-                @keyup.native.13="feedTableLookup"
-                @change="feedTableLookup"></el-input>
         </div>
 
         <data-tables v-loading="feedTable.loading" v-bind="feedTable" lazy>

--- a/src/views/FriendList/FriendList.vue
+++ b/src/views/FriendList/FriendList.vue
@@ -48,7 +48,27 @@
                 </div>
             </div>
 
-            <div style="margin: 10px 0 0 10px; display: flex; align-items: center">
+            <div style="margin: 10px 0px 10px 0px; display: flex; align-items: center">
+                <el-input
+                    :value="friendsListSearch"
+                    :placeholder="$t('view.friend_list.search_placeholder')"
+                    clearable
+                    style="flex: 1 1 30%; margin-right: 10px"
+                    @input="$emit('update:friends-list-search', $event)"
+                    @change="friendsListSearchChange"></el-input>
+                <el-select
+                    v-model="friendsListSearchFilters"
+                    multiple
+                    clearable
+                    style="flex: 1 1 70%; margin-right: 10px"
+                    :placeholder="$t('view.friend_list.filter_placeholder')"
+                    @change="friendsListSearchChange">
+                    <el-option
+                        v-for="type in ['Display Name', 'User Name', 'Rank', 'Status', 'Bio', 'Note', 'Memo']"
+                        :key="type"
+                        :label="type"
+                        :value="type"></el-option>
+                </el-select>
                 <div style="flex: none; margin-right: 10px; display: flex; align-items: center">
                     <el-tooltip
                         placement="bottom"
@@ -60,26 +80,6 @@
                             @change="friendsListSearchChange"></el-switch>
                     </el-tooltip>
                 </div>
-                <el-input
-                    :value="friendsListSearch"
-                    :placeholder="$t('view.friend_list.search_placeholder')"
-                    clearable
-                    style="flex: 1 1 60%; margin-right: 10px"
-                    @input="$emit('update:friends-list-search', $event)"
-                    @change="friendsListSearchChange"></el-input>
-                <el-select
-                    v-model="friendsListSearchFilters"
-                    multiple
-                    clearable
-                    style="flex: 1 1 40%; margin-right: 10px"
-                    :placeholder="$t('view.friend_list.filter_placeholder')"
-                    @change="friendsListSearchChange">
-                    <el-option
-                        v-for="type in ['Display Name', 'User Name', 'Rank', 'Status', 'Bio', 'Note', 'Memo']"
-                        :key="type"
-                        :label="type"
-                        :value="type"></el-option>
-                </el-select>
                 <el-tooltip placement="top" :content="$t('view.friend_list.refresh_tooltip')" :disabled="hideTooltips">
                     <el-button
                         type="default"

--- a/src/views/FriendList/FriendList.vue
+++ b/src/views/FriendList/FriendList.vue
@@ -64,15 +64,14 @@
                     :value="friendsListSearch"
                     :placeholder="$t('view.friend_list.search_placeholder')"
                     clearable
-                    style="flex: 1"
+                    style="flex: 1 1 60%; margin-right: 10px"
                     @input="$emit('update:friends-list-search', $event)"
                     @change="friendsListSearchChange"></el-input>
                 <el-select
                     v-model="friendsListSearchFilters"
                     multiple
                     clearable
-                    collapse-tags
-                    style="flex: none; width: 200px; margin: 0 10px"
+                    style="flex: 1 1 40%;"
                     :placeholder="$t('view.friend_list.filter_placeholder')"
                     @change="friendsListSearchChange">
                     <el-option
@@ -86,7 +85,7 @@
                         type="default"
                         icon="el-icon-refresh"
                         circle
-                        style="flex: none"
+                        style="flex: none;"
                         @click="friendsListSearchChange"></el-button>
                 </el-tooltip>
             </div>

--- a/src/views/FriendList/FriendList.vue
+++ b/src/views/FriendList/FriendList.vue
@@ -71,7 +71,7 @@
                     v-model="friendsListSearchFilters"
                     multiple
                     clearable
-                    style="flex: 1 1 40%;"
+                    style="flex: 1 1 40%; margin-right: 10px"
                     :placeholder="$t('view.friend_list.filter_placeholder')"
                     @change="friendsListSearchChange">
                     <el-option

--- a/src/views/FriendLog/FriendLog.vue
+++ b/src/views/FriendLog/FriendLog.vue
@@ -6,12 +6,12 @@
                     <el-input
                         v-model="friendLogTable.filters[1].value"
                         :placeholder="t('view.friend_log.search_placeholder')"
-                        style="flex: 1 1 60%; margin-right: 10px"></el-input>
+                        style="flex: 1 1 30%; margin-right: 10px"></el-input>
                     <el-select
                         v-model="friendLogTable.filters[0].value"
                         multiple
                         clearable
-                        style="flex: 1 1 40%;"
+                        style="flex: 1 1 70%;"
                         :placeholder="t('view.friend_log.filter_placeholder')"
                         @change="saveTableFilters">
                         <el-option

--- a/src/views/FriendLog/FriendLog.vue
+++ b/src/views/FriendLog/FriendLog.vue
@@ -3,11 +3,15 @@
         <data-tables v-bind="friendLogTable">
             <template #tool>
                 <div style="margin: 0 0 10px; display: flex; align-items: center">
+                    <el-input
+                        v-model="friendLogTable.filters[1].value"
+                        :placeholder="t('view.friend_log.search_placeholder')"
+                        style="flex: 1 1 60%; margin-right: 10px"></el-input>
                     <el-select
                         v-model="friendLogTable.filters[0].value"
                         multiple
                         clearable
-                        style="flex: 1"
+                        style="flex: 1 1 40%;"
                         :placeholder="t('view.friend_log.filter_placeholder')"
                         @change="saveTableFilters">
                         <el-option
@@ -23,10 +27,6 @@
                             :label="t('view.friend_log.filters.' + type)"
                             :value="type" />
                     </el-select>
-                    <el-input
-                        v-model="friendLogTable.filters[1].value"
-                        :placeholder="t('view.friend_log.search_placeholder')"
-                        style="flex: none; width: 150px; margin-left: 10px" />
                 </div>
             </template>
 

--- a/src/views/GameLog/GameLog.vue
+++ b/src/views/GameLog/GameLog.vue
@@ -14,11 +14,18 @@
                                 @change="gameLogTableLookup"></el-switch>
                         </el-tooltip>
                     </div>
+                    <el-input
+                        v-model="gameLogTable.search"
+                        :placeholder="t('view.game_log.search_placeholder')"
+                        clearable
+                        style="flex: 1 1 60%; margin-right: 10px"
+                        @keyup.native.enter="gameLogTableLookup"
+                        @change="gameLogTableLookup"></el-input>
                     <el-select
                         v-model="gameLogTable.filter"
                         multiple
                         clearable
-                        style="flex: 1"
+                        style="flex: 1 1 40%;"
                         :placeholder="t('view.game_log.filter_placeholder')"
                         @change="gameLogTableLookup">
                         <el-option
@@ -36,13 +43,6 @@
                             :label="t('view.game_log.filters.' + type)"
                             :value="type"></el-option>
                     </el-select>
-                    <el-input
-                        v-model="gameLogTable.search"
-                        :placeholder="t('view.game_log.search_placeholder')"
-                        clearable
-                        style="flex: none; width: 150px; margin: 0 10px"
-                        @keyup.native.enter="gameLogTableLookup"
-                        @change="gameLogTableLookup"></el-input>
                 </div>
             </template>
 

--- a/src/views/GameLog/GameLog.vue
+++ b/src/views/GameLog/GameLog.vue
@@ -3,29 +3,18 @@
         <data-tables v-loading="gameLogTable.loading" v-bind="gameLogTable" lazy>
             <template #tool>
                 <div style="margin: 0 0 10px; display: flex; align-items: center">
-                    <div style="flex: none; margin-right: 10px; display: flex; align-items: center">
-                        <el-tooltip
-                            placement="bottom"
-                            :content="t('view.feed.favorites_only_tooltip')"
-                            :disabled="hideTooltips">
-                            <el-switch
-                                v-model="gameLogTable.vip"
-                                active-color="#13ce66"
-                                @change="gameLogTableLookup"></el-switch>
-                        </el-tooltip>
-                    </div>
                     <el-input
                         v-model="gameLogTable.search"
                         :placeholder="t('view.game_log.search_placeholder')"
                         clearable
-                        style="flex: 1 1 60%; margin-right: 10px"
+                        style="flex: 1 1 30%; margin-right: 10px"
                         @keyup.native.enter="gameLogTableLookup"
                         @change="gameLogTableLookup"></el-input>
                     <el-select
                         v-model="gameLogTable.filter"
                         multiple
                         clearable
-                        style="flex: 1 1 40%;"
+                        style="flex: 1 1 70%; margin-right: 10px;"
                         :placeholder="t('view.game_log.filter_placeholder')"
                         @change="gameLogTableLookup">
                         <el-option
@@ -43,6 +32,17 @@
                             :label="t('view.game_log.filters.' + type)"
                             :value="type"></el-option>
                     </el-select>
+                    <div style="flex: none; display: flex; align-items: center">
+                        <el-tooltip
+                            placement="bottom"
+                            :content="t('view.feed.favorites_only_tooltip')"
+                            :disabled="hideTooltips">
+                            <el-switch
+                                v-model="gameLogTable.vip"
+                                active-color="#13ce66"
+                                @change="gameLogTableLookup"></el-switch>
+                        </el-tooltip>
+                    </div>
                 </div>
             </template>
 

--- a/src/views/Moderation/Moderation.vue
+++ b/src/views/Moderation/Moderation.vue
@@ -9,23 +9,25 @@
             v-loading="API.isPlayerModerationsLoading">
             <template slot="tool">
                 <div class="tool-slot">
-                    <el-select
-                        v-model="filters[0].value"
-                        @change="saveTableFilters()"
-                        multiple
-                        clearable
-                        style="flex: 1"
-                        :placeholder="$t('view.moderation.filter_placeholder')">
-                        <el-option
-                            v-for="item in moderationTypes"
-                            :key="item"
-                            :label="$t('view.moderation.filters.' + item)"
-                            :value="item" />
-                    </el-select>
-                    <el-input
-                        v-model="filters[1].value"
-                        :placeholder="$t('view.moderation.search_placeholder')"
-                        class="filter-input" />
+                    <div style="display: flex; align-items: center; margin-right: 10px; width: 100%;">
+                        <el-input
+                            v-model="filters[1].value"
+                            :placeholder="$t('view.moderation.search_placeholder')"
+                            style="flex: 1 1 60%; margin-right: 10px;" />
+                        <el-select
+                            v-model="filters[0].value"
+                            @change="saveTableFilters()"
+                            multiple
+                            clearable
+                            style="flex: 1 1 40%;"
+                            :placeholder="$t('view.moderation.filter_placeholder')">
+                            <el-option
+                                v-for="item in moderationTypes"
+                                :key="item"
+                                :label="$t('view.moderation.filters.' + item)"
+                                :value="item" />
+                        </el-select>
+                    </div>
                     <el-tooltip
                         placement="bottom"
                         :content="$t('view.moderation.refresh_tooltip')"

--- a/src/views/Moderation/Moderation.vue
+++ b/src/views/Moderation/Moderation.vue
@@ -13,13 +13,13 @@
                         <el-input
                             v-model="filters[1].value"
                             :placeholder="$t('view.moderation.search_placeholder')"
-                            style="flex: 1 1 60%; margin-right: 10px;" />
+                            style="flex: 1 1 30%; margin-right: 10px;" />
                         <el-select
                             v-model="filters[0].value"
                             @change="saveTableFilters()"
                             multiple
                             clearable
-                            style="flex: 1 1 40%;"
+                            style="flex: 1 1 70%;"
                             :placeholder="$t('view.moderation.filter_placeholder')">
                             <el-option
                                 v-for="item in moderationTypes"

--- a/src/views/Notifications/Notification.vue
+++ b/src/views/Notifications/Notification.vue
@@ -6,12 +6,12 @@
                     <el-input
                         v-model="notificationTable.filters[1].value"
                         :placeholder="t('view.notification.search_placeholder')"
-                        style="flex: 1 1 60%; margin-right: 10px" />
+                        style="flex: 1 1 30%; margin-right: 10px" />
                     <el-select
                         v-model="notificationTable.filters[0].value"
                         multiple
                         clearable
-                        style="flex: 1 1 40%; margin-right: 10px;"
+                        style="flex: 1 1 70%; margin-right: 10px;"
                         :placeholder="t('view.notification.filter_placeholder')"
                         @change="saveTableFilters">
                         <el-option

--- a/src/views/Notifications/Notification.vue
+++ b/src/views/Notifications/Notification.vue
@@ -3,11 +3,15 @@
         <data-tables v-bind="notificationTable" ref="notificationTableRef" class="notification-table">
             <template #tool>
                 <div style="margin: 0 0 10px; display: flex; align-items: center">
+                    <el-input
+                        v-model="notificationTable.filters[1].value"
+                        :placeholder="t('view.notification.search_placeholder')"
+                        style="flex: 1 1 60%; margin-right: 10px" />
                     <el-select
                         v-model="notificationTable.filters[0].value"
                         multiple
                         clearable
-                        style="flex: 1"
+                        style="flex: 1 1 40%;"
                         :placeholder="t('view.notification.filter_placeholder')"
                         @change="saveTableFilters">
                         <el-option
@@ -35,10 +39,6 @@
                             :label="t('view.notification.filters.' + type)"
                             :value="type" />
                     </el-select>
-                    <el-input
-                        v-model="notificationTable.filters[1].value"
-                        :placeholder="t('view.notification.search_placeholder')"
-                        style="flex: none; width: 150px; margin: 0 10px" />
                     <el-tooltip
                         placement="bottom"
                         :content="t('view.notification.refresh_tooltip')"

--- a/src/views/Notifications/Notification.vue
+++ b/src/views/Notifications/Notification.vue
@@ -11,7 +11,7 @@
                         v-model="notificationTable.filters[0].value"
                         multiple
                         clearable
-                        style="flex: 1 1 40%;"
+                        style="flex: 1 1 40%; margin-right: 10px;"
                         :placeholder="t('view.notification.filter_placeholder')"
                         @change="saveTableFilters">
                         <el-option


### PR DESCRIPTION
Building off of #1269 , I found it easier to navigate with a larger search bar than filters. I swapped the two and made the styling more consistent between views.

- **Search bars**: Enlarged to take primary space for easier interaction
- **Consistent layout**: Applied across all affected views

### Before Changes

| View | Screenshot |
|------|------------|
| **Feed** | ![image](https://github.com/user-attachments/assets/95c19098-a516-40cd-80ce-e5678d621ada) |
| **Game Log** | ![image](https://github.com/user-attachments/assets/d5c73c5a-38a6-45f9-b732-6c79157ada25) |
| **Friend Log** | ![image](https://github.com/user-attachments/assets/2a1c1611-7c83-4e9b-af58-8c7d4d896dd6) |
| **Moderation** | ![image](https://github.com/user-attachments/assets/4f5cdcbc-5e0c-467f-9692-72295bea0982) |
| **Notifications** | ![image](https://github.com/user-attachments/assets/9fdeb382-6190-4d20-b6b2-f07ff8187df5) |
| **Friend List** | ![image](https://github.com/user-attachments/assets/72f6a372-0d51-4ae8-976a-4930c2a3d526) |

### After Changes

| View | Screenshot |
|------|------------|
| **Feed** | ![image](https://github.com/user-attachments/assets/88170863-e161-461d-936a-64080deedfe5) |
| **Game Log** | ![image](https://github.com/user-attachments/assets/79df17ba-eb8e-4ef6-9ee5-41e7a9c49943) |
| **Friend Log** | ![image](https://github.com/user-attachments/assets/24e4285b-2c5a-4b5c-9594-d885fbf0ddbf) |
| **Moderation** | ![image](https://github.com/user-attachments/assets/f768fc1a-e5b9-4e24-95c7-9dc939144445) |
| **Notifications** | ![image](https://github.com/user-attachments/assets/153f4ba2-3854-49cc-86ed-f58efb502645) |
| **Friend List** | ![image](https://github.com/user-attachments/assets/e5090bdd-799e-4776-b0dd-d9dfdd1d751e) |