### PR TITLE
feat(search): support prefix-based user and world ID search

### DIFF
--- a/src/stores/search.js
+++ b/src/stores/search.js
@@ -4,7 +4,7 @@ import { toast } from 'vue-sonner';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 
-import { compareByName, localeIncludes } from '../shared/utils';
+import { compareByName, compareByDisplayName, localeIncludes } from '../shared/utils';
 import { instanceRequest, userRequest } from '../api';
 import { groupRequest } from '../api/';
 import removeConfusables, { removeWhitespace } from '../service/confusables';
@@ -92,6 +92,25 @@ export const useSearchStore = defineStore('Search', () => {
             searchUserResults.value = Array.from(map.values());
             return args;
         });
+    }
+
+    async function searchUserByIdPrefix(prefix) {
+        const users = Array.from(userStore.cachedUsers.values()).filter((u) =>
+            u.id.startsWith(prefix)
+        );
+        if (users.length) {
+            users.sort(compareByDisplayName);
+            searchUserResults.value = users.slice(0, 10);
+            return;
+        }
+        if (prefix.length >= 40) {
+            try {
+                const args = await userRequest.getCachedUser({ userId: prefix });
+                searchUserResults.value = args.ref ? [args.ref] : [];
+            } catch {
+                searchUserResults.value = [];
+            }
+        }
     }
 
     function quickSearchRemoteMethod(query) {
@@ -422,6 +441,7 @@ export const useSearchStore = defineStore('Search', () => {
         directAccessParse,
         directAccessPaste,
         directAccessWorld,
-        verifyShortName
+        verifyShortName,
+        searchUserByIdPrefix
     };
 });

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -493,6 +493,12 @@
     }
 
     async function searchUser() {
+        const q = (searchText.value || '').trim();
+        if (q && q.startsWith('usr_')) {
+            searchUserResults.value = [];
+            await useSearchStore().searchUserByIdPrefix(q);
+            return;
+        }
         searchUserParams.value = {
             n: 10,
             offset: 0,
@@ -512,6 +518,31 @@
     function searchWorld(ref) {
         searchWorldOption.value = '';
         searchWorldCategoryIndex.value = ref?.index ?? null;
+        const q = (searchText.value || '').trim();
+        if (q && q.startsWith('wrld_')) {
+            const list = Array.from(cachedWorlds.values()).filter((w) => w.id.startsWith(q));
+            if (list.length) {
+                list.sort(compareByName);
+                searchWorldResults.value = list.slice(0, 10);
+                return;
+            }
+            if (q.length >= 41) {
+                isSearchWorldLoading.value = true;
+                worldRequest
+                    .getCachedWorld({ worldId: q })
+                    .finally(() => {
+                        isSearchWorldLoading.value = false;
+                    })
+                    .then((args) => {
+                        searchWorldResults.value = args.ref ? [args.ref] : [];
+                        return args;
+                    })
+                    .catch(() => {
+                        searchWorldResults.value = [];
+                    });
+                return;
+            }
+        }
         const params = {
             n: 10,
             offset: 0


### PR DESCRIPTION
- Add searchUserByIdPrefix to enable quick lookup by user ID prefix (usr_).
- In the search view, when the query starts with usr_ or wrld_, first match cached records whose IDs start with the prefix.
- If no cached matches and the ID length is a full UUID, attempt to fetch the entry via API.
- Preserve existing name/tag search behavior for non-prefixed queries.
- Improves efficiency when searching with known ID fragments.