### PR TITLE
Fix spelling of 'automaticly' to 'automatically' in the auto status change popup.

### DIFF
--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -1590,7 +1590,7 @@ export const useUserStore = defineStore('User', () => {
                 status: newStatus
             })
             .then(() => {
-                const text = `Status automaticly changed to ${newStatus}`;
+                const text = `Status automatically changed to ${newStatus}`;
                 if (AppDebug.errorNoty) {
                     AppDebug.errorNoty.close();
                 }


### PR DESCRIPTION
It was misspelled is all.