### PR TITLE
fix(tooltips): set 100ms delay to spawn a tooltip per default

### DIFF
--- a/src/components/ui/tooltip/TooltipWrapper.vue
+++ b/src/components/ui/tooltip/TooltipWrapper.vue
@@ -14,7 +14,20 @@
         side: { type: null, required: false },
         align: { type: null, required: false },
         sideOffset: { type: Number, required: false },
-        delayDuration: { type: Number, required: false },
+        delayDuration: {
+            type: Number,
+            required: false,
+            default() {
+                100;
+            }
+        },
+        skipDelayDuration: {
+            type: Number,
+            required: false,
+            default() {
+                100;
+            }
+        },
         disableHoverableContent: { type: Boolean, required: false },
         ignoreNonKeyboardFocus: { type: Boolean, required: false, default: true },
         disabled: { type: Boolean, required: false },
@@ -49,3 +62,4 @@
         </TooltipContent>
     </Tooltip>
 </template>
+


### PR DESCRIPTION
this fixes tooltips being stuck when hovering multiple fields that have a tooltip in quick sucession, requiring a click to despawn the tooltip
