### PR TITLE
Remove outline from delete buttons in avatar database provider UI

### DIFF
--- a/src/views/Settings/dialogs/AvatarProviderDialog.vue
+++ b/src/views/Settings/dialogs/AvatarProviderDialog.vue
@@ -13,7 +13,7 @@
                     style="margin-top: 5px"
                     @change="saveAvatarProviderList">
                     <template #actions>
-                        <Trash2 class="cursor-pointer opacity-60 hover:opacity-100" @click="removeAvatarProvider(provider)" />
+                        <Trash2 class="cursor-pointer opacity-80 hover:opacity-100" @click="removeAvatarProvider(provider)" />
                     </template>
                 </InputGroupAction>
 


### PR DESCRIPTION
With the new UI, using outline style buttons for deleting provider entries causes the buttons to extend beyond the textbox borders:

<img width="696" height="302" alt="1" src="https://github.com/user-attachments/assets/65526f93-6302-4abe-8453-8455d5919b2d" />

This changes the button styling so it appears as an integrated part of the input component instead:

<img width="681" height="286" alt="2" src="https://github.com/user-attachments/assets/dfc240b7-aef6-4b8e-ba00-e6dcab1eaf9d" />