### PR TITLE
Revert main.js Start minimized changes

### DIFF
--- a/src-electron/main.js
+++ b/src-electron/main.js
@@ -39,7 +39,6 @@ const args = process.argv.slice(1);
 const noInstall = args.includes('--no-install');
 const x11 = args.includes('--x11');
 const noDesktop = args.includes('--no-desktop');
-const startup = args.includes('--startup');
 
 const homePath = getHomePath();
 tryRelaunchWithArgs(args);
@@ -585,7 +584,7 @@ function tryCopyFromWinePrefix() {
 }
 
 function applyWindowState() {
-    if (VRCXStorage.Get('VRCX_StartAsMinimizedState') === 'true' && startup) {
+    if (VRCXStorage.Get('VRCX_StartAsMinimizedState') === 'true') {
         if (isCloseToTray) {
             mainWindow.hide();
             return;


### PR DESCRIPTION
Reverts the requirement of the --startup launch option for start minimized to work from commit c9687bd.