### PR TITLE
Fix attribution header for OpenAI translation

### DIFF
--- a/src/stores/settings/advanced.js
+++ b/src/stores/settings/advanced.js
@@ -681,6 +681,7 @@ export const useAdvancedSettingsStore = defineStore('AdvancedSettings', () => {
 
         const headers = {
             'Content-Type': 'application/json',
+            Referer: 'https://vrcx.app',
             'HTTP-Referer': 'https://vrcx.app',
             'X-Title': 'VRCX'
         };


### PR DESCRIPTION
Closes #1622.
This fixes the header used for app attribution in AI providers, like OpenRouter.

Over time, this will also allow [displaying](https://openrouter.ai/apps?url=https://vrcx.app/) the total usage of this feature on AI providers that support these kinds of statistics.