### PR TITLE
Fixed overflowing text in a cell drawing over the adjacent cell

### DIFF
--- a/src/components/ui/table/TableCell.vue
+++ b/src/components/ui/table/TableCell.vue
@@ -11,7 +11,7 @@
         data-slot="table-cell"
         :class="
             cn(
-                'p-2 align-middle whitespace-nowrap in-[.is-compact-table]:py-1! in-[.is-comfortable-table]:py-1.5! [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5',
+                'p-2 align-middle whitespace-nowrap truncate in-[.is-compact-table]:py-1! in-[.is-comfortable-table]:py-1.5! [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5',
                 props.class
             )
         ">


### PR DESCRIPTION
Fixed overflowing text in a cell drawing over the adjacent cell.

Before:
<img width="853" height="377" alt="image" src="https://github.com/user-attachments/assets/37246929-5e3a-433f-bcb2-d33eec896b40" />

After:
<img width="940" height="549" alt="image" src="https://github.com/user-attachments/assets/6b886c60-195e-4128-a8ce-6ae8bfc2c6c6" />
