### PR TITLE
Fix process detection bugs and resource leaks in AppApiElectron (GameHandler.cs)

### DIFF
--- a/Dotnet/AppApi/Electron/GameHandler.cs
+++ b/Dotnet/AppApi/Electron/GameHandler.cs
@@ -92,12 +92,8 @@ namespace VRCX
                     Arguments = $"-applaunch 438100 {arguments}",
                     UseShellExecute = false,
                 });
-                if (process?.ExitCode == 0)
-                {
-                    process.Dispose();
-                    return true;
-                }
                 process?.Dispose();
+                return true; // Steam accepted launch command (no exception thrown)
             }
             catch (Exception e)
             {
@@ -125,7 +121,7 @@ namespace VRCX
                     FileName = steamExecutable,
                     Arguments = $"-applaunch 438100 {arguments}",
                     UseShellExecute = false,
-                })?.Close();
+                })?.Dispose();
 
                 return true;
             }


### PR DESCRIPTION
**AppApiElectron.cs** changes:

Bugs:
* Fix VRChat detection by removing .exe from process name
* Fix StartGame ExitCode check that threw InvalidOperationException on running process
   - (can't check ExitCode on running process)

Performance:
* Use GetProcessesByName() to avoid scanning all processes
* Optimize IsSteamVRRunning to check exact matches first

Resource management:
* Add Process.Dispose() calls to prevent handle leaks
* Standardize on Dispose() instead of Close()