### PR TITLE
Add offline status for sortStatus method

### DIFF
--- a/src/shared/utils/friend.js
+++ b/src/shared/utils/friend.js
@@ -99,6 +99,8 @@ function sortStatus(a, b) {
                     return 1;
                 case 'busy':
                     return 1;
+                case 'offline':
+                    return 1;
             }
             break;
         case 'active':
@@ -108,6 +110,8 @@ function sortStatus(a, b) {
                 case 'ask me':
                     return 1;
                 case 'busy':
+                    return 1;
+                case 'offline':
                     return 1;
             }
             break;
@@ -119,6 +123,8 @@ function sortStatus(a, b) {
                     return -1;
                 case 'busy':
                     return 1;
+                case 'offline':
+                    return 1;
             }
             break;
         case 'busy':
@@ -128,6 +134,20 @@ function sortStatus(a, b) {
                 case 'active':
                     return -1;
                 case 'ask me':
+                    return -1;
+                case 'offline':
+                    return 1;
+            }
+            break;
+        case 'offline':
+            switch (a) {
+                case 'join me':
+                    return -1;
+                case 'active':
+                    return -1;
+                case 'ask me':
+                    return -1;
+                case 'busy':
                     return -1;
             }
             break;


### PR DESCRIPTION
## Summary
Make `sortStatus` method handle `offline` status.

## Background
In the FriendList view, sorting by Status does not work correctly, as offline friends may appear between online friends.
This PR fixes this behavior by handling the `offline` status in the `sortStatus` method.

## Screenshots
|Before|After|
|:--:|:--:|
|<img width="194" height="342" alt="image" src="https://github.com/user-attachments/assets/6e3b8721-035c-4ff9-8e02-9e280ead95d2" />|<img width="188" height="473" alt="image" src="https://github.com/user-attachments/assets/a7b40bd8-9c16-4537-b2c3-628140e6bd08" />|
