### PR TITLE
fix: edit-note-and-memo-dialog overflow

### DIFF
--- a/src/components/dialogs/UserDialog/EditNoteAndMemoDialog.vue
+++ b/src/components/dialogs/UserDialog/EditNoteAndMemoDialog.vue
@@ -6,36 +6,39 @@
                 if (!open) cancel();
             }
         ">
-        <DialogContent class="x-dialog sm:max-w-125 translate-y-0" style="top: 30vh" :show-close-button="false">
+        <DialogContent class="x-dialog sm:max-w-125 translate-y-0" style="top: 10vh" :show-close-button="false">
             <DialogHeader>
                 <DialogTitle>{{ t('dialog.user.note_memo.header') }}</DialogTitle>
             </DialogHeader>
 
-            <template v-if="!hideUserNotes || (hideUserNotes && hideUserMemos)">
-                <span class="name my-2">{{ t('dialog.user.info.note') }}</span>
-                <br />
-                <InputGroupTextareaField
-                    v-model="note"
-                    :autosize="{ minRows: 6, maxRows: 20 }"
-                    :maxlength="256"
-                    :rows="6"
-                    :placeholder="t('dialog.user.info.note_placeholder')"
-                    input-class="text-xs resize-none"
-                    class="my-2"
-                    show-count />
-            </template>
-            <template v-if="!hideUserMemos || (hideUserNotes && hideUserMemos)">
-                <span class="name">{{ t('dialog.user.info.memo') }}</span>
-                <InputGroupTextareaField
-                    v-model="memo"
-                    class="text-xs mt-2"
-                    :rows="6"
-                    :placeholder="t('dialog.user.info.memo_placeholder')"
-                    input-class="resize-none min-h-0" />
-            </template>
+            <div>
+                <template v-if="!hideUserNotes || (hideUserNotes && hideUserMemos)">
+                    <span class="name">{{ t('dialog.user.info.note') }}</span>
+                    <InputGroupTextareaField
+                        v-model="note"
+                        :autosize="{ minRows: 6, maxRows: 20 }"
+                        :maxlength="256"
+                        :rows="6"
+                        :placeholder="t('dialog.user.info.note_placeholder')"
+                        input-class="text-xs resize-none"
+                        class="my-2"
+                        show-count />
+                </template>
+                <template v-if="!hideUserMemos || (hideUserNotes && hideUserMemos)">
+                    <span class="name">{{ t('dialog.user.info.memo') }}</span>
+                    <InputGroupTextareaField
+                        v-model="memo"
+                        class="text-xs mt-2"
+                        :rows="6"
+                        :placeholder="t('dialog.user.info.memo_placeholder')"
+                        input-class="resize-none min-h-0" />
+                </template>
+            </div>
 
             <DialogFooter>
-                <Button variant="secondary" @click="cancel" class="mr-2">{{ t('dialog.user.note_memo.cancel') }}</Button>
+                <Button variant="secondary" @click="cancel" class="mr-2">{{
+                    t('dialog.user.note_memo.cancel')
+                }}</Button>
                 <Button @click="saveChanges">{{ t('dialog.user.note_memo.confirm') }}</Button>
             </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Before fix

<img width="1898" height="1067" alt="image" src="https://github.com/user-attachments/assets/e8ba20df-728f-42fd-b304-4a1b854e22c7" />

## After fix

<img width="1898" height="1067" alt="image" src="https://github.com/user-attachments/assets/071af424-9eea-4bb4-9aa1-fdab2eb304d6" />
