### PR TITLE
Updated the Friends Card to be more compact and user friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ bun.lock
 AGENTS.md
 AI_GUIDE.md
 CLAUDE.md
-coverage/
+coverage/package-lock.json 

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ bun.lock
 AGENTS.md
 AI_GUIDE.md
 CLAUDE.md
-coverage/package-lock.json 
+coverage/

--- a/src/views/FriendsLocations/components/FriendsLocationsCard.vue
+++ b/src/views/FriendsLocations/components/FriendsLocationsCard.vue
@@ -79,14 +79,14 @@
         }
     });
 
-    const avatarSize = computed(() => Math.max(36, 46 * props.cardScale));
+    const avatarSize = computed(() => Math.max(28, 32 * props.cardScale));
 
     const cardStyle = computed(() => ({
         '--card-scale': props.cardScale,
         '--card-spacing': props.cardSpacing,
         cursor: 'pointer',
-        padding: `${54 * props.cardScale * props.cardSpacing}px`,
-        paddingBottom: `${36 * props.cardScale * props.cardSpacing}px !important`
+        padding: `${8 * props.cardScale}px`,
+        paddingBottom: `${6 * props.cardScale}px !important`
     }));
 
     const statusDotClass = computed(() => {
@@ -220,7 +220,7 @@
     }
 
     .friend-card__name {
-        font-size: calc(18px * var(--card-scale));
+        font-size: calc(13px * var(--card-scale));
     }
 
     .friend-card__signature {
@@ -234,7 +234,7 @@
     }
 
     .friend-card__world {
-        min-height: calc(40px * var(--card-scale));
+        min-height: calc(24px * var(--card-scale));
         padding: calc(7px * var(--card-scale)) calc(8px * var(--card-scale));
         border-radius: calc(var(--radius-lg) * var(--card-scale));
         font-size: calc(12px * var(--card-scale));

--- a/src/views/FriendsLocations/components/FriendsLocationsCard.vue
+++ b/src/views/FriendsLocations/components/FriendsLocationsCard.vue
@@ -90,22 +90,6 @@
     }));
 
     const statusDotClass = computed(() => {
-            // friend.ref can (most likely) have old data from a previous session. Instead we should call ctx.state directly
-            // So states of the users will be shown correctly on VRCX boot..
-        if (!props.friend.pendingOffline && props.friend.state === 'active') {
-            const friendStatus = props.friend.ref?.status;
-            if (friendStatus === 'join me') {
-                return 'friend-card__status-dot--active-join';
-            }
-            if (friendStatus === 'ask me') {
-                return 'friend-card__status-dot--active-ask';
-            }
-            if (friendStatus === 'busy') {
-                return 'friend-card__status-dot--active-busy';
-            }
-            return 'friend-card__status-dot--active';
-        }
-
         const status = userStatusClass(props.friend.ref, props.friend.pendingOffline);
 
         if (status?.joinme) {
@@ -116,7 +100,7 @@
         }
         // sometimes appearing and sometimes disappearing
         if (status?.active) {
-            const friendStatus = props.friend.ref?.status;
+            const friendStatus = props.friend.status;
             if (friendStatus === 'join me') {
                 return 'friend-card__status-dot--active-join';
             }

--- a/src/views/FriendsLocations/components/FriendsLocationsCard.vue
+++ b/src/views/FriendsLocations/components/FriendsLocationsCard.vue
@@ -90,6 +90,22 @@
     }));
 
     const statusDotClass = computed(() => {
+            // friend.ref can (most likely) have old data from a previous session. Instead we should call ctx.state directly
+            // So states of the users will be shown correctly on VRCX boot..
+        if (!props.friend.pendingOffline && props.friend.state === 'active') {
+            const friendStatus = props.friend.ref?.status;
+            if (friendStatus === 'join me') {
+                return 'friend-card__status-dot--active-join';
+            }
+            if (friendStatus === 'ask me') {
+                return 'friend-card__status-dot--active-ask';
+            }
+            if (friendStatus === 'busy') {
+                return 'friend-card__status-dot--active-busy';
+            }
+            return 'friend-card__status-dot--active';
+        }
+
         const status = userStatusClass(props.friend.ref, props.friend.pendingOffline);
 
         if (status?.joinme) {
@@ -100,7 +116,7 @@
         }
         // sometimes appearing and sometimes disappearing
         if (status?.active) {
-            const friendStatus = props.friend.status;
+            const friendStatus = props.friend.ref?.status;
             if (friendStatus === 'join me') {
                 return 'friend-card__status-dot--active-join';
             }


### PR DESCRIPTION
This PR fixes a small responsiveness issue. In the old version, VRCX used very large cards with large names, which caused truncation on almost every monitor size. The only workaround was to make the app bigger or scale it, which was not very userfriendly...

Instead of using oversized cards that waste space in a modern UI, compact user items that make much better use of the interface space. :)

Why is this a banger change?
1. More Space
2. You can actually read usernames
3. You can see more Instance Infos :D!
4. More content to see when the app is in a small size

_Note: I did not use AI in this PR but did ask claude to find the related css quickly for me._
Note 2: should have been using the WebView Editor lol.

shiny out ^^

<img width="1794" height="687" alt="Screenshot 2026-04-13 151709" src="https://github.com/user-attachments/assets/2cf10fb9-ec61-40ff-976e-4b6f896cf27f" />
