### PR TITLE
Vrcx fixFix FriendsLocationsCard - Use ctx.state to show status on start

### DIFF
--- a/src/views/FriendsLocations/components/FriendsLocationsCard.vue
+++ b/src/views/FriendsLocations/components/FriendsLocationsCard.vue
@@ -90,22 +90,6 @@
     }));
 
     const statusDotClass = computed(() => {
-            // friend.ref can (most likely) have old data from a previous session. Instead we should call ctx.state directly
-            // So states of the users will be shown correctly on VRCX boot..
-        if (!props.friend.pendingOffline && props.friend.state === 'active') {
-            const friendStatus = props.friend.ref?.status;
-            if (friendStatus === 'join me') {
-                return 'friend-card__status-dot--active-join';
-            }
-            if (friendStatus === 'ask me') {
-                return 'friend-card__status-dot--active-ask';
-            }
-            if (friendStatus === 'busy') {
-                return 'friend-card__status-dot--active-busy';
-            }
-            return 'friend-card__status-dot--active';
-        }
-
         const status = userStatusClass(props.friend.ref, props.friend.pendingOffline);
 
         if (status?.joinme) {
@@ -116,7 +100,7 @@
         }
         // sometimes appearing and sometimes disappearing
         if (status?.active) {
-            const friendStatus = props.friend.ref?.status;
+            const friendStatus = props.friend.status;
             if (friendStatus === 'join me') {
                 return 'friend-card__status-dot--active-join';
             }

--- a/src/views/FriendsLocations/components/FriendsLocationsCard.vue
+++ b/src/views/FriendsLocations/components/FriendsLocationsCard.vue
@@ -90,6 +90,22 @@
     }));
 
     const statusDotClass = computed(() => {
+            // friend.ref can (most likely) have old data from a previous session. Instead we should call ctx.state directly
+            // So states of the users will be shown correctly on VRCX boot..
+        if (!props.friend.pendingOffline && props.friend.state === 'active') {
+            const friendStatus = props.friend.ref?.status;
+            if (friendStatus === 'join me') {
+                return 'friend-card__status-dot--active-join';
+            }
+            if (friendStatus === 'ask me') {
+                return 'friend-card__status-dot--active-ask';
+            }
+            if (friendStatus === 'busy') {
+                return 'friend-card__status-dot--active-busy';
+            }
+            return 'friend-card__status-dot--active';
+        }
+
         const status = userStatusClass(props.friend.ref, props.friend.pendingOffline);
 
         if (status?.joinme) {
@@ -100,7 +116,7 @@
         }
         // sometimes appearing and sometimes disappearing
         if (status?.active) {
-            const friendStatus = props.friend.status;
+            const friendStatus = props.friend.ref?.status;
             if (friendStatus === 'join me') {
                 return 'friend-card__status-dot--active-join';
             }


### PR DESCRIPTION
This fixes an issue where friends marked as "Active" were shown as offline with no status. It uses ctx.state directly to initialize each friend’s state on startup, so all statuses are correct immediately without needing to open and close profiles.

The issue before was that friend.ref had cached data on start / old session data. with direct ctx.state we can get a fresh server response. 

<img width="1274" height="773" alt="image" src="https://github.com/user-attachments/assets/751f9225-d14d-4eb9-b901-f4d0a62537e2" />

Excuse the revert spam. i did not sleep at all.