### PR TITLE
Vrcx fixThis refactor improves how statuses are displayed.

### DIFF
--- a/src/components/dialogs/UserDialog/UserSummaryHeader.vue
+++ b/src/components/dialogs/UserDialog/UserSummaryHeader.vue
@@ -35,7 +35,7 @@
                         <template #content>
                             <span>{{ getUserStateText(userDialog.ref) }}</span>
                         </template>
-                        <i class="x-user-status" :class="userStatusClass(userDialog.ref)"></i>
+                        <i class="x-user-status" :class="dialogStatusClass"></i>
                     </TooltipWrapper>
                     <template v-if="userDialog.previousDisplayNames.length > 0">
                         <TooltipWrapper side="bottom">
@@ -263,7 +263,7 @@
 
 <script setup>
     import { Apple, ChevronDown, IdCard, Image, Monitor, Shield, Smartphone, UserPlus, Users } from 'lucide-vue-next';
-    import { ref, watch } from 'vue';
+    import { computed, ref, watch } from 'vue';
     import { storeToRefs } from 'pinia';
     import { useI18n } from 'vue-i18n';
 
@@ -306,6 +306,20 @@
 
     const { showFullscreenImageDialog } = useGalleryStore();
     const { userImage, userStatusClass } = useUserDisplay();
+
+    // Use ctx.state instead of ref.state to determine active status...
+    // problem it would cause userStatusClass to return the wrong class so we fix that here.
+    const dialogStatusClass = computed(() => {
+        const r = userDialog.value?.ref;
+        if (!r) return {};
+        if (r.state === 'active') {
+            if (r.status === 'join me') return { 'active-joinme': true };
+            if (r.status === 'ask me') return { 'active-askme': true };
+            if (r.status === 'busy') return { 'active-busy': true };
+            return { active: true };
+        }
+        return userStatusClass(r);
+    });
 
     const profileImageError = ref(false);
     const userIconError = ref(false);

