### PR TITLE
fix(localization): add missing translator

### DIFF
--- a/src/localization/ja.json
+++ b/src/localization/ja.json
@@ -1,6 +1,6 @@
 {
     "language": "日本語 (ja)",
-    "translator": "Assault1892, Yuu198, paralleltree, kazu3jp, Cayahuanca, ecto0310, Map1en, neco222",
+    "translator": "Assault1892, Yuu198, paralleltree, kazu3jp, Cayahuanca, ecto0310, Map1en, neco222, puk06",
     "common": {
         "no_data": "データがありません",
         "no_matching_records": "一致するレコードがありません",


### PR DESCRIPTION
https://github.com/vrcx-team/VRCX/pull/1753

This pull request makes a minor update to the Japanese localization file by adding "puk06" to the list of translators.

* Added "puk06" to the `translator` field in `src/localization/ja.json`.