### PR TITLE
fix: prevent default autoUpdateVRCX config from being unexpectedly suppressed

### DIFF
--- a/src/stores/vrcxUpdater.js
+++ b/src/stores/vrcxUpdater.js
@@ -48,7 +48,7 @@ export const useVRCXUpdaterStore = defineStore('VRCXUpdater', () => {
         }
 
         const [autoUpdateVRCX, vrcxId] = await Promise.all([
-            configRepository.getString('VRCX_autoUpdateVRCX', 'Auto Download'),
+            configRepository.getString('VRCX_autoUpdateVRCX', state.autoUpdateVRCX),
             configRepository.getString('VRCX_id', '')
         ]);
 


### PR DESCRIPTION
fix: prevent default autoUpdateVRCX config from being unexpectedly suppressed

For OS dstros that should not rely on a 3rd-party updater,  a reasonable patch like 
```
--- a/src/stores/vrcxUpdater.js
+++ b/src/stores/vrcxUpdater.js
@@ -18,1 +18,1 @@
-        autoUpdateVRCX: 'Auto Download',
+        autoUpdateVRCX: 'Off',
```
should do the job. For example, for Arch Linux, people can apply a patch like this https://aur.archlinux.org/cgit/aur.git/tree/build.patch?h=vrcx

However, the default value in `state.autoUpdateVRCX` was suppressed by `configRepository.getString('VRCX_autoUpdateVRCX', '')`. This causes the default value in `state.autoUpdateVRCX` to be ignored and potentially misleading, which can confuse people and make the issue harder to trace.