### PR TITLE
Vrcx css refactor - Log Aligns. - badge sizes

### DIFF
--- a/src/components/dialogs/AvatarDialog/AvatarDialog.vue
+++ b/src/components/dialogs/AvatarDialog/AvatarDialog.vue
@@ -39,7 +39,7 @@
                                 @click="showUserDialog(avatarDialog.ref.authorId)"
                                 v-text="avatarDialog.ref.authorName"></span>
                         </div>
-                        <div>
+                        <div class="flex flex-wrap items-center">
                             <Badge
                                 class="mr-1.5 mt-1.5"
                                 v-if="avatarDialog.ref.releaseStatus === 'public'"
@@ -54,7 +54,7 @@
                                     ><Monitor class="h-4 w-4 text-platform-pc" />
                                     <span
                                         v-if="avatarDialog.platformInfo.pc"
-                                        class="x-grey text-platform-pc border-l-[0.8px] border-solid ml-1.5 pl-1.5 pb-px"
+                                        class="x-grey text-platform-pc border-l-[0.8px] border-solid ml-1.5 pl-1.5"
                                         >{{
                                             t(
                                                 `dialog.avatar.tags.performanceRating.${avatarDialog.platformInfo.pc.performanceRating.replace(' ', '')}`
@@ -63,7 +63,7 @@
                                     >
                                     <span
                                         v-if="avatarDialog.fileAnalysis.standalonewindows?._fileSize"
-                                        class="x-grey text-platform-pc border-l-[0.8px] border-solid ml-1.5 pl-1.5 pb-px"
+                                        class="x-grey text-platform-pc border-l-[0.8px] border-solid ml-1.5 pl-1.5"
                                         >{{ avatarDialog.fileAnalysis.standalonewindows._fileSize }}</span
                                     >
                                 </Badge>
@@ -75,7 +75,7 @@
                                     ><Smartphone class="h-4 w-4 text-platform-quest" />
                                     <span
                                         v-if="avatarDialog.platformInfo.android"
-                                        class="x-grey text-platform-quest border-l-[0.8px] border-solid ml-1.5 pl-1.5 pb-px"
+                                        class="x-grey text-platform-quest border-l-[0.8px] border-solid ml-1.5 pl-1.5"
                                         >{{
                                             t(
                                                 `dialog.avatar.tags.performanceRating.${avatarDialog.platformInfo.android.performanceRating.replace(' ', '')}`
@@ -84,7 +84,7 @@
                                     >
                                     <span
                                         v-if="avatarDialog.fileAnalysis.android?._fileSize"
-                                        class="x-grey text-platform-quest border-l-[0.8px] border-solid ml-1.5 pl-1.5 pb-px"
+                                        class="x-grey text-platform-quest border-l-[0.8px] border-solid ml-1.5 pl-1.5"
                                         >{{ avatarDialog.fileAnalysis.android._fileSize }}</span
                                     >
                                 </Badge>
@@ -94,7 +94,7 @@
                                     ><Apple class="h-4 w-4 text-platform-ios" />
                                     <span
                                         v-if="avatarDialog.platformInfo.ios"
-                                        class="x-grey text-platform-ios border-platform-ios border-l-[0.8px] border-solid ml-1.5 pl-1.5 pb-px"
+                                        class="x-grey text-platform-ios border-platform-ios border-l-[0.8px] border-solid ml-1.5 pl-1.5"
                                         >{{
                                             t(
                                                 `dialog.avatar.tags.performanceRating.${avatarDialog.platformInfo.ios.performanceRating.replace(' ', '')}`
@@ -103,7 +103,7 @@
                                     >
                                     <span
                                         v-if="avatarDialog.fileAnalysis.ios?._fileSize"
-                                        class="x-grey text-platform-ios border-platform-ios border-l-[0.8px] border-solid ml-1.5 pl-1.5 pb-px"
+                                        class="x-grey text-platform-ios border-platform-ios border-l-[0.8px] border-solid ml-1.5 pl-1.5"
                                         >{{ avatarDialog.fileAnalysis.ios._fileSize }}</span
                                     >
                                 </Badge>

--- a/src/components/dialogs/GroupDialog/GroupDialog.vue
+++ b/src/components/dialogs/GroupDialog/GroupDialog.vue
@@ -50,84 +50,45 @@
                                 @click="showUserDialog(groupDialog.ref.ownerId)"
                                 v-text="groupDialog.ownerDisplayName"></span>
                         </div>
-                        <div class="group-tags">
-                            <Badge
-                                v-if="groupDialog.ref.isVerified"
-                                variant="outline"
-                                style="margin-right: 6px; margin-top: 6px">
+                        <div class="group-tags flex flex-wrap items-center">
+                            <Badge v-if="groupDialog.ref.isVerified" variant="outline" class="mr-1.5 mt-1.5">
                                 {{ t('dialog.group.tags.verified') }}
                             </Badge>
-                            <Badge
-                                v-if="groupDialog.ref.privacy === 'private'"
-                                variant="outline"
-                                style="margin-right: 6px; margin-top: 6px">
+                            <Badge v-if="groupDialog.ref.privacy === 'private'" variant="outline" class="mr-1.5 mt-1.5">
                                 {{ t('dialog.group.tags.private') }}
                             </Badge>
-                            <Badge
-                                v-if="groupDialog.ref.privacy === 'default'"
-                                variant="outline"
-                                style="margin-right: 6px; margin-top: 6px">
+                            <Badge v-if="groupDialog.ref.privacy === 'default'" variant="outline" class="mr-1.5 mt-1.5">
                                 {{ t('dialog.group.tags.public') }}
                             </Badge>
-                            <Badge
-                                v-if="groupDialog.ref.joinState === 'open'"
-                                variant="outline"
-                                style="margin-right: 6px; margin-top: 6px">
+                            <Badge v-if="groupDialog.ref.joinState === 'open'" variant="outline" class="mr-1.5 mt-1.5">
                                 {{ t('dialog.group.tags.open') }}
                             </Badge>
-                            <Badge
-                                v-else-if="groupDialog.ref.joinState === 'request'"
-                                variant="outline"
-                                style="margin-right: 6px; margin-top: 6px">
+                            <Badge v-else-if="groupDialog.ref.joinState === 'request'" variant="outline" class="mr-1.5 mt-1.5">
                                 {{ t('dialog.group.tags.request') }}
                             </Badge>
-                            <Badge
-                                v-else-if="groupDialog.ref.joinState === 'invite'"
-                                variant="outline"
-                                style="margin-right: 6px; margin-top: 6px">
+                            <Badge v-else-if="groupDialog.ref.joinState === 'invite'" variant="outline" class="mr-1.5 mt-1.5">
                                 {{ t('dialog.group.tags.invite') }}
                             </Badge>
-                            <Badge
-                                v-else-if="groupDialog.ref.joinState === 'closed'"
-                                variant="outline"
-                                style="margin-right: 6px; margin-top: 6px">
+                            <Badge v-else-if="groupDialog.ref.joinState === 'closed'" variant="outline" class="mr-1.5 mt-1.5">
                                 {{ t('dialog.group.tags.closed') }}
                             </Badge>
-                            <Badge
-                                v-if="groupDialog.inGroup"
-                                variant="outline"
-                                style="margin-right: 6px; margin-top: 6px">
+                            <Badge v-if="groupDialog.inGroup" variant="outline" class="mr-1.5 mt-1.5">
                                 {{ t('dialog.group.tags.joined') }}
                             </Badge>
-                            <Badge
-                                v-if="groupDialog.ref.myMember && groupDialog.ref.myMember.bannedAt"
-                                variant="outline"
-                                style="margin-right: 6px; margin-top: 6px">
+                            <Badge v-if="groupDialog.ref.myMember && groupDialog.ref.myMember.bannedAt" variant="outline" class="mr-1.5 mt-1.5">
                                 {{ t('dialog.group.tags.banned') }}
                             </Badge>
                             <template v-if="groupDialog.inGroup && groupDialog.ref.myMember">
-                                <Badge
-                                    v-if="groupDialog.ref.myMember.visibility === 'visible'"
-                                    variant="outline"
-                                    style="margin-right: 6px; margin-top: 6px">
+                                <Badge v-if="groupDialog.ref.myMember.visibility === 'visible'" variant="outline" class="mr-1.5 mt-1.5">
                                     {{ t('dialog.group.tags.visible') }}
                                 </Badge>
-                                <Badge
-                                    v-else-if="groupDialog.ref.myMember.visibility === 'friends'"
-                                    variant="outline"
-                                    style="margin-right: 6px; margin-top: 6px">
+                                <Badge v-else-if="groupDialog.ref.myMember.visibility === 'friends'" variant="outline" class="mr-1.5 mt-1.5">
                                     {{ t('dialog.group.tags.friends') }}
                                 </Badge>
-                                <Badge
-                                    v-else-if="groupDialog.ref.myMember.visibility === 'hidden'"
-                                    variant="outline"
-                                    style="margin-right: 6px; margin-top: 6px">
+                                <Badge v-else-if="groupDialog.ref.myMember.visibility === 'hidden'" variant="outline" class="mr-1.5 mt-1.5">
                                     {{ t('dialog.group.tags.hidden') }}
                                 </Badge>
-                                <Badge
-                                    v-if="groupDialog.ref.myMember.isSubscribedToAnnouncements"
-                                    variant="outline"
-                                    style="margin-right: 6px; margin-top: 6px">
+                                <Badge v-if="groupDialog.ref.myMember.isSubscribedToAnnouncements" variant="outline" class="mr-1.5 mt-1.5">
                                     {{ t('dialog.group.tags.subscribed') }}
                                 </Badge>
                             </template>

--- a/src/components/dialogs/WorldDialog/WorldDialog.vue
+++ b/src/components/dialogs/WorldDialog/WorldDialog.vue
@@ -43,7 +43,7 @@
                                 @click="showUserDialog(worldDialog.ref.authorId)"
                                 v-text="worldDialog.ref.authorName" />
                         </div>
-                        <div>
+                        <div class="flex flex-wrap items-center">
                             <Badge class="mr-1.5 mt-1.5" v-if="worldDialog.ref.$isLabs" variant="outline">
                                 {{ t('dialog.world.tags.labs') }}
                             </Badge>
@@ -61,7 +61,7 @@
                                     <Monitor class="h-4 w-4 text-platform-pc" />
                                     <span
                                         v-if="worldDialog.fileAnalysis.standalonewindows?._fileSize"
-                                        class="x-grey text-platform-pc border-l-[0.8px] border-solid ml-1.5 pl-1.5 pb-px">
+                                        class="x-grey text-platform-pc border-l-[0.8px] border-solid ml-1.5 pl-1.5">
                                         {{ worldDialog.fileAnalysis.standalonewindows._fileSize }}
                                     </span>
                                 </Badge>
@@ -74,7 +74,7 @@
                                     <Smartphone class="h-4 w-4 text-platform-quest" />
                                     <span
                                         v-if="worldDialog.fileAnalysis.android?._fileSize"
-                                        class="x-grey text-platform-quest border-l-[0.8px] border-solid ml-1.5 pl-1.5 pb-px">
+                                        class="x-grey text-platform-quest border-l-[0.8px] border-solid ml-1.5 pl-1.5">
                                         {{ worldDialog.fileAnalysis.android._fileSize }}
                                     </span>
                                 </Badge>
@@ -85,7 +85,7 @@
                                     <Apple class="h-4 w-4 text-platform-ios" />
                                     <span
                                         v-if="worldDialog.fileAnalysis.ios?._fileSize"
-                                        class="x-grey text-platform-ios border-platform-ios border-l-[0.8px] border-solid ml-1.5 pl-1.5 pb-px">
+                                        class="x-grey text-platform-ios border-platform-ios border-l-[0.8px] border-solid ml-1.5 pl-1.5">
                                         {{ worldDialog.fileAnalysis.ios._fileSize }}
                                     </span>
                                 </Badge>

--- a/src/views/Feed/columns.jsx
+++ b/src/views/Feed/columns.jsx
@@ -243,6 +243,7 @@ export const columns = [
         header: ({ column }) => (
             <Button
                 variant="ghost"
+                class="pl-0!"
                 onClick={() =>
                     column.toggleSorting(column.getIsSorted() === 'asc')
                 }

--- a/src/views/GameLog/columns.jsx
+++ b/src/views/GameLog/columns.jsx
@@ -60,6 +60,7 @@ export const createColumns = ({ getCreatedAt, onDelete, onDeletePrompt }) => {
             header: ({ column }) => (
                 <Button
                     variant="ghost"
+                    class="pl-0!"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }

--- a/src/views/Notifications/columns.jsx
+++ b/src/views/Notifications/columns.jsx
@@ -109,6 +109,15 @@ export const createColumns = ({
 
     return [
         {
+            id: 'spacer',
+            header: () => null,
+            enableSorting: false,
+            size: 20,
+            minSize: 0,
+            maxSize: 20,
+            cell: () => null
+        },
+        {
             accessorFn: (row) => getNotificationCreatedAtTs(row),
             id: 'created_at',
             size: 120,
@@ -116,6 +125,7 @@ export const createColumns = ({
             header: ({ column }) => (
                 <Button
                     variant="ghost"
+                    class="pl-0!"
                     onClick={() =>
                         column.toggleSorting(column.getIsSorted() === 'asc')
                     }


### PR DESCRIPTION
1. Fix date column misalignment in GameLog, Feed, and Notifications by aligning header text with cell content and normalizing column offsets
2. Fix badge inconsistencies in World, Avatar, and Group dialogs by equalizing text and icon badge heights and unifying spacing with Tailwind classes

<img width="405" height="42" alt="image" src="https://github.com/user-attachments/assets/70a6f69c-272b-492a-bd0b-5f727a5d4b5b" />
<img width="482" height="237" alt="image" src="https://github.com/user-attachments/assets/69940ff4-c022-440d-b082-b03da3b18d09" />
