### PR TITLE
Update improper japanese translation.

### DIFF
--- a/src/localization/ja.json
+++ b/src/localization/ja.json
@@ -23,10 +23,6 @@
             "open_link": "リンクを開く"
         },
         "sort_by": "並び替え:",
-        "duration": "期間",
-        "load_more": "さらに読み込む",
-        "no_more": "これ以上ありません",
-        "current_session": "現在",
         "time_units": {
             "y": "年",
             "d": "日",
@@ -42,7 +38,11 @@
             "thursday": "木曜日",
             "friday": "金曜日",
             "saturday": "土曜日"
-        }
+        },
+        "duration": "期間",
+        "load_more": "さらに読み込む",
+        "no_more": "これ以上ありません",
+        "current_session": "現在"
     },
     "nav_tooltip": {
         "friends_locations": "フレンドの現在地",
@@ -1630,12 +1630,12 @@
                 "content_adult": "成人向けの言葉やテーマ",
                 "content_sex": "性的なものを思わせる",
                 "performanceRating": {
-                    "Excellent": "優秀",
-                    "Good": "いいね",
-                    "Medium": "まあまあ",
-                    "Poor": "能無し",
-                    "VeryPoor": "めっちゃ能無し",
-                    "None": "なし"
+                    "Excellent": "Excellent",
+                    "Good": "Good",
+                    "Medium": "Medium",
+                    "Poor": "Poor",
+                    "VeryPoor": "Very Poor",
+                    "None": "None"
                 }
             },
             "labels": {


### PR DESCRIPTION
I have removed the improper translation of "Performance Rank" for the following two reasons:

Adherence to Official Guidelines: According to VRChat's official translation guidelines, the term "Performance Rank" should not be translated and must be used as-is. Using a unique translation that differs from the VRChat's terminology causes unnecessary confusion for users.

Inappropriate Word Choice: The specific term used in the translation—"能無し" (nonashi/incapable)—is a derogatory and insulting expression used to belittle others. It is a disrespectful term; even if one were to translate it into Japanese, a completely different expression should be chosen. Furthermore, while there are individuals on X (formerly Twitter) posting interpretations that equate "Poor" or "Very Poor" with "incapable," these are merely personal theories from a translation volunteer proofreader and do not represent the official stance of VRChat Inc.

https://x.com/naqtn/status/2046268138933846430


> 翻訳しない用語 (Terms Not Translated)
> 全ての言語で共通して、そのまま使用すべき用語があります。これらについては英語表記をそのまま使用してください。(There are terms that should be used as they are, common to all languages. Please use the English terms as they are.)
> 
> 「VRChat」
> 「VRChat Plus」とその略語「VRC+」
> 「Excellent」、「Good」、「Medium」、「Poor」、「Very Poor」 （performance rank において）
> 「Trusted User」、「Known User」、「User」、「New User」、「Visitor」、「Nuisance」（trust rank において）
> 「Full Body Tracking」とその略語「FBT」 ⇒下記補則参照
> 「Avatar Dynamics」、「Phys Bones」
> 「SDK」

https://docs.vrchat.com/docs/suggesting-localization-changes
https://discord.com/channels/1096246414603997194/1097626505019920424/1100305191993098290



The other change I made (Line 26-29, 41-45) was to correct the misalignment of columns between en.json and ja.json, so I made them the same order.

---

Performance Rank の翻訳において、不適切な翻訳があったため、削除しました。

これは、以下の2つの理由があります。

1つ目に、VRChat 本体の翻訳ガイドラインにおいて、Percormance Rank の言葉は翻訳せず、そのまま使用することが定められているためです。本体の表記と異なる、独自の翻訳があることは、ユーザーに混乱を生みます。

2つ目に、独自の翻訳の言葉の選択が不適切であることです。"能無し" という言葉は、他人を馬鹿にし、罵るために使用される、汚い表現です。他人を尊重しない言葉であり、日本語に翻訳するにしても、異なる表現が選択されなければなりません。なお、Twitter において、Poor, Very Poor を能無しと訳す解釈について投稿している方もいますが、VRChat の翻訳ボランティアでの proofreader であり、VRChat 社の公式的な解釈ではない、独自の説に留まるものです。

https://x.com/naqtn/status/2046268138933846430

> 翻訳しない用語
> 全ての言語で共通して、そのまま使用すべき用語があります。これらについては英語表記をそのまま使用してください。
> 
> 「VRChat」
> 「VRChat Plus」とその略語「VRC+」
> 「Excellent」、「Good」、「Medium」、「Poor」、「Very Poor」 （performance rank において）
> 「Trusted User」、「Known User」、「User」、「New User」、「Visitor」、「Nuisance」（trust rank において）
> 「Full Body Tracking」とその略語「FBT」 ⇒下記補則参照
> 「Avatar Dynamics」、「Phys Bones」
> 「SDK」

https://docs.vrchat.com/docs/suggesting-localization-changes
https://discord.com/channels/1096246414603997194/1097626505019920424/1100305191993098290