### PR TITLE
fix(memory leak): implement self-destruct timeout for notyMap

### DIFF
--- a/src/stores/notification.js
+++ b/src/stores/notification.js
@@ -75,7 +75,7 @@ export const useNotificationStore = defineStore('Notification', () => {
     const unseenNotifications = ref([]);
     const isNotificationsLoading = ref(false);
 
-    let notyMap = [];
+    let notyMap = {};
 
     watch(
         () => watchState.isLoggedIn,
@@ -613,11 +613,13 @@ export const useNotificationStore = defineStore('Notification', () => {
                 return;
             }
             notyMap[notyId] = noty.created_at;
-            if (notyMap.length > 100) {
-                notyMap = [];
-            }
         }
         const bias = new Date(Date.now() - 60000).toJSON();
+        for (const [notyId, createdAt] of Object.entries(notyMap)) {
+            if (createdAt < bias) {
+                delete notyMap[notyId];
+            }
+        }
         if (noty.created_at < bias) {
             // don't play noty if it's over 1min old
             return;


### PR DESCRIPTION
This PR resolves a memory leak issue in the notification system caused by the unbounded growth of the notyMap dictionary. During long sessions this map would grow indefinitely, leading to increased memory pressure over time.
This removes the entry if no longer needed, in this case being after 60 seconds.

```javascript
// The line that don't play sound after 60 seconds
const bias = new Date(Date.now() - 60000).toJSON();
if (noty.created_at < bias) {
    // don't play noty if it's over 1min old
    return;
}
```

Making this change not remove things that could be used later.