### PR TITLE
Update japanese translation

### DIFF
--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -250,6 +250,34 @@
                 }
             }
         },
+        "tools": {
+            "header": "Tools",
+            "group": {
+                "header": "Group",
+                "calendar": {
+                    "title": "Calendar",
+                    "info": "Group Events Calendar"
+                }
+            },
+            "image": {
+                "header": "Image",
+                "screenshot": {
+                    "title": "Screenshot Management",
+                    "info": "Manage screenshots and view metadata"
+                },
+                "vrchat_inventory": {
+                    "title": "VRC+ Images & Inventory Management",
+                    "info": "Manage VRC+ images and inventory"
+                }
+            },
+            "user": {
+                "header": "User",
+                "export_notes": {
+                    "title": "Export User Notes",
+                    "info": "Export VRCX user memos to VRChat notes"
+                }
+            }
+        },
         "profile": {
             "profile": {
                 "header": "Profile",
@@ -1656,7 +1684,18 @@
             "save": "Save"
         },
         "group_calendar": {
-            "header": "Group Calendar"
+            "header": "Group Calendar",
+            "no_events": "No events found",
+            "search_placeholder": "Search groups or events...",
+            "search_no_matching": "No matching events found",
+            "search_no_this_month": "No events this month",
+            "event_card": {
+                "category": "Category",
+                "interested_user": "Interested User",
+                "close_time": "Close Instance After End",
+                "created": "Created Date",
+                "description": "Description"
+            }
         },
         "moderate_group": {
             "header": "Moderate Group Member",

--- a/src/localization/ja/en.json
+++ b/src/localization/ja/en.json
@@ -250,6 +250,34 @@
                 }
             }
         },
