### PR TITLE
Make sorting of group instances stable

### DIFF
--- a/src/shared/utils/compare.js
+++ b/src/shared/utils/compare.js
@@ -90,6 +90,22 @@ function compareByDisplayName(a, b) {
 }
 
 /**
+ * ascending
+ * @param {object} a
+ * @param {object} b
+ * @returns
+ */
+function compareById(a, b) {
+    if (
+        typeof a.id !== 'string' ||
+        typeof b.id !== 'string'
+    ) {
+        return 0;
+    }
+    return a.id.localeCompare(b.id);
+}
+
+/**
  *
  * @param {object} a
  * @param {object} b
@@ -252,6 +268,7 @@ export {
     compareByCreatedAtAscending,
     compareByUpdatedAt,
     compareByDisplayName,
+    compareById,
     compareByMemberCount,
     compareByPrivate,
     compareByStatus,

--- a/src/stores/instance.js
+++ b/src/stores/instance.js
@@ -9,6 +9,7 @@ import { instanceContentSettings } from '../shared/constants';
 import {
     checkVRChatCache,
     compareByDisplayName,
+    compareById,
     compareByLocationAt,
     displayLocation,
     getAvailablePlatforms,
@@ -727,17 +728,21 @@ export const useInstanceStore = defineStore('Instance', () => {
                 return -1;
             }
             // sort by number of users when no friends in instance
-            if (a.users.length === 0 && b.users.length === 0) {
+            if (a.users.length === 0 && b.users.length === 0 && a.ref?.userCount !== b.ref?.userCount) {
                 if (a.ref?.userCount < b.ref?.userCount) {
                     return 1;
                 }
                 return -1;
             }
             // sort by number of friends in instance
-            if (a.users.length < b.users.length) {
-                return 1;
+            if (a.users.length !== b.users.length) {
+                if (a.users.length < b.users.length) {
+                    return 1;
+                }
+                return -1;
             }
-            return -1;
+            // sort by id
+            return compareById(a, b)
         });
         D.rooms = rooms;
     }


### PR DESCRIPTION
Small change to make the instances listed under a group more stable by also sorting by id if everything else fails, as currently they can jump around a lot if there is many instances with same amount of players. 