### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -18,7 +18,7 @@ jobs:
             version: ${{ steps.version.outputs.version }}
             date: ${{ steps.version.outputs.date }}
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
             - id: version
               run: |
                   export FILENAME="$(cat Version)"
@@ -33,7 +33,7 @@ jobs:
                 shell: bash
         needs: [set_version, build_node]
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
             - name: Setup .NET 10
               uses: actions/setup-dotnet@v5
               with:
@@ -43,7 +43,7 @@ jobs:
                   echo "${{ needs.set_version.outputs.version }}" > Version
                   echo "!define PRODUCT_VERSION_FROM_FILE \"${{ needs.set_version.outputs.date }}.0\"" > Installer/version_define.nsh
                   cat Version
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: ~/.nuget/packages
                   key: ${{ runner.os }}-nuget-${{ hashFiles('**/Dotnet/VRCX-Cef.csproj') }}
@@ -57,14 +57,14 @@ jobs:
                   echo "sign=${{ secrets.AZURE_CLIENT_ID != '' }}" >> $GITHUB_OUTPUT
             - name: Azure login
               if: steps.check_sign.outputs.sign == 'true'
-              uses: azure/login@v2
+              uses: azure/login@v3
               with:
                   client-id: ${{ secrets.AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.AZURE_TENANT_ID }}
                   subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
             - name: Sign Dotnet executables
               if: steps.check_sign.outputs.sign == 'true'
-              uses: azure/trusted-signing-action@v0
+              uses: azure/trusted-signing-action@v1
               with:
                   azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
                   azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -91,14 +91,14 @@ jobs:
                       ${{ github.workspace }}\build\Cef\VRCX.exe
 
             - name: Download Cef-html artifacts
-              uses: actions/download-artifact@v6
+              uses: actions/download-artifact@v8
               with:
                   name: Cef-html
                   path: build/Cef/html
             - name: Install NSIS
               run: choco install nsis -y
             - name: Create NSIS installer
-              uses: joncloud/makensis-action@v4
+              uses: joncloud/makensis-action@v5
               with:
                   script-file: Installer/installer.nsi
                   additional-plugin-paths: Installer/Plugins
@@ -108,7 +108,7 @@ jobs:
                   echo "Setup FileName: ${file_name}"
                   mv Installer/VRCX_Setup.exe $file_name
             - name: Sign Cef setup
-              uses: azure/trusted-signing-action@v0
+              uses: azure/trusted-signing-action@v1
               if: steps.check_sign.outputs.sign == 'true'
               with:
                   azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -124,12 +124,12 @@ jobs:
                       ${{ github.workspace }}\VRCX_${{ needs.set_version.outputs.version }}_Setup.exe
 
             - name: Upload Cef dotnet artifacts
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Cef-Release
                   path: build/Cef
             - name: Upload setup artifact
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Cef-Setup
                   path: VRCX_${{ needs.set_version.outputs.version }}_Setup.exe
@@ -138,7 +138,7 @@ jobs:
         runs-on: ubuntu-latest
         needs: set_version
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
             - name: Setup .NET 9
               uses: actions/setup-dotnet@v5
               with:
@@ -147,7 +147,7 @@ jobs:
               run: |
                   echo "${{ needs.set_version.outputs.version }}" > Version
                   cat Version
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: ~/.nuget/packages
                   key: ${{ runner.os }}-nuget-${{ hashFiles('**/Dotnet/VRCX-Electron.csproj') }}-${{ hashFiles('**/Dotnet/VRCX-Electron-arm64.csproj') }}
@@ -156,7 +156,7 @@ jobs:
             - name: Build Electron x64 .NET Application
               run: dotnet build 'Dotnet/VRCX-Electron.csproj' -p:Configuration=Release -p:WarningLevel=0 -p:Platform=x64 -p:PlatformTarget=x64 -p:RestorePackagesConfig=true -t:"Restore;Clean;Build" -m -a x64
             - name: Upload Electron x64 dotnet artifacts
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Electron-Release-Linux-x64
                   path: build/Electron
@@ -168,7 +168,7 @@ jobs:
             - name: Build Electron arm64 .NET Application
               run: dotnet build 'Dotnet/VRCX-Electron-arm64.csproj' -p:Configuration=Release -p:WarningLevel=0 -p:Platform=arm64 -p:PlatformTarget=arm64 -p:RestorePackagesConfig=true -t:"Restore;Clean;Build" -m -a arm64
             - name: Upload Electron arm64 dotnet artifacts
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Electron-Release-Linux-arm64
                   path: build/Electron
@@ -177,7 +177,7 @@ jobs:
         runs-on: macos-latest
         needs: set_version
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
             - name: Setup .NET 9
               uses: actions/setup-dotnet@v5
               with:
@@ -186,7 +186,7 @@ jobs:
               run: |
                   echo "${{ needs.set_version.outputs.version }}" > Version
                   cat Version
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: ~/.nuget/packages
                   key: ${{ runner.os }}-nuget-${{ hashFiles('**/Dotnet/VRCX-Electron.csproj') }}-${{ hashFiles('**/Dotnet/VRCX-Electron-arm64.csproj') }}
@@ -195,7 +195,7 @@ jobs:
             - name: Build Electron x64 .NET Application
               run: dotnet build 'Dotnet/VRCX-Electron.csproj' -p:Configuration=Release -p:WarningLevel=0 -p:Platform=x64 -p:PlatformTarget=x64 -p:RestorePackagesConfig=true -t:"Restore;Clean;Build" -m -a x64
             - name: Upload Electron x64 .NET artifacts
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Electron-Release-macOS-x64
                   path: build/Electron
@@ -207,7 +207,7 @@ jobs:
             - name: Build Electron arm64 .NET Application
               run: dotnet build 'Dotnet/VRCX-Electron-arm64.csproj' -p:Configuration=Release -p:WarningLevel=0 -p:Platform=arm64 -p:PlatformTarget=arm64 -p:RestorePackagesConfig=true -t:"Restore;Clean;Build" -m -a arm64
             - name: Upload Electron arm64 dotnet artifacts
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Electron-Release-macOS-arm64
                   path: build/Electron
@@ -216,20 +216,20 @@ jobs:
         runs-on: ubuntu-latest
         needs: [set_version, build_dotnet_linux]
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
             - name: Set version
               run: |
                   echo "${{ needs.set_version.outputs.version }}" > Version
                   cat Version
             - name: Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: lts/*
             - name: Get npm cache directory
               id: npm-cache-dir
               shell: bash
               run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
               with:
                   path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -243,7 +243,7 @@ jobs:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SentryAuthToken }}
               run: npm run prod
             - name: Upload Cef-html artifacts
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Cef-html
                   path: build/html
@@ -253,27 +253,27 @@ jobs:
                   SENTRY_AUTH_TOKEN: ${{ secrets.SentryAuthToken }}
               run: npm run prod-linux
             - name: Download Electron x64 dotnet artifacts
-              uses: actions/download-artifact@v6
+              uses: actions/download-artifact@v8
               with:
                   name: Electron-Release-Linux-x64
                   path: build/Electron
             - name: Build x64 AppImage
               run: npm run build-electron
             - name: Upload Electron x64 AppImage artifacts
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Electron-AppImage-x64
                   path: 'build/VRCX_${{ needs.set_version.outputs.version }}_x64.AppImage'
 
             - name: Download Electron arm64 dotnet artifacts
-              uses: actions/download-artifact@v6
+              uses: actions/download-artifact@v8
               with:
                   name: Electron-Release-Linux-arm64
                   path: build/Electron
             - name: Build arm64 AppImage
               run: npm run build-electron-arm64
             - name: Upload Electron arm64 AppImage artifacts
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Electron-AppImage-arm64
                   path: 'build/VRCX_${{ needs.set_version.outputs.version }}_arm64.AppImage'
@@ -282,20 +282,20 @@ jobs:
         runs-on: macos-latest
         needs: [set_version, build_dotnet_macos]
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
             - name: Set version
               run: |
                   echo "${{ needs.set_version.outputs.version }}" > Version
                   cat Version
             - name: Use Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: lts/*
             - name: Get npm cache directory
               id: npm-cache-dir
               shell: bash
               run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
               with:
                   path: ${{ steps.npm-cache-dir.outputs.dir }}
@@ -308,14 +308,14 @@ jobs:
               run: npm run prod-linux --arch=x64
 
             - name: Download x64 Electron dotnet artifacts
-              uses: actions/download-artifact@v6
+              uses: actions/download-artifact@v8
               with:
                   name: Electron-Release-macOS-x64
                   path: build/Electron
             - name: Build x64 macOS .dmg
               run: npm run build-electron
             - name: Upload x64 Electron macOS artifacts
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Electron-MacDmg-x64
                   path: 'build/VRCX_${{ needs.set_version.outputs.version }}_x64.dmg'
@@ -328,14 +328,14 @@ jobs:
               run: npm run prod-linux --arch=arm64
 
             - name: Download arm64 Electron dotnet artifacts
-              uses: actions/download-artifact@v6
+              uses: actions/download-artifact@v8
               with:
                   name: Electron-Release-macOS-arm64
                   path: build/Electron
             - name: Build arm64 macOS .dmg
               run: npm run build-electron-arm64
             - name: Upload arm64 Electron macOS artifacts
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: Electron-MacDmg-arm64
                   path: 'build/VRCX_${{ needs.set_version.outputs.version }}_arm64.dmg'
@@ -353,16 +353,16 @@ jobs:
             ]
         steps:
             - name: Download Cef-Setup artifacts
-              uses: actions/download-artifact@v6
+              uses: actions/download-artifact@v8
               with:
                   name: Cef-Setup
             - name: Download Cef dotnet artifacts
-              uses: actions/download-artifact@v6
+              uses: actions/download-artifact@v8
               with:
                   name: Cef-Release
                   path: build/Cef
             - name: Download Cef-html artifacts
-              uses: actions/download-artifact@v6
+              uses: actions/download-artifact@v8
               with:
                   name: Cef-html
                   path: build/Cef/html
@@ -375,7 +375,7 @@ jobs:
                   mv ${file_name} ../../${file_name}
                   echo "Zip FileName: ${file_name}"
             - name: Upload Zip artifact
-              uses: actions/upload-artifact@v5
+              uses: actions/upload-artifact@v7
               with:
                   name: VRCX-Zip
                   path: 'VRCX_${{ needs.set_version.outputs.version }}.zip'

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -98,7 +98,7 @@ jobs:
             - name: Install NSIS
               run: choco install nsis -y
             - name: Create NSIS installer
-              uses: joncloud/makensis-action@v5
+              uses: joncloud/makensis-action@v5.0
               with:
                   script-file: Installer/installer.nsi
                   additional-plugin-paths: Installer/Plugins


### PR DESCRIPTION
Node.js 20 is [being deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on GitHub Actions runners (June 2, 2026 default switch and September 16, 2026 removal).

We can already see some warnings when running the build workflow: https://github.com/monolithic827/VRCX/actions/runs/23692183135
The updated actions use Node.js 24 on the runner and have clean output: https://github.com/monolithic827/VRCX/actions/runs/23691943929