### PR TITLE
Make avatar thumbnail display consistent with other images

### DIFF
--- a/src/components/dialogs/AvatarDialog/AvatarDialog.vue
+++ b/src/components/dialogs/AvatarDialog/AvatarDialog.vue
@@ -13,7 +13,7 @@
                         :src="avatarDialog.ref.thumbnailImageUrl"
                         class="cursor-pointer"
                         @click="showFullscreenImageDialog(avatarDialog.ref.imageUrl)"
-                        style="width: 160px; height: 120px; border-radius: 12px"
+                        style="width: 160px; height: 120px; border-radius: 12px; object-fit: cover"
                         loading="lazy" />
                 </div>
                 <div style="flex: 1; display: flex; align-items: flex-start; margin-left: 15px">


### PR DESCRIPTION
Avatar thumbnails in the dialog were displaying without `object-fit: cover`, causing them to appear squished when the source image didn't match the 4:3 aspect ratio of the container.

This adds `object-fit: cover` to match the behavior of all other image thumbnails in the app.