### PR TITLE
Fix FavoriteCoordinator, Friends, Worlds, Avatars - Counter fix, refr…

### DIFF
--- a/src/coordinators/favoriteCoordinator.js
+++ b/src/coordinators/favoriteCoordinator.js
@@ -214,6 +214,10 @@ export function applyFavoriteCached(json) {
     let ref = favoriteStore.cachedFavorites.get(json.id);
     if (typeof ref === 'undefined') {
         ref = createDefaultFavoriteCachedRef(json);
+        const oldEntry = favoriteStore.cachedFavoritesByObjectId.get(ref.favoriteId);
+        if (oldEntry && oldEntry.id !== ref.id) {
+            favoriteStore.cachedFavorites.delete(oldEntry.id);
+        }
         favoriteStore.cachedFavorites.set(ref.id, ref);
         favoriteStore.cachedFavoritesByObjectId.set(ref.favoriteId, ref);
         if (
@@ -236,6 +240,7 @@ export function applyFavoriteCached(json) {
             favoriteStore.cachedFavoritesByObjectId.delete(ref.favoriteId);
         }
         Object.assign(ref, json);
+        ref.$groupKey = `${ref.type}:${String(ref.tags[0])}`;
         favoriteStore.cachedFavoritesByObjectId.set(ref.favoriteId, ref);
     }
 
@@ -306,6 +311,7 @@ export async function applyFavorite(type, objectId) {
                     removeFromArray(favoriteStore.state.favoriteAvatars_, ctx);
                 }
             }
+            ctx.groupKey = favorite.$groupKey;
             if (type === 'friend') {
                 ref = userStore.cachedUsers.get(objectId);
                 if (typeof ref !== 'undefined') {
@@ -427,7 +433,7 @@ export function refreshFavorites() {
             if (ok) {
                 for (const id of favoriteStore.favoritesSortOrder) {
                     if (!newFavoriteSortOrder.includes(id)) {
-                        const fav = favoriteStore.cachedFavorites.get(id);
+                        const fav = favoriteStore.cachedFavoritesByObjectId.get(id);
                         if (fav) {
                             handleFavoriteAtDelete(fav);
                         }


### PR DESCRIPTION
This fixes multiple issues in **Favorites**, which were reported by Tony in the nightly chat. I had already noticed the issue and made a simplified fix that also tackles a few more issues I discovered.

**Favorite Worlds**

1. Moving a world to a different category now updates correctly after refreshing the page.
2. Moving a world to a different category now refreshes and validates the category counter, for example `X/XXX`.

**Favorite Avatars**

1. Moving an avatar to a different category now refreshes and validates the category counter, for example `X/XXX`.

**Favorite Friends**

1. Moving a friend to a different category now refreshes and validates the category counter, for example `X/XXX`.

**Favorites Refresh: 4 bug fixes in `favoriteCoordinator.js`**

1. **Unfavorite not detected on refresh**
   The cleanup logic checked object IDs like `wrld_xxx` against `cachedFavorites`, which uses favorite entry IDs like `fvrt_xxx`. It now uses `cachedFavoritesByObjectId`, so removed favorites are deleted correctly.

2. **Group changes not reflected**
   When VRChat moves a favorite to another group, it creates a new favorite entry ID. The old cached entry is now removed so the item is not counted in both the old and new group.

3. **`$groupKey` not recalculated on update**
   After `Object.assign` updates the favorite data, `$groupKey` is now recalculated from the latest tags so the group key stays correct.

4. **Display object `groupKey` not updated**
   `state.favoriteObjects` now updates `ctx.groupKey` from `favorite.$groupKey`, so favorite worlds appear in the correct group after refreshing.