--- a/src/styles/status-icon.css
+++ b/src/styles/status-icon.css
@@ -15,8 +15,35 @@
 }
 
 .status-icon.active::after {
-    background: var(--status-active);
-    box-shadow: 0 0 0 2px var(--background);
+    background: transparent;
+    border: 2px solid var(--status-online);
+    box-shadow:
+        0 0 0 1.5px var(--background),
+        0 0 4px color-mix(in oklch, var(--status-online) 40%, transparent);
+}
+
+.status-icon.active-joinme::after {
+    background: transparent;
+    border: 2px solid var(--status-joinme);
+    box-shadow:
+        0 0 0 1.5px var(--background),
+        0 0 4px color-mix(in oklch, var(--status-joinme) 40%, transparent);
+}
+
+.status-icon.active-askme::after {
+    background: transparent;
+    border: 2px solid var(--status-askme);
+    box-shadow:
+        0 0 0 1.5px var(--background),
+        0 0 4px color-mix(in oklch, var(--status-askme) 40%, transparent);
+}
+
+.status-icon.active-busy::after {
+    background: transparent;
+    border: 2px solid var(--status-busy);
+    box-shadow:
+        0 0 0 1.5px var(--background),
+        0 0 4px color-mix(in oklch, var(--status-busy) 40%, transparent);
 }
 
 .status-icon.online::after {
@@ -115,7 +142,23 @@ i.x-status-icon::after {
 }
 
 i.x-user-status.active {
-    background: var(--status-active);
+    background: transparent;
+    border: 2px solid var(--status-online);
+}
+
+i.x-user-status.active-joinme {
+    background: transparent;
+    border: 2px solid var(--status-joinme);
+}
+
+i.x-user-status.active-askme {
+    background: transparent;
+    border: 2px solid var(--status-askme);
+}
+
+i.x-user-status.active-busy {
+    background: transparent;
+    border: 2px solid var(--status-busy);
 }
 
 i.x-user-status.online {

--- a/src/views/FriendsLocations/components/FriendsLocationsCard.vue
+++ b/src/views/FriendsLocations/components/FriendsLocationsCard.vue
@@ -90,22 +90,6 @@
     }));
 
     const statusDotClass = computed(() => {
-            // friend.ref can (most likely) have old data from a previous session. Instead we should call ctx.state directly
-            // So states of the users will be shown correctly on VRCX boot..
-        if (!props.friend.pendingOffline && props.friend.state === 'active') {
-            const friendStatus = props.friend.ref?.status;
-            if (friendStatus === 'join me') {
-                return 'friend-card__status-dot--active-join';
-            }
-            if (friendStatus === 'ask me') {
-                return 'friend-card__status-dot--active-ask';
-            }
-            if (friendStatus === 'busy') {
-                return 'friend-card__status-dot--active-busy';
-            }
-            return 'friend-card__status-dot--active';
-        }
-
         const status = userStatusClass(props.friend.ref, props.friend.pendingOffline);
 
         if (status?.joinme) {
@@ -116,7 +100,7 @@
         }
         // sometimes appearing and sometimes disappearing
         if (status?.active) {
-            const friendStatus = props.friend.ref?.status;
+            const friendStatus = props.friend.status;
             if (friendStatus === 'join me') {
                 return 'friend-card__status-dot--active-join';
             }

--- a/src/views/FriendsLocations/components/FriendsLocationsCard.vue
+++ b/src/views/FriendsLocations/components/FriendsLocationsCard.vue
@@ -90,6 +90,22 @@
     }));
 
     const statusDotClass = computed(() => {
+            // friend.ref can (most likely) have old data from a previous session. Instead we should call ctx.state directly
+            // So states of the users will be shown correctly on VRCX boot..
+        if (!props.friend.pendingOffline && props.friend.state === 'active') {
+            const friendStatus = props.friend.ref?.status;
+            if (friendStatus === 'join me') {
+                return 'friend-card__status-dot--active-join';
+            }
+            if (friendStatus === 'ask me') {
+                return 'friend-card__status-dot--active-ask';
+            }
+            if (friendStatus === 'busy') {
+                return 'friend-card__status-dot--active-busy';
+            }
+            return 'friend-card__status-dot--active';
+        }
+
         const status = userStatusClass(props.friend.ref, props.friend.pendingOffline);
 
         if (status?.joinme) {
@@ -100,7 +116,7 @@
         }
         // sometimes appearing and sometimes disappearing
         if (status?.active) {
-            const friendStatus = props.friend.status;
+            const friendStatus = props.friend.ref?.status;
             if (friendStatus === 'join me') {
                 return 'friend-card__status-dot--active-join';
             }

--- a/src/views/Sidebar/components/FriendItem.vue
+++ b/src/views/Sidebar/components/FriendItem.vue
@@ -5,7 +5,7 @@
         <template v-if="friend.ref">
             <div
                 class="relative inline-block flex-none size-9 mr-2.5"
-                :class="isFriendActiveOrOffline ? undefined : userStatusClass(friend.ref, friend.pendingOffline)">
+                :class="friendStatusClass">
                 <Avatar class="size-full rounded-full">
                     <AvatarImage :src="userImage(friend.ref, true)" class="object-cover" />
                     <AvatarFallback>
@@ -96,6 +96,22 @@
 
     const isFriendTraveling = computed(() => props.friend.ref?.location === 'traveling');
     const isFriendActiveOrOffline = computed(() => props.friend.state === 'active' || props.friend.state === 'offline');
+
+    // we show status dots for active friends using circles instead of status--active to differ them from online friends.
+    // ctx.state is reliable at login... but ref.state may be stale until bulkRefreshFriends finishes. here again we check for ctx.state
+    // should note this is a wip refactor for online statuses. for now everything should work fine!
+    const friendStatusClass = computed(() => {
+        if (props.friend.state === 'offline') return undefined;
+        if (!props.friend.pendingOffline && props.friend.state === 'active') {
+            const refStatus = props.friend.ref?.status;
+            if (refStatus === 'join me') return { 'status-icon': true, 'active-joinme': true };
+            if (refStatus === 'ask me') return { 'status-icon': true, 'active-askme': true };
+            if (refStatus === 'busy') return { 'status-icon': true, 'active-busy': true };
+            return { 'status-icon': true, active: true };
+        }
+        return userStatusClass(props.friend.ref, props.friend.pendingOffline);
+    });
+
     const epoch = computed(() =>
         isFriendTraveling.value ? props.friend.ref?.$travelingToTime : props.friend.ref?.$location_at
     );


### PR DESCRIPTION
This refactor improves how statuses are displayed. :)

Sidebar
<img width="380" height="546" alt="image" src="https://github.com/user-attachments/assets/cecc361e-7426-44ee-ab82-5e2a688b1707" />

Profile Modal

<img width="364" height="189" alt="image" src="https://github.com/user-attachments/assets/fe80ef5c-83c0-45a0-9991-936b6bbb54af" />


1. The correct web/mobile status is now shown in the Active sidebar. Previously, no status was shown until opening a profile, which caused confusion.
2. The profile modal no longer shows a yellow dot that required hovering to reveal the actual status. It now uses the new status circles, which directly show Active, Join Me, Ask Me, or Busy, matching the VRChat website.

This is a follow up improvement to the previous PR and makes the UI clearer and easier to use for end users.

Please review `status-icon.css`. As far as I can tell, there was no proper CSS for these icons besides the glow version, so it may need to be rewritten. I am not fully sure at this point.

I did not delete `--status-active` because it is still referenced in the overlay. I did not want to touch the overlay in this PR, so I will probably open a follow up later.

I use `ctx.state` for the updates, same as in the previous PR #1732.
