### PR TITLE
Add drag&drop to upload Prints, Stickers, Emojis, Photos and Icons

### DIFF
--- a/src/views/Tools/Gallery.vue
+++ b/src/views/Tools/Gallery.vue
@@ -49,7 +49,9 @@
                 </span>
             </template>
             <template #gallery>
-                <div>
+                <div
+                    @dragover.prevent
+                    @drop.prevent="handleDropGallery">
                     <input
                         id="GalleryUploadButton"
                         type="file"
@@ -129,7 +131,9 @@
             </template>
 
             <template #icons>
-                <div>
+                <div
+                    @dragover.prevent
+                    @drop.prevent="handleDropIcon">
                     <input
                         id="VRCPlusIconUploadButton"
                         type="file"
@@ -209,7 +213,9 @@
             </template>
 
             <template #emojis>
-                <div>
+                <div
+                    @dragover.prevent
+                    @drop.prevent="handleDropEmoji">
                     <input
                         id="EmojiUploadButton"
                         type="file"
@@ -931,6 +937,12 @@
         deleteFileAndRemove(fileId, galleryTable.value);
     }
 
+    async function uploadVRCPlusIcon(base64Body) {
+        const args = await vrcPlusIconRequest.uploadVRCPlusIcon(base64Body);
+        if (VRCPlusIconsTable.value.length > 0) {
+            VRCPlusIconsTable.value.unshift(args.json);
+        }
+    }
     /**
      *
      * @param e
@@ -941,10 +953,7 @@
             aspectRatio: 1 / 1,
             errorMessage: 'Failed to upload VRC+ icon',
             upload: async ({ base64Body }) => {
-                const args = await vrcPlusIconRequest.uploadVRCPlusIcon(base64Body);
-                if (VRCPlusIconsTable.value.length > 0) {
-                    VRCPlusIconsTable.value.unshift(args.json);
-                }
+                await uploadVRCPlusIcon(base64Body);
             }
         });
     }
@@ -1025,6 +1034,25 @@
         }
     }
 
+    async function uploadEmoji(base64Body) {
+        const params = {
+            tag: emojiAnimType.value ? 'emojianimated' : 'emoji',
+            animationStyle: emojiAnimationStyle.value.toLowerCase(),
+            maskTag: 'square'
+        };
+        if (emojiAnimType.value) {
+            params.frames = emojiAnimFrameCount.value;
+            params.framesOverTime = emojiAnimFps.value;
+        }
+        if (emojiAnimLoopPingPong.value) {
+            params.loopStyle = 'pingpong';
+        }
+        const args = await vrcPlusImageRequest.uploadEmoji(base64Body, params);
+        if (emojiTable.value.length > 0) {
+            emojiTable.value.unshift(args.json);
+        }
+    }
+
     /**
      *
      * @param e
@@ -1038,22 +1066,7 @@
                 parseEmojiFileName(file.name);
             },
             upload: async ({ base64Body }) => {
-                const params = {
-                    tag: emojiAnimType.value ? 'emojianimated' : 'emoji',
-                    animationStyle: emojiAnimationStyle.value.toLowerCase(),
-                    maskTag: 'square'
-                };
-                if (emojiAnimType.value) {
-                    params.frames = emojiAnimFrameCount.value;
-                    params.framesOverTime = emojiAnimFps.value;
-                }
-                if (emojiAnimLoopPingPong.value) {
-                    params.loopStyle = 'pingpong';
-                }
-                const args = await vrcPlusImageRequest.uploadEmoji(base64Body, params);
-                if (emojiTable.value.length > 0) {
-                    emojiTable.value.unshift(args.json);
-                }
+                await uploadEmoji(base64Body);
             }
         });
     }
@@ -1073,6 +1086,15 @@
         deleteFileAndRemove(fileId, emojiTable.value);
     }
 
+    async function uploadSticker(base64Body) {
+        const params = {
+            tag: 'sticker',
+            maskTag: 'square'
+        };
+        const args = await vrcPlusImageRequest.uploadSticker(base64Body, params);
+        handleStickerAdd(args);
+    }
+
     /**
      *
      * @param e
@@ -1082,12 +1104,7 @@
             inputSelector: '#StickerUploadButton',
             aspectRatio: 1 / 1,
             upload: async ({ base64Body }) => {
-                const params = {
-                    tag: 'sticker',
-                    maskTag: 'square'
-                };
-                const args = await vrcPlusImageRequest.uploadSticker(base64Body, params);
-                handleStickerAdd(args);
+                await uploadSticker(base64Body);
             }
         });
     }
@@ -1107,6 +1124,20 @@
         deleteFileAndRemove(fileId, stickerTable.value);
     }
 
+    async function uploadPrint(base64Body, date) {
+        const timestamp = date.toISOString().slice(0, 19);
+        const params = {
+            note: printUploadNote.value,
+            // worldId: '',
+            timestamp
+        };
+        const cropWhiteBorder = printCropBorder.value;
+        const args = await vrcPlusImageRequest.uploadPrint(base64Body, cropWhiteBorder, params);
+        if (printTable.value.length > 0) {
+            printTable.value.unshift(args.json);
+        }
+    }
+
     /**
      *
      * @param e
@@ -1116,20 +1147,10 @@
             inputSelector: '#PrintUploadButton',
             aspectRatio: 16 / 9,
             upload: async ({ base64Body }) => {
-                const date = new Date();
                 // why the fuck isn't this UTC
+                const date = new Date();
                 date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
-                const timestamp = date.toISOString().slice(0, 19);
-                const params = {
-                    note: printUploadNote.value,
-                    // worldId: '',
-                    timestamp
-                };
-                const cropWhiteBorder = printCropBorder.value;
-                const args = await vrcPlusImageRequest.uploadPrint(base64Body, cropWhiteBorder, params);
-                if (printTable.value.length > 0) {
-                    printTable.value.unshift(args.json);
-                }
+                await uploadPrint(base64Body, date);
             }
         });
     }
@@ -1151,16 +1172,36 @@
         });
     }
 
+    async function handleDropGallery(event) {
+      event.preventDefault();
+      for (const file of event.dataTransfer.files) {
+        const b64str = await readFileToBase64Str(file);
+        const args = await vrcPlusImageRequest.uploadGalleryImage(b64str);
+        handleGalleryImageAdd(args);
+      }
+    }
+
+    async function handleDropIcon(event) {
+      event.preventDefault();
+      for (const file of event.dataTransfer.files) {
+        const b64str = await readFileToBase64Str(file);
+        await uploadVRCPlusIcon(b64str);
+      }
+    }
+
+    async function handleDropEmoji(event) {
+      event.preventDefault();
+      for (const file of event.dataTransfer.files) {
+        const b64str = await readFileToBase64Str(file);
+        await uploadEmoji(b64str);
+      }
+    }
+
     async function handleDropSticker(event) {
       event.preventDefault();
       for (const file of event.dataTransfer.files) {
         const b64str = await readFileToBase64Str(file);
-        const params = {
-            tag: 'sticker',
-            maskTag: 'square'
-        };
-        const args = await vrcPlusImageRequest.uploadSticker(b64str, params);
-        handleStickerAdd(args);
+        await uploadSticker(b64str);
       }
     }
 
@@ -1169,17 +1210,7 @@
       for (const file of event.dataTransfer.files) {
         const b64str = await readFileToBase64Str(file);
         const filedate = file.lastModifiedDate ?? new Date();
-        const timestamp = filedate.toISOString().slice(0, 19);
-        const params = {
-          note: '',
-          // worldId: '',
-          timestamp,
-        };
-        const cropWhiteBorder = false;
-        const args = await vrcPlusImageRequest.uploadPrint(b64str, cropWhiteBorder, params);
-        if (printTable.value.length > 0) {
-          printTable.value.unshift(args.json);
-        }
+        await uploadPrint(b64str, filedate);
       }
     }
 

--- a/src/views/Tools/Gallery.vue
+++ b/src/views/Tools/Gallery.vue
@@ -355,7 +355,9 @@
             </template>
 
             <template #stickers>
-                <div>
+                <div
+                    @dragover.prevent
+                    @drop.prevent="handleDropSticker">
                     <input
                         id="StickerUploadButton"
                         type="file"
@@ -419,7 +421,9 @@
             </template>
 
             <template #prints>
-                <div>
+                <div
+                    @dragover.prevent
+                    @drop.prevent="handleDropPrint">
                     <input
                         id="PrintUploadButton"
                         type="file"
@@ -1145,6 +1149,56 @@
         vrcPlusImageRequest.deletePrint(printId).then((args) => {
             removeItemById(printTable.value, args.printId);
         });
+    }
+
+    async function handleDropSticker(event) {
+      event.preventDefault();
+      for (const file of event.dataTransfer.files) {
+        const b64str = await readFileToBase64Str(file);
+        const params = {
+            tag: 'sticker',
+            maskTag: 'square'
+        };
+        const args = await vrcPlusImageRequest.uploadSticker(b64str, params);
+        handleStickerAdd(args);
+      }
+    }
+
+    async function handleDropPrint(event) {
+      event.preventDefault();
+      for (const file of event.dataTransfer.files) {
+        const b64str = await readFileToBase64Str(file);
+        const filedate = file.lastModifiedDate ?? new Date();
+        const timestamp = filedate.toISOString().slice(0, 19);
+        const params = {
+          note: '',
+          // worldId: '',
+          timestamp,
+        };
+        const cropWhiteBorder = false;
+        const args = await vrcPlusImageRequest.uploadPrint(b64str, cropWhiteBorder, params);
+        if (printTable.value.length > 0) {
+          printTable.value.unshift(args.json);
+        }
+      }
+    }
+
+    function readFileAsDataUrlAsync(file) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+    }
+
+    async function readFileToBase64Str(file) {
+      if (!file || !file.type.startsWith('image/'))
+        throw Exception(`unrecognized image format: ${file.type}`);
+
+      const reader = new FileReader();
+      const b64uri = await readFileAsDataUrlAsync(file);
+      return b64uri.split(',', 2)[1]; // strip data:...;base64,
     }
 
     /**


### PR DESCRIPTION
I found using the "upload" button with prompt to be tedious just to share a few pictures with friends. This PR adds seamless drag and drop of image files into the Gallery for any tabs. For example to upload my last meme pictures I have my explorer open there and I can select those files and drop them into VRCX in the Prints tab. Yes multiple files at once.

To achieve this I added `@drop.prevent` inside the parent `<div>` of each `<template>` tab. I refactored the upload logic so it's shared.

Caveats:
- (a) No UI hint, no visual change that drag&drop is (now) possible.
- (b) No visual feedback when we wait for upload to finish. A popup or toast could be added.
- (c) This directly uploads the files, thus VRC decides how to handle aspect ratio/crop. But this is convenient to quickly upload. For prints VRC rotates portraits to landscape which is cool. Motivation: Since we can upload many files at once it wouldn't make sense to show the upload modal or it would need to be modified to show each file in sequence which isn't convenient to users for quick upload.