### PR TITLE
Add "Last Visited" to group profile

### DIFF
--- a/src/classes/groups.js
+++ b/src/classes/groups.js
@@ -8,6 +8,7 @@ import {
     groupRequest
 } from '../api';
 import $utils from './utils';
+import database from '../service/database.js';
 
 export default class extends baseClass {
     constructor(_app, _API, _t) {
@@ -507,7 +508,8 @@ export default class extends baseClass {
                 value: 'joinedAt:desc'
             },
             postsSearch: '',
-            galleries: {}
+            galleries: {},
+            lastVisit: ''
         },
         inviteGroupDialog: {
             visible: false,
@@ -771,6 +773,7 @@ export default class extends baseClass {
             D.postsFiltered = [];
             D.instances = [];
             D.memberRoles = [];
+            D.lastVisit = '';
             D.memberSearch = '';
             D.memberSearchResults = [];
             D.galleries = {};
@@ -802,6 +805,11 @@ export default class extends baseClass {
                                 D.ownerDisplayName = args1.ref.displayName;
                                 return args1;
                             });
+                        database.getLastGroupVisit(D.ref.name).then((r) => {
+                            if (D.id === args.ref.id) {
+                                D.lastVisit = r.created_at;
+                            }
+                        });
                         this.applyGroupDialogInstances();
                         this.getGroupDialogGroup(groupId);
                     }

--- a/src/components/dialogs/PreviousInstancesDialog/PreviousInstancesGroupDialog.vue
+++ b/src/components/dialogs/PreviousInstancesDialog/PreviousInstancesGroupDialog.vue
@@ -1,0 +1,175 @@
+<template>
+    <safe-dialog
+        ref="previousInstancesGroupDialog"
+        :visible.sync="isVisible"
+        :title="$t('dialog.previous_instances.header')"
+        width="1000px"
+        append-to-body>
+        <div style="display: flex; align-items: center; justify-content: space-between">
+            <span style="font-size: 14px" v-text="previousInstancesGroupDialog.groupRef.name"></span>
+            <el-input
+                v-model="previousInstancesGroupDialogTable.filters[0].value"
+                :placeholder="$t('dialog.previous_instances.search_placeholder')"
+                style="display: block; width: 150px"></el-input>
+        </div>
+        <data-tables v-loading="loading" v-bind="previousInstancesGroupDialogTable" style="margin-top: 10px">
+            <el-table-column :label="$t('table.previous_instances.date')" prop="created_at" sortable width="170">
+                <template slot-scope="scope">
+                    <span>{{ scope.row.created_at | formatDate('long') }}</span>
+                </template>
+            </el-table-column>
+            <el-table-column :label="$t('table.previous_instances.instance_name')" prop="name">
+                <template slot-scope="scope">
+                    <location-world
+                        :locationobject="scope.row.$location"
+                        :grouphint="scope.row.groupName"
+                        :currentuserid="API.currentUser.id"
+                        @show-launch-dialog="showLaunchDialog"></location-world>
+                </template>
+            </el-table-column>
+            <el-table-column :label="$t('table.previous_instances.instance_creator')" prop="location">
+                <template slot-scope="scope">
+                    <display-name
+                        :userid="scope.row.$location.userId"
+                        :location="scope.row.$location.tag"
+                        :force-update-key="previousInstancesGroupDialog.forceUpdate"></display-name>
+                </template>
+            </el-table-column>
+            <el-table-column :label="$t('table.previous_instances.time')" prop="time" width="100" sortable>
+                <template slot-scope="scope">
+                    <span v-text="scope.row.timer"></span>
+                </template>
+            </el-table-column>
+            <el-table-column :label="$t('table.previous_instances.action')" width="90" align="right">
+                <template slot-scope="scope">
+                    <el-button
+                        type="text"
+                        icon="el-icon-s-data"
+                        size="mini"
+                        @click="showPreviousInstancesInfoDialog(scope.row.location)"></el-button>
+                    <el-button
+                        v-if="shiftHeld"
+                        style="color: #f56c6c"
+                        type="text"
+                        icon="el-icon-close"
+                        size="mini"
+                        @click="deleteGameLogGroupInstance(scope.row)"></el-button>
+                    <el-button
+                        v-else
+                        type="text"
+                        icon="el-icon-close"
+                        size="mini"
+                        @click="deleteGameLogGroupInstancePrompt(scope.row)"></el-button>
+                </template>
+            </el-table-column>
+        </data-tables>
+    </safe-dialog>
+</template>
+
+<script>
+import utils from '../../../classes/utils';
+import { parseLocation } from '../../../composables/instance/utils';
+import database from '../../../service/database';
+
+export default {
+    name: 'PreviousInstancesGroupDialog',
+    inject: ['API', 'showLaunchDialog', 'showPreviousInstancesInfoDialog', 'adjustDialogZ'],
+    props: {
+        previousInstancesGroupDialog: {
+            type: Object,
+            required: true
+        },
+        shiftHeld: Boolean
+    },
+    data() {
+        return {
+            previousInstancesGroupDialogTable: {
+                data: [],
+                filters: [
+                    {
+                        prop: 'worldName',
+                        value: ''
+                    }
+                ],
+                tableProps: {
+                    stripe: true,
+                    size: 'mini',
+                    defaultSort: {
+                        prop: 'created_at',
+                        order: 'descending'
+                    }
+                },
+                pageSize: 10,
+                paginationProps: {
+                    small: true,
+                    layout: 'sizes,prev,pager,next,total',
+                    pageSizes: [10, 25, 50, 100]
+                }
+            },
+            loading: false
+        };
+    },
+    computed: {
+        isVisible: {
+            get() {
+                return this.previousInstancesGroupDialog.visible;
+            },
+            set(value) {
+                this.$emit('update:previousInstancesGroupDialog', {
+                    ...this.previousInstancesGroupDialog,
+                    visible: value
+                });
+            }
+        }
+    },
+    watch: {
+        'previousInstancesGroupDialog.openFlg'() {
+            if (this.previousInstancesGroupDialog.visible) {
+                this.$nextTick(() => {
+                    this.adjustDialogZ(this.$refs.previousInstancesGroupDialog.$el);
+                });
+                this.refreshPreviousInstancesGroupTable();
+            }
+        }
+    },
+    methods: {
+        refreshPreviousInstancesGroupTable() {
+            this.loading = true;
+            const D = this.previousInstancesGroupDialog;
+            database.getpreviousInstancesByGroupName(D.groupRef.name).then((data) => {
+                const array = [];
+                for (const ref of data.values()) {
+                    ref.$location = parseLocation(ref.location);
+                    if (ref.time > 0) {
+                        ref.timer = utils.timeToText(ref.time);
+                    } else {
+                        ref.timer = '';
+                    }
+                    array.push(ref);
+                }
+                array.sort(utils.compareByCreatedAt);
+                this.previousInstancesGroupDialogTable.data = array;
+                this.loading = false;
+            });
+        },
+        deleteGameLogGroupInstance(row) {
+            database.deleteGameLogInstanceByInstanceId({
+                location: row.location
+            });
+            utils.removeFromArray(this.previousInstancesGroupDialogTable.data, row);
+        },
+        deleteGameLogGroupInstancePrompt(row) {
+            this.$confirm('Continue? Delete GameLog Instance', 'Confirm', {
+                confirmButtonText: 'Confirm',
+                cancelButtonText: 'Cancel',
+                type: 'info',
+                callback: (action) => {
+                    if (action === 'confirm') {
+                        this.deleteGameLogGroupInstance(row);
+                    }
+                }
+            });
+        }
+    }
+};
+</script>

--- a/src/localization/cz/en.json
+++ b/src/localization/cz/en.json
@@ -919,7 +919,8 @@
                 "role_description": "Description:",
                 "role_updated_at": "Updated At:",
                 "role_created_at": "Created At:",
-                "role_permissions": "Permissions:"
+                "role_permissions": "Permissions:",
+                "last_visited": "Last Visited"
             },
             "posts": {
                 "header": "Posts",

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -1066,7 +1066,8 @@
                 "role_description": "Description:",
                 "role_updated_at": "Updated At:",
                 "role_created_at": "Created At:",
-                "role_permissions": "Permissions:"
+                "role_permissions": "Permissions:",
+                "last_visited": "Last Visited"
             },
             "posts": {
                 "header": "Posts",

--- a/src/localization/es/en.json
+++ b/src/localization/es/en.json
@@ -1039,7 +1039,8 @@
                 "role_description": "Descripción:",
                 "role_updated_at": "Actualizado el:",
                 "role_created_at": "Creado el:",
-                "role_permissions": "Permisos:"
+                "role_permissions": "Permisos:",
+                "last_visited": "Última visita"
             },
             "posts": {
                 "header": "Publicaciones",

--- a/src/localization/fr/en.json
+++ b/src/localization/fr/en.json
@@ -989,7 +989,8 @@
                 "role_description": "Description :",
                 "role_updated_at": "Mis à jour le :",
                 "role_created_at": "Créé le :",
-                "role_permissions": "Permissions :"
+                "role_permissions": "Permissions :",
+                "last_visited": "Dernière visite"
             },
             "posts": {
                 "header": "Publications",

--- a/src/localization/hu/en.json
+++ b/src/localization/hu/en.json
@@ -873,7 +873,8 @@
                 "role_description": "Description:",
                 "role_updated_at": "Updated At:",
                 "role_created_at": "Created At:",
-                "role_permissions": "Permissions:"
+                "role_permissions": "Permissions:",
+                "last_visited": "Last Visited"
             },
             "posts": {
                 "header": "Posts",

--- a/src/localization/ja/en.json
+++ b/src/localization/ja/en.json
@@ -1042,7 +1042,8 @@
                 "role_description": "説明:",
                 "role_updated_at": "更新日:",
                 "role_created_at": "作成日:",
-                "role_permissions": "権限:"
+                "role_permissions": "権限:",
+                "last_visited": "最終訪問"
             },
             "posts": {
                 "header": "投稿",

--- a/src/localization/ko/en.json
+++ b/src/localization/ko/en.json
@@ -873,7 +873,8 @@
                 "role_description": "설명:",
                 "role_updated_at": "업데이트:",
                 "role_created_at": "생성일:",
-                "role_permissions": "권한:"
+                "role_permissions": "권한:",
+                "last_visited": "마지막 방문"
             },
             "posts": {
                 "header": "Posts",

--- a/src/localization/pl/en.json
+++ b/src/localization/pl/en.json
@@ -873,7 +873,8 @@
                 "role_description": "Opis:",
                 "role_updated_at": "Zaktualizowano:",
                 "role_created_at": "Data utworzenia:",
-                "role_permissions": "Uprawnienia:"
+                "role_permissions": "Uprawnienia:",
+                "last_visited": "Ostatnia wizyta"
             },
             "posts": {
                 "header": "Posty",

--- a/src/localization/pt/en.json
+++ b/src/localization/pt/en.json
@@ -873,7 +873,8 @@
                 "role_description": "Descrição:",
                 "role_updated_at": "Atualizado Em:",
                 "role_created_at": "Criado Em:",
-                "role_permissions": "Permissões:"
+                "role_permissions": "Permissões:",
+                "last_visited": "Última visita"
             },
             "posts": {
                 "header": "Publicações",

--- a/src/localization/ru/en.json
+++ b/src/localization/ru/en.json
@@ -1043,7 +1043,8 @@
                 "role_description": "Описание:",
                 "role_updated_at": "Обновлена:",
                 "role_created_at": "Создана:",
-                "role_permissions": "Права доступа:"
+                "role_permissions": "Права доступа:",
+                "last_visited": "Последний визит"
             },
             "posts": {
                 "header": "Объявления",

--- a/src/localization/vi/en.json
+++ b/src/localization/vi/en.json
@@ -873,7 +873,8 @@
                 "role_description": "Mô tả:",
                 "role_updated_at": "Cập nhật lúc:",
                 "role_created_at": "Tạo lúc:",
-                "role_permissions": "Quyền:"
+                "role_permissions": "Quyền:",
+                "last_visited": "Lần truy cập cuối"
             },
             "posts": {
                 "header": "Posts",

--- a/src/localization/zh-CN/en.json
+++ b/src/localization/zh-CN/en.json
@@ -1045,7 +1045,8 @@
                 "role_description": "描述：",
                 "role_updated_at": "更新时间：",
                 "role_created_at": "创建时间：",
-                "role_permissions": "权限："
+                "role_permissions": "权限：",
+                "last_visited": "上次访问"
             },
             "posts": {
                 "header": "帖子",

--- a/src/localization/zh-TW/en.json
+++ b/src/localization/zh-TW/en.json
@@ -1043,7 +1043,8 @@
                 "role_description": "敘述：",
                 "role_updated_at": "更新時間：",
                 "role_created_at": "創建時間：",
-                "role_permissions": "權限："
+                "role_permissions": "權限：",
+                "last_visited": "上次造訪"
             },
             "posts": {
                 "header": "貼文",

--- a/src/service/database.js
+++ b/src/service/database.js
@@ -1076,6 +1076,55 @@ class Database {
         return ref;
     }
 
+    async getLastGroupVisit(groupName) {
+        var ref = {
+            created_at: '',
+            groupName: ''
+        };
+        await sqliteService.execute(
+            (row) => {
+                ref = {
+                    created_at: row[0],
+                    groupName: row[1]
+                };
+            },
+            `SELECT created_at, group_name FROM gamelog_location WHERE group_name = @groupName ORDER BY id DESC LIMIT 1`,
+            {
+                '@groupName': groupName
+            }
+        );
+        return ref;
+    }
+
+    async getpreviousInstancesByGroupName(groupName) {
+        var data = new Map();
+        await sqliteService.execute(
+            (dbRow) => {
+                var time = 0;
+                if (dbRow[2]) {
+                    time = dbRow[2];
+                }
+                var ref = data.get(dbRow[1]);
+                if (typeof ref !== 'undefined') {
+                    time += ref.time;
+                }
+                var row = {
+                    created_at: dbRow[0],
+                    location: dbRow[1],
+                    time,
+                    worldName: dbRow[3],
+                    groupName: dbRow[4]
+                };
+                data.set(row.location, row);
+            },
+            `SELECT created_at, location, time, world_name, group_name FROM gamelog_location WHERE group_name = @groupName ORDER BY id DESC`,
+            {
+                '@groupName': groupName
+            }
+        );
+        return data;
+    }
+
     async getLastSeen(input, inCurrentWorld) {
         if (inCurrentWorld) {
             var count = 2;


### PR DESCRIPTION
I added a field to the group profile showing when you last visited a group instance, including the date and how many days ago it was.

Additionally, you can click on the date to see a list of all instances of that group you've previously been in.

And this time with a correct translation. 👍

![image](https://github.com/user-attachments/assets/5e60aa9d-c3e9-45ea-b456-e898302bde60)
![image](https://github.com/user-attachments/assets/ac627137-e3f2-4390-b4dd-e8708b7273c2)