+        "tools": {
+            "header": "ツール",
+            "group": {
+                "header": "グループ",
+                "calendar": {
+                    "title": "カレンダー",
+                    "info": "グループイベントカレンダー"
+                }
+            },
+            "image": {
+                "header": "写真",
+                "screenshot": {
+                    "title": "スクリーンショットの管理",
+                    "info": "スクリーンショットのメタデータを管理"
+                },
+                "vrchat_inventory": {
+                    "title": "VRC+インベントリの管理",
+                    "info": "VRC+ギャラリーとインベントリの管理"
+                }
+            },
+            "user": {
+                "header": "ユーザー",
+                "export_notes": {
+                    "title": "ノートをエクスポート",
+                    "info": "VRCXユーザーメモをVRChatノートにエクスポート"
+                }
+            }
+        },
         "profile": {
             "profile": {
                 "header": "プロフィール",
@@ -1656,7 +1684,18 @@
             "save": "保存"
         },
         "group_calendar": {
-            "header": "グループカレンダー"
+            "header": "グループカレンダー",
+            "no_events": "イベントが見つかりません",
+            "search_placeholder": "グループまたはイベントを検索...",
+            "search_no_matching": "一致するイベントが見つかりません",
+            "search_no_this_month": "今月のイベントはありません",
+            "event_card": {
+                "category": "カテゴリ",
+                "interested_user": "興味のあるユーザー",
+                "close_time": "終了後にインスタンスを閉じる時間",
+                "created": "イベント作成日",
+                "description": "このイベントについて"
+            }
         },
         "moderate_group": {
             "header": "グループメンバーのモデレーション",

--- a/src/views/Tools/Tools.vue
+++ b/src/views/Tools/Tools.vue
@@ -1,13 +1,13 @@
 <template>
     <div id="chart" class="x-container" v-show="menuActiveIndex === 'tools'">
         <div class="options-container" style="margin-top: 0">
-            <span class="header">Tools</span>
+            <span class="header">{{ t('view.tools.header') }}</span>
 
             <div class="tool-categories">
                 <div class="tool-category">
                     <div class="category-header" @click="toggleCategory('group')">
                         <i class="el-icon-arrow-right" :class="{ rotate: !categoryCollapsed['group'] }"></i>
-                        <span class="category-title">Group</span>
+                        <span class="category-title">{{ t('view.tools.group.header') }}</span>
                     </div>
                     <div class="tools-grid" v-show="!categoryCollapsed['group']">
                         <el-card :body-style="{ padding: '0px' }" class="tool-card">
@@ -16,8 +16,8 @@
                                     <i class="ri-calendar-event-line"></i>
                                 </div>
                                 <div class="tool-info">
-                                    <div class="tool-name">Calendar</div>
-                                    <div class="tool-description">Group Events Calendar</div>
+                                    <div class="tool-name">{{ t('view.tools.group.calendar.title') }}</div>
+                                    <div class="tool-description">{{ t('view.tools.group.calendar.info') }}</div>
                                 </div>
                             </div>
                         </el-card>
@@ -27,7 +27,7 @@
                 <div class="tool-category">
                     <div class="category-header" @click="toggleCategory('image')">
                         <i class="el-icon-arrow-right" :class="{ rotate: !categoryCollapsed['image'] }"></i>
-                        <span class="category-title">Image</span>
+                        <span class="category-title">{{ t('view.tools.image.header') }}</span>
                     </div>
                     <div class="tools-grid" v-show="!categoryCollapsed['image']">
                         <el-card :body-style="{ padding: '0px' }" class="tool-card">
@@ -36,8 +36,8 @@
                                     <i class="ri-screenshot-2-line"></i>
                                 </div>
                                 <div class="tool-info">
-                                    <div class="tool-name">Screenshot Management</div>
-                                    <div class="tool-description">Manage screenshots and view metadata</div>
+                                    <div class="tool-name">{{ t('view.tools.image.screenshot.title') }}</div>
+                                    <div class="tool-description">{{ t('view.tools.image.screenshot.info') }}</div>
                                 </div>
                             </div>
                         </el-card>
@@ -47,8 +47,8 @@
                                     <i class="ri-multi-image-line"></i>
                                 </div>
                                 <div class="tool-info">
-                                    <div class="tool-name">VRC+ Images & Inventory Management</div>
-                                    <div class="tool-description">Manage VRC+ Images & Inventory</div>
+                                    <div class="tool-name">{{ t('view.tools.image.vrchat_inventory.title') }}</div>
+                                    <div class="tool-description">{{ t('view.tools.image.vrchat_inventory.info') }}</div>
                                 </div>
                             </div>
                         </el-card>
@@ -58,7 +58,7 @@
                 <div class="tool-category">
                     <div class="category-header" @click="toggleCategory('user')">
                         <i class="el-icon-arrow-right" :class="{ rotate: !categoryCollapsed['user'] }"></i>
-                        <span class="category-title">User</span>
+                        <span class="category-title">{{ t('view.tools.user.header') }}</span>
                     </div>
                     <div class="tools-grid" v-show="!categoryCollapsed['user']">
                         <el-card :body-style="{ padding: '0px' }" class="tool-card">
@@ -67,8 +67,8 @@
                                     <i class="ri-user-shared-line"></i>
                                 </div>
                                 <div class="tool-info">
-                                    <div class="tool-name">Export User Notes</div>
-                                    <div class="tool-description">Export VRCX user memos to VRChat notes</div>
+                                    <div class="tool-name">{{ t('view.tools.user.export_notes.title') }}</div>
+                                    <div class="tool-description">{{ t('view.tools.user.export_notes.info') }}</div>
                                 </div>
                             </div>
                         </el-card>

--- a/src/views/Tools/components/GroupCalendarEventCard.vue
+++ b/src/views/Tools/components/GroupCalendarEventCard.vue
@@ -14,19 +14,21 @@
                             </div>
                         </template>
 
-                        <el-descriptions-item label="Category">{{
-                            capitalizeFirst(event.category)
-                        }}</el-descriptions-item>
-                        <el-descriptions-item label="Interested User">
+                        <el-descriptions-item :label="t('dialog.group_calendar.event_card.category')">
+                            {{ capitalizeFirst(event.category) }}
+                        </el-descriptions-item>
+                        <el-descriptions-item :label="t('dialog.group_calendar.event_card.interested_user')">
                             {{ event.interestedUserCount }}
                         </el-descriptions-item>
-                        <el-descriptions-item label="Close Instance After End">
+                        <el-descriptions-item :label="t('dialog.group_calendar.event_card.close_time')">
                             {{ event.closeInstanceAfterEndMinutes + ' min' }}
                         </el-descriptions-item>
-                        <el-descriptions-item label="Created Date">{{
-                            dayjs(event.createdAt).format('YYYY-MM-DD HH:mm')
-                        }}</el-descriptions-item>
-                        <el-descriptions-item label="Description">{{ event.description }}</el-descriptions-item>
+                        <el-descriptions-item :label="t('dialog.group_calendar.event_card.created')">
+                            {{ dayjs(event.createdAt).format('YYYY-MM-DD HH:mm') }}
+                        </el-descriptions-item>
+                        <el-descriptions-item :label="t('dialog.group_calendar.event_card.description')">
+                            {{ event.description }}
+                        </el-descriptions-item>
                     </el-descriptions>
                     <div class="event-title-content" slot="reference" @click="onGroupClick">
                         {{ event.title }}
@@ -50,9 +52,12 @@
 
 <script setup>
     import { computed } from 'vue';
+    import { useI18n } from 'vue-i18n-bridge';
     import dayjs from 'dayjs';
     import { storeToRefs } from 'pinia';
     import { useGroupStore } from '../../../stores';
+
+    const { t } = useI18n();
 
     const { cachedGroups } = storeToRefs(useGroupStore());
     const { showGroupDialog } = useGroupStore();

--- a/src/views/Tools/dialogs/GroupCalendarDialog.vue
+++ b/src/views/Tools/dialogs/GroupCalendarDialog.vue
@@ -69,7 +69,7 @@
                     <div class="search-container">
                         <el-input
                             v-model="searchQuery"
-                            placeholder="Search groups or events..."
+                            :placeholder="t('dialog.group_calendar.search_placeholder')"
                             clearable
                             size="small"
                             prefix-icon="el-icon-search"
@@ -97,7 +97,7 @@
                             </div>
                         </div>
                         <div v-else class="no-events">
-                            {{ searchQuery ? 'No matching events found' : 'No events this month' }}
+                            {{ searchQuery ? t('dialog.group_calendar.search_no_matching') : t('dialog.group_calendar.search_no_this_month') }}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Update japanese translation based on v2025.09.10 english version.

Also add localization support for Tools page.

This second commit depends on the commit above (a1d69e5).
(Because it adds the last comma in the dialog.group_calendar.header section in japanese translation.)

<img src="https://github.com/user-attachments/assets/807efa68-0f41-4323-8c6b-7990665c37b3" />
<img src="https://github.com/user-attachments/assets/b532be43-3ff3-4068-bc3e-defa52c99ea0" />

