### PR TITLE
fix path.join failing due to undefined process.env.DOTNET_ROOT

### DIFF
--- a/src-electron/main.js
+++ b/src-electron/main.js
@@ -748,11 +748,19 @@ function getVersion() {
 }
 
 function isDotNetInstalled() {
-    let dotnetPath = path.join(process.env.DOTNET_ROOT, 'dotnet');
-    if (!process.env.DOTNET_ROOT || !fs.existsSync(dotnetPath)) {
+    let dotnetPath;
+
+    if (process.env.DOTNET_ROOT) {
+        dotnetPath = path.join(process.env.DOTNET_ROOT, 'dotnet');
+        if (!fs.existsSync(dotnetPath)) {
+            // fallback to command
+            dotnetPath = 'dotnet';
+        }
+    } else {
         // fallback to command
         dotnetPath = 'dotnet';
     }
+
     console.log('Checking for .NET installation at:', dotnetPath);
 
     // Fallback to system .NET runtime


### PR DESCRIPTION
In case when DOTNET_ROOT is missing from system environment variables for some odd reason.