### PR TITLE
Fix overflowing text in avatar search and avatar details

### DIFF
--- a/src/components/dialogs/AvatarDialog/AvatarDialog.vue
+++ b/src/components/dialogs/AvatarDialog/AvatarDialog.vue
@@ -28,7 +28,7 @@
                     <div style="flex: 1">
                         <div>
                             <span
-                                class="font-bold mr-1.5"
+                                class="font-bold mr-1.5 break-all"
                                 style="cursor: pointer"
                                 v-text="avatarDialog.ref.name"
                                 @click="copyToClipboard(avatarDialog.ref.name)"></span>
@@ -177,7 +177,7 @@
                         <div style="margin-top: 6px">
                             <span
                                 v-show="avatarDialog.ref.name !== avatarDialog.ref.description"
-                                class="text-xs"
+                                class="text-xs break-all"
                                 v-text="avatarDialog.ref.description"></span>
                         </div>
                     </div>

--- a/src/views/Favorites/FavoritesAvatar.vue
+++ b/src/views/Favorites/FavoritesAvatar.vue
@@ -327,7 +327,7 @@
                                                 </div>
                                                 <div class="favorites-search-card__detail">
                                                     <div class="flex items-center gap-2">
-                                                        <span class="name">{{ favorite.name }}</span>
+                                                        <span class="name truncate">{{ favorite.name }}</span>
                                                     </div>
                                                     <span class="text-xs">{{ favorite.authorName }}</span>
                                                 </div>


### PR DESCRIPTION
# Before:

<img width="539" height="370" alt="Screenshot 2026-05-08 222003" src="https://github.com/user-attachments/assets/f8384ad7-fe31-4d49-9937-2315e51637ad" />
<img width="948" height="547" alt="Screenshot 2026-05-08 222022" src="https://github.com/user-attachments/assets/c514f450-773c-4c34-9916-1511fb88dfc5" />

# After:

<img width="438" height="314" alt="Screenshot 2026-05-08 221944" src="https://github.com/user-attachments/assets/a492f910-35e2-4366-98bb-a15b9b2c941e" />
<img width="979" height="624" alt="Screenshot 2026-05-08 221929" src="https://github.com/user-attachments/assets/f446b8ed-2072-41fb-97a1-aba7ba203cdb" />
