### PR TITLE
Fix layout issues and prevent auto-scrolling on MyAvatars page

### DIFF
--- a/src/views/MyAvatars/MyAvatars.vue
+++ b/src/views/MyAvatars/MyAvatars.vue
@@ -244,7 +244,7 @@
                 :style="{ height: `${virtualizer?.getTotalSize?.() ?? 0}px` }">
                 <div
                     v-for="vItem in virtualItems"
-                    :key="String(vItem.virtualItem.key)"
+                    :key="vItem.row?.key ?? String(vItem.virtualItem.index)"
                     class="absolute left-0 top-0 w-full box-border pb-2"
                     :data-index="vItem.virtualItem.index"
                     :ref="virtualizer.measureElement"
@@ -258,7 +258,6 @@
                         <MyAvatarCard
                             v-for="avatar in vItem.row.items"
                             :key="avatar.id"
-                            v-memo="[currentAvatarId, cardScale]"
                             :avatar="avatar"
                             :current-avatar-id="currentAvatarId"
                             :card-scale="cardScale"
@@ -314,7 +313,7 @@
     import { useI18n } from 'vue-i18n';
     import { useVirtualizer } from '@tanstack/vue-virtual';
 
-    import { useAppearanceSettingsStore, useAvatarStore, useModalStore, useUserStore } from '../../stores';
+    import { useAppearanceSettingsStore, useModalStore, useUserStore } from '../../stores';
     import { ContextMenuContent, ContextMenuItem, ContextMenuSeparator } from '../../components/ui/context-menu';
     import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '../../components/ui/dropdown-menu';
     import { Field, FieldContent, FieldLabel } from '../../components/ui/field';
@@ -353,7 +352,6 @@
 
     const { t } = useI18n();
     const appearanceSettingsStore = useAppearanceSettingsStore();
-    const avatarStore = useAvatarStore();
     const modalStore = useModalStore();
 
     const { currentUser } = storeToRefs(useUserStore());
@@ -722,6 +720,7 @@
     const virtualizer = useVirtualizer(
         computed(() => ({
             count: gridRows.value.length,
+            getItemKey: (index) => gridRows.value[index]?.key ?? `avatar-row:${index}`,
             getScrollElement: () => gridScrollRef.value,
             estimateSize: (index) => estimateRowHeight(gridRows.value[index]?.items?.length ?? 0),
             overscan: 5
@@ -739,7 +738,13 @@
     watch(gridContainerRefEl, (el) => {
         gridContainerRef.value = el;
     });
-    watch([cardScale, cardSpacing, gridRows], () => {
+
+    const gridLayoutSignature = computed(() => {
+        const firstRowItems = gridRows.value[0]?.items?.length ?? 0;
+        return `${filteredAvatars.value.length}:${firstRowItems}:${cardScale.value}:${cardSpacing.value}`;
+    });
+
+    watch(gridLayoutSignature, () => {
         nextTick(() => {
             updateContainerWidth();
             virtualizer.value?.measure?.();


### PR DESCRIPTION
Fixes #1754 

This pull request makes several improvements and minor fixes to the `MyAvatars.vue` view, primarily focused on virtualized grid rendering and reactivity. The most significant changes include fixing key handling for virtualized rows, improving reactivity when grid layout parameters change, and cleaning up unused imports and variables.

**Improvements to virtualized grid rendering:**

* Updated the `key` for each virtualized row to use `vItem.row?.key` if available, improving key stability and preventing rendering issues when rows are reordered or updated.
* Added a `getItemKey` function to the virtualizer configuration to further ensure consistent and unique keys for rows.

**Reactivity and performance enhancements:**

* Replaced the watcher on `[cardScale, cardSpacing, gridRows]` with a computed `gridLayoutSignature` that tracks all relevant layout parameters, ensuring the grid re-measures correctly when any of these change.

**Code cleanup:**

* Removed the unused `useAvatarStore` import and the associated `avatarStore` variable, as they were not used in the component. [[1]](diffhunk://#diff-d89a57e71a9cbbc18ef9a50364d5e93d82f234aec6df9d0015c929bc2f6e8ddbL317-R316) [[2]](diffhunk://#diff-d89a57e71a9cbbc18ef9a50364d5e93d82f234aec6df9d0015c929bc2f6e8ddbL356)
* Removed the unnecessary `v-memo` directive from the `MyAvatarCard` component, simplifying the template.