### PR TITLE
Colored private avatars lock icon

### DIFF
--- a/src/components/AvatarInfo.vue
+++ b/src/components/AvatarInfo.vue
@@ -1,7 +1,7 @@
 <template>
     <div @click="confirm" class="cursor-pointer w-fit align-top flex items-center">
         <span class="flex items-center"
-            >{{ avatarName }} <Lock v-if="avatarType && avatarType === '(own)'" class="h-4 w-4 mx-1"
+            >{{ avatarName }} <Lock v-if="avatarType && avatarType === '(own)'" class="h-4 w-4 mx-1" color="orange"
         /></span>
         <TooltipWrapper v-if="avatarTags">
             <template #content>


### PR DESCRIPTION
The white lock icon blends in when scanning through multiple entries, making it difficult to quickly understand that an avatar is private.
Adding color to the icon improves glanceability, similar to how it was handled in the previous UI.