### PR TITLE
Improve 'Previous Instances' grouping behavior

### DIFF
--- a/src/components/dialogs/UserDialog/PreviousInstancesUserDialog.vue
+++ b/src/components/dialogs/UserDialog/PreviousInstancesUserDialog.vue
@@ -165,7 +165,8 @@
         database.deleteGameLogInstance({
             id: props.previousInstancesUserDialog.userRef.id,
             displayName: props.previousInstancesUserDialog.userRef.displayName,
-            location: row.location
+            location: row.location,
+            localDate: row.localDate
         });
         removeFromArray(previousInstancesUserDialogTable.data, row);
     }

--- a/src/components/dialogs/UserDialog/PreviousInstancesUserDialog.vue
+++ b/src/components/dialogs/UserDialog/PreviousInstancesUserDialog.vue
@@ -166,7 +166,7 @@
             id: props.previousInstancesUserDialog.userRef.id,
             displayName: props.previousInstancesUserDialog.userRef.displayName,
             location: row.location,
-            localDate: row.localDate
+            events: row.events
         });
         removeFromArray(previousInstancesUserDialogTable.data, row);
     }

--- a/src/service/database/gameLog.js
+++ b/src/service/database/gameLog.js
@@ -870,14 +870,11 @@ const gameLog = {
         var data = new Set();
         await sqliteService.execute(
             (dbRow) => {
-                var time = 0;
-                if (dbRow[2]) {
-                    time = dbRow[2];
-                }
+                if (!dbRow[2]) return; // prevent zero-time records due to OnPlayerJoined and OnPlayerLeft happening on different calendar days
                 var row = {
                     created_at: dbRow[0],
                     location: dbRow[1],
-                    time,
+                    time: dbRow[2],
                     worldName: dbRow[3],
                     groupName: dbRow[4]
                 };

--- a/src/service/database/gameLog.js
+++ b/src/service/database/gameLog.js
@@ -876,7 +876,8 @@ const gameLog = {
                     location: dbRow[1],
                     time: dbRow[2],
                     worldName: dbRow[3],
-                    groupName: dbRow[4]
+                    groupName: dbRow[4],
+                    localDate: dbRow[5]
                 };
                 data.add(row);
             },
@@ -885,7 +886,7 @@ const gameLog = {
                 SELECT DISTINCT location, world_name, group_name
                 FROM gamelog_location
             )
-            SELECT gamelog_join_leave.created_at, gamelog_join_leave.location, sum(gamelog_join_leave.time) time, grouped_locations.world_name, grouped_locations.group_name
+            SELECT gamelog_join_leave.created_at, gamelog_join_leave.location, sum(gamelog_join_leave.time) time, grouped_locations.world_name, grouped_locations.group_name, date(gamelog_join_leave.created_at, 'localtime') local_date
             FROM gamelog_join_leave
             INNER JOIN grouped_locations ON gamelog_join_leave.location = grouped_locations.location
             WHERE user_id = @userId OR display_name = @displayName
@@ -1125,11 +1126,12 @@ const gameLog = {
 
     deleteGameLogInstance(input) {
         sqliteService.executeNonQuery(
-            `DELETE FROM gamelog_join_leave WHERE (user_id = @user_id OR display_name = @displayName) AND (location = @location)`,
+            `DELETE FROM gamelog_join_leave WHERE (user_id = @user_id OR display_name = @displayName) AND (location = @location) AND (date(created_at, 'localtime') = @localDate)`,
             {
                 '@user_id': input.id,
                 '@displayName': input.displayName,
-                '@location': input.location
+                '@location': input.location,
+                '@localDate': input.localDate
             }
         );
     },

--- a/src/service/database/gameLog.js
+++ b/src/service/database/gameLog.js
@@ -892,7 +892,7 @@ const gameLog = {
             FROM gamelog_join_leave
             INNER JOIN grouped_locations ON gamelog_join_leave.location = grouped_locations.location
             WHERE user_id = @userId OR display_name = @displayName
-            GROUP BY gamelog_join_leave.location, date(gamelog_join_leave.created_at)
+            GROUP BY gamelog_join_leave.location, date(gamelog_join_leave.created_at, 'localtime')
             ORDER BY gamelog_join_leave.id DESC`,
             {
                 '@userId': input.id,

--- a/src/service/database/gameLog.js
+++ b/src/service/database/gameLog.js
@@ -870,6 +870,7 @@ const gameLog = {
         var groupingTimeTolerance = 1 * 60 * 60 * 1000; // 1 hour
         var data = new Set();
         var currentGroup;
+        var prevEvent;
 
         await sqliteService.execute(
             (dbRow) => {
@@ -880,7 +881,7 @@ const gameLog = {
                     || currentGroup.location !== location
                     || (
                         (created_at_ts - currentGroup.last_ts) > groupingTimeTolerance // groups multiple OnPlayerJoined and OnPlayerLeft together if they are within time tolerance limit
-                        && !(currentGroup.last_join_ts && Math.abs((created_at_ts - currentGroup.last_join_ts) - time) < 1000) // allows OnPlayerLeft to connect with nearby OnPlayerJoined
+                        && !(prevEvent === "OnPlayerJoined" && eventType === "OnPlayerLeft") // allows OnPlayerLeft to connect with nearby OnPlayerJoined
                     )
                 ) {
                     currentGroup = {
@@ -900,7 +901,7 @@ const gameLog = {
                     currentGroup.events.push(eventId);
                 }
 
-                if (eventType == 'OnPlayerJoined') currentGroup.last_join_ts = created_at_ts;
+                prevEvent = eventType;
             },
             `
             WITH grouped_locations AS (


### PR DESCRIPTION
Group a user’s previous instances by both location and calendar date for better clarity, instead of grouping only by instance identifier.

This issue is most noticeable with 24/7 public group instances, where the instance ID remains the same. In such cases, VRCX would group sessions from multiple days into a single row, making it much harder to track when you played with a particular user.

The algorithm connects multiple OnPlayerJoined / OnPlayerLeft events from gamelog_join_leave together if they're from the same instance and fall within 1 hour threshold window. This approach prevents log clutter from frequent rejoins as well.

Before:
<img width="980" height="429" alt="image" src="https://github.com/user-attachments/assets/72972360-42b5-44d3-98fd-d7ddf1215594" />

After:
<img width="996" height="513" alt="image" src="https://github.com/user-attachments/assets/4a40433d-a1e7-419c-ac43-c4f77b48cd2a" />


