### PR TITLE
Open gallery popup when redirecting to tools tab

### DIFF
--- a/src/components/dialogs/UserDialog/UserDialog.vue
+++ b/src/components/dialogs/UserDialog/UserDialog.vue
@@ -1889,7 +1889,7 @@
     const { friendLogTable } = storeToRefs(useFriendStore());
     const { getFriendRequest, handleFriendDelete } = useFriendStore();
     const { previousImagesDialogVisible, previousImagesTable } = storeToRefs(useGalleryStore());
-    const { clearInviteImageUpload, checkPreviousImageAvailable, showFullscreenImageDialog } = useGalleryStore();
+    const { clearInviteImageUpload, showGalleryDialog, checkPreviousImageAvailable, showFullscreenImageDialog } = useGalleryStore();
     const { isGameRunning } = storeToRefs(useGameStore());
     const { logout } = useAuthStore();
     const { cachedConfig } = storeToRefs(useAuthStore());
@@ -2313,9 +2313,10 @@
         } else if (command === 'Previous Instances') {
             showPreviousInstancesUserDialog(D.ref);
         } else if (command === 'Manage Gallery') {
-            // redirect to tools tab
+            // redirect to tools tab and open gallery dialog
             userDialog.value.visible = false;
             menuActiveIndex.value = 'tools';
+            showGalleryDialog();
         } else if (command === 'Invite To Group') {
             showInviteGroupDialog('', D.id);
             // } else if (command === 'Send Boop') {

--- a/src/views/Profile/Profile.vue
+++ b/src/views/Profile/Profile.vue
@@ -549,9 +549,10 @@
 
     const visits = ref(0);
 
-    // redirect to tools tab
+    // redirect to tools tab and open gallery dialog
     function showGalleryDialog() {
         menuActiveIndex.value = 'tools';
+        useGalleryStore();
     }
 
     function getVisits() {


### PR DESCRIPTION
The Gallery has been moved to the Tools page, but if simply open the Tools page when clicking "Manage VRC+ Images & Inventory" from my profile, it will have to click "Manage VRC+ Images & Inventory" in tools page again to open it, which is a double step.
To ensure that users are aware that the page has moved, I think it would be better to redirect them to the Tools page but keep the pop-up displayed as usual, ensuring the convenience of using the previous operations.

![Animation](https://github.com/user-attachments/assets/1ecf38cc-3bc4-4118-b452-c6405b4a2d38)
