### PR TITLE
improve activity tab and other cleanup

### DIFF
--- a/src/api/group.js
+++ b/src/api/group.js
@@ -1021,21 +1021,6 @@ const groupReq = {
             };
             return args;
         });
-    },
-
-    followGroupEvent(params) {
-        return request(`calendar/${params.groupId}/${params.eventId}/follow`, {
-            method: 'POST',
-            params: {
-                isFollowing: params.isFollowing
-            }
-        }).then((json) => {
-            const args = {
-                json,
-                params
-            };
-            return args;
-        });
     }
 
     // getRequestedGroups() {

--- a/src/components/dialogs/UserDialog/UserDialog.vue
+++ b/src/components/dialogs/UserDialog/UserDialog.vue
@@ -215,15 +215,6 @@
         }
     );
 
-    watch(
-        () => userDialog.value.activeTab,
-        (activeTab) => {
-            if (activeTab === 'Activity' && userDialog.value.visible && !userDialog.value.loading) {
-                activityTabRef.value?.loadOnlineFrequency(userDialog.value.id);
-            }
-        }
-    );
-
     onMounted(() => {
         if (userDialog.value.visible && !userDialog.value.loading) {
             loadLastActiveTab();

--- a/src/components/dialogs/UserDialog/UserDialogActivityTab.vue
+++ b/src/components/dialogs/UserDialog/UserDialogActivityTab.vue
@@ -55,7 +55,9 @@
             </div>
         </div>
 
-        <div v-if="isLoading && filteredEventCount === 0" class="flex flex-col items-center justify-center flex-1 mt-8 gap-2">
+        <div
+            v-if="isLoading && filteredEventCount === 0"
+            class="flex flex-col items-center justify-center flex-1 mt-8 gap-2">
             <Spinner class="h-5 w-5" />
             <span class="text-sm text-muted-foreground">{{ t('dialog.user.activity.preparing_data') }}</span>
             <span class="text-xs text-muted-foreground">{{ t('dialog.user.activity.preparing_data_hint') }}</span>
@@ -491,7 +493,10 @@
             return;
         }
 
-        const rangeDays = parseInt(userDialog.value.activityPeriodDays, 10) === 0 ? 3650 : parseInt(userDialog.value.activityPeriodDays, 10) || 30;
+        const rangeDays =
+            parseInt(userDialog.value.activityPeriodDays, 10) === 0
+                ? 3650
+                : parseInt(userDialog.value.activityPeriodDays, 10) || 30;
         await loadTopWorldsSection({
             userId,
             rangeDays,
@@ -514,7 +519,9 @@
 
         try {
             const rangeDays =
-                parseInt(userDialog.value.activityPeriodDays, 10) === 0 ? 3650 : parseInt(userDialog.value.activityPeriodDays, 10) || 30;
+                parseInt(userDialog.value.activityPeriodDays, 10) === 0
+                    ? 3650
+                    : parseInt(userDialog.value.activityPeriodDays, 10) || 30;
             const activityView = await activityStore.loadActivityView({
                 userId,
                 isSelf: isSelf.value,
@@ -596,7 +603,9 @@
 
         try {
             const rangeDays =
-                parseInt(userDialog.value.activityPeriodDays, 10) === 0 ? 3650 : parseInt(userDialog.value.activityPeriodDays, 10) || 30;
+                parseInt(userDialog.value.activityPeriodDays, 10) === 0
+                    ? 3650
+                    : parseInt(userDialog.value.activityPeriodDays, 10) || 30;
             const overlapView = await activityStore.loadOverlapView({
                 currentUserId: currentUser.value.id,
                 targetUserId: userId,
@@ -844,8 +853,7 @@
         }
         if (userId !== userActivity.value.lastLoadedUserId) {
             resetActivityState();
-        }
-        else if (isLoading.value || filteredEventCount.value > 0) {
+        } else if (isLoading.value || filteredEventCount.value > 0) {
             return;
         }
 

--- a/src/components/dialogs/UserDialog/UserDialogActivityTab.vue
+++ b/src/components/dialogs/UserDialog/UserDialogActivityTab.vue
@@ -18,7 +18,7 @@
             </div>
             <div class="flex items-center gap-2">
                 <span class="text-muted-foreground text-sm">{{ t('dialog.user.activity.period') }}</span>
-                <Select v-model="selectedPeriod" :disabled="isLoading">
+                <Select v-model="userDialog.activityPeriodDays" :disabled="isLoading">
                     <SelectTrigger size="sm" class="w-40" @click.stop>
                         <SelectValue />
                     </SelectTrigger>
@@ -55,7 +55,7 @@
             </div>
         </div>
 
-        <div v-if="isLoading" class="flex flex-col items-center justify-center flex-1 mt-8 gap-2">
+        <div v-if="isLoading && filteredEventCount === 0" class="flex flex-col items-center justify-center flex-1 mt-8 gap-2">
             <Spinner class="h-5 w-5" />
             <span class="text-sm text-muted-foreground">{{ t('dialog.user.activity.preparing_data') }}</span>
             <span class="text-xs text-muted-foreground">{{ t('dialog.user.activity.preparing_data_hint') }}</span>
@@ -74,13 +74,13 @@
 
         <DailyPlaytime v-if="isSelf" :sessions="cachedSessions" :range-days="currentRangeDays" />
 
-        <div v-if="!isSelf" class="mt-4 border-t border-border pt-3">
+        <div v-if="!isSelf" v-show="filteredEventCount > 0" class="mt-4 border-t border-border pt-3">
             <div class="flex items-center justify-between mb-2">
                 <div class="flex items-center gap-2">
                     <span class="text-sm font-medium">{{ t('dialog.user.activity.overlap.header') }}</span>
                     <Spinner v-if="isOverlapLoadingVisible" class="h-3.5 w-3.5" />
                 </div>
-                <div v-if="hasOverlapData" class="flex items-center gap-1.5 shrink-0">
+                <div class="flex items-center gap-1.5 shrink-0">
                     <Switch :model-value="excludeHoursEnabled" class="scale-75" @update:model-value="onExcludeToggle" />
                     <span class="text-sm text-muted-foreground whitespace-nowrap">
                         {{ t('dialog.user.activity.overlap.exclude_hours') }}
@@ -143,7 +143,7 @@
             </div>
         </div>
 
-        <div v-if="isSelf" class="mt-4 border-t border-border pt-3">
+        <div v-if="isSelf && filteredEventCount > 0" class="mt-4 border-t border-border pt-3">
             <div class="flex items-center justify-between mb-2">
                 <div class="flex items-center gap-2">
                     <span class="text-sm font-medium">
@@ -276,11 +276,10 @@
     const { userDialog, currentUser } = storeToRefs(useUserStore());
     const { isDarkMode, weekStartsOn } = storeToRefs(useAppearanceSettingsStore());
     const activityStore = useActivityStore();
-    const { fullCacheReady } = storeToRefs(activityStore);
+    const { fullCacheReady, userActivity } = storeToRefs(activityStore);
     const worldStore = useWorldStore();
 
     const isLoading = ref(false);
-    const selectedPeriod = ref('30');
     const currentRangeDays = ref(30);
     const cachedSessions = ref([]);
     const filteredEventCount = ref(0);
@@ -309,10 +308,6 @@
     });
     const isRestoringSettings = ref(false);
 
-    let activeRequestId = 0;
-    let activeOverlapRequestId = 0;
-    let activeTopWorldsRequestId = 0;
-    let lastLoadedUserId = '';
     let topWorldsLoadingTimer = null;
     let overlapLoadingTimer = null;
     let overlapRenderTimer = null;
@@ -344,24 +339,19 @@
         return Array.from({ length: 7 }, (_, index) => dayLabels.value[(start + index) % 7]);
     });
     const hourLabels = Array.from({ length: 24 }, (_, index) => `${String(index).padStart(2, '0')}:00`);
-    const ACTIVITY_SELF_PERIOD_KEY = 'VRCX_activitySelfPeriodDays';
-    const ACTIVITY_FRIEND_PERIOD_KEY = 'VRCX_activityFriendPeriodDays';
     const ACTIVITY_SELF_TOP_WORLDS_SORT_KEY = 'VRCX_activitySelfTopWorldsSortBy';
     const ACTIVITY_SELF_EXCLUDE_HOME_WORLD_KEY = 'VRCX_activitySelfExcludeHomeWorld';
 
-    async function applySettingsForCurrentContext() {
+    async function applySettingsAndRefresh() {
         isRestoringSettings.value = true;
-        const periodKey = isSelf.value ? ACTIVITY_SELF_PERIOD_KEY : ACTIVITY_FRIEND_PERIOD_KEY;
-        const [period, sortBy, excludeHomeWorld, overlapExcludeEnabled, overlapExcludeStart, overlapExcludeEnd] =
+        const [sortBy, excludeHomeWorld, overlapExcludeEnabled, overlapExcludeStart, overlapExcludeEnd] =
             await Promise.all([
-                configRepository.getString(periodKey, '30'),
                 configRepository.getString(ACTIVITY_SELF_TOP_WORLDS_SORT_KEY, 'count'),
                 configRepository.getBool(ACTIVITY_SELF_EXCLUDE_HOME_WORLD_KEY, false),
                 configRepository.getBool('VRCX_overlapExcludeEnabled', false),
                 configRepository.getString('VRCX_overlapExcludeStart', '1'),
                 configRepository.getString('VRCX_overlapExcludeEnd', '6')
             ]);
-        selectedPeriod.value = ['0', '7', '30', '90', '180', '365'].includes(period) ? period : '30';
         topWorldsSortBy.value = ['time', 'count'].includes(sortBy) ? sortBy : 'count';
         excludeHomeWorldEnabled.value = excludeHomeWorld;
         excludeHoursEnabled.value = overlapExcludeEnabled;
@@ -369,6 +359,7 @@
         excludeEndHour.value = String(overlapExcludeEnd);
         await nextTick();
         isRestoringSettings.value = false;
+        await refreshData();
     }
 
     function resetActivityState() {
@@ -376,7 +367,6 @@
         filteredEventCount.value = 0;
         peakDayText.value = '';
         peakTimeText.value = '';
-        selectedPeriod.value = '30';
         hasOverlapData.value = false;
         overlapPercent.value = 0;
         bestOverlapTime.value = '';
@@ -389,10 +379,6 @@
         overlapHeatmapView.value = { rawBuckets: [], normalizedBuckets: [] };
         clearOverlapLoadingTimer();
         clearOverlapRenderTimer();
-        activeRequestId++;
-        activeOverlapRequestId++;
-        activeTopWorldsRequestId++;
-        lastLoadedUserId = '';
         clearTimeout(topWorldsLoadingTimer);
         topWorldsLoadingTimer = null;
     }
@@ -417,14 +403,14 @@
         clearOverlapLoadingTimer();
         overlapLoadingTimer = setTimeout(() => {
             overlapLoadingTimer = null;
-            if (requestId === activeOverlapRequestId && isOverlapLoading.value) {
+            if (requestId === userActivity.value.activeOverlapRequestId && isOverlapLoading.value) {
                 isOverlapLoadingVisible.value = true;
             }
         }, OVERLAP_LOADING_DELAY);
     }
 
     function finishOverlapLoading(requestId) {
-        if (requestId !== activeOverlapRequestId) {
+        if (requestId !== userActivity.value.activeOverlapRequestId) {
             return;
         }
         clearOverlapLoadingTimer();
@@ -454,14 +440,14 @@
         clearTimeout(topWorldsLoadingTimer);
         topWorldsLoadingTimer = setTimeout(() => {
             topWorldsLoadingTimer = null;
-            if (requestId === activeTopWorldsRequestId) {
+            if (requestId === userActivity.value.activeTopWorldsRequestId) {
                 topWorldsLoadingVisible.value = true;
             }
         }, TOP_WORLDS_LOADING_DELAY);
     }
 
     function finishTopWorldsLoading(requestId) {
-        if (requestId !== activeTopWorldsRequestId) {
+        if (requestId !== userActivity.value.activeTopWorldsRequestId) {
             return;
         }
         clearTimeout(topWorldsLoadingTimer);
@@ -471,7 +457,7 @@
     }
 
     async function loadTopWorldsSection({ userId, rangeDays, sortBy, period }) {
-        const requestId = ++activeTopWorldsRequestId;
+        const requestId = ++userActivity.value.activeTopWorldsRequestId;
         topWorldsLoading.value = true;
         scheduleTopWorldsLoading(requestId);
 
@@ -484,10 +470,10 @@
                 excludeWorldId: excludeHomeWorldEnabled.value ? currentHomeWorldId.value : ''
             });
             if (
-                requestId !== activeTopWorldsRequestId ||
+                requestId !== userActivity.value.activeTopWorldsRequestId ||
                 userDialog.value.id !== userId ||
                 topWorldsSortBy.value !== sortBy ||
-                selectedPeriod.value !== period
+                userDialog.value.activityPeriodDays !== period
             ) {
                 return;
             }
@@ -505,12 +491,12 @@
             return;
         }
 
-        const rangeDays = parseInt(selectedPeriod.value, 10) === 0 ? 3650 : parseInt(selectedPeriod.value, 10) || 30;
+        const rangeDays = parseInt(userDialog.value.activityPeriodDays, 10) === 0 ? 3650 : parseInt(userDialog.value.activityPeriodDays, 10) || 30;
         await loadTopWorldsSection({
             userId,
             rangeDays,
             sortBy: topWorldsSortBy.value,
-            period: selectedPeriod.value
+            period: userDialog.value.activityPeriodDays
         });
     }
 
@@ -520,15 +506,15 @@
             return;
         }
 
-        const requestId = ++activeRequestId;
-        const overlapRequestId = ++activeOverlapRequestId;
+        const requestId = ++userActivity.value.activeRequestId;
+        const overlapRequestId = ++userActivity.value.activeOverlapRequestId;
         if (!silent) {
             isLoading.value = true;
         }
 
         try {
             const rangeDays =
-                parseInt(selectedPeriod.value, 10) === 0 ? 3650 : parseInt(selectedPeriod.value, 10) || 30;
+                parseInt(userDialog.value.activityPeriodDays, 10) === 0 ? 3650 : parseInt(userDialog.value.activityPeriodDays, 10) || 30;
             const activityView = await activityStore.loadActivityView({
                 userId,
                 isSelf: isSelf.value,
@@ -536,7 +522,7 @@
                 dayLabels: dayLabels.value,
                 forceRefresh
             });
-            if (requestId !== activeRequestId || userDialog.value.id !== userId) {
+            if (requestId !== userActivity.value.activeRequestId || userDialog.value.id !== userId) {
                 return;
             }
 
@@ -547,7 +533,7 @@
                 rawBuckets: activityView.rawBuckets,
                 normalizedBuckets: activityView.normalizedBuckets
             };
-            lastLoadedUserId = userId;
+            userActivity.value.lastLoadedUserId = userId;
 
             if (isSelf.value) {
                 currentRangeDays.value = rangeDays;
@@ -560,9 +546,9 @@
                     userId,
                     rangeDays,
                     sortBy: topWorldsSortBy.value,
-                    period: selectedPeriod.value
+                    period: userDialog.value.activityPeriodDays
                 });
-                if (requestId !== activeRequestId || userDialog.value.id !== userId) {
+                if (requestId !== userActivity.value.activeRequestId || userDialog.value.id !== userId) {
                     return;
                 }
                 hasOverlapData.value = false;
@@ -582,38 +568,20 @@
                     endHour: parseInt(excludeEndHour.value, 10)
                 }
             });
-            if (requestId !== activeRequestId || userDialog.value.id !== userId) {
+            if (requestId !== userActivity.value.activeRequestId || userDialog.value.id !== userId) {
                 return;
             }
             applyOverlapView(overlapView);
         } finally {
-            if (requestId === activeRequestId) {
+            if (requestId === userActivity.value.activeRequestId) {
                 isLoading.value = false;
             }
             finishOverlapLoading(overlapRequestId);
         }
     }
 
-    async function loadForVisibleTab() {
-        const userId = userDialog.value.id;
-        if (!userId) {
-            return;
-        }
-        if (userId !== lastLoadedUserId) {
-            resetActivityState();
-            lastLoadedUserId = userId;
-        }
-        if (isLoading.value) {
-            return;
-        }
-        await refreshData();
-    }
-
-    async function onPeriodChange() {
-        await configRepository.setString(
-            isSelf.value ? ACTIVITY_SELF_PERIOD_KEY : ACTIVITY_FRIEND_PERIOD_KEY,
-            selectedPeriod.value
-        );
+    async function onPeriodChange(period) {
+        userDialog.value.activityPeriodDays = period;
         await refreshData();
     }
 
@@ -623,12 +591,12 @@
             return;
         }
 
-        const requestId = ++activeOverlapRequestId;
+        const requestId = ++userActivity.value.activeOverlapRequestId;
         beginOverlapLoading(requestId);
 
         try {
             const rangeDays =
-                parseInt(selectedPeriod.value, 10) === 0 ? 3650 : parseInt(selectedPeriod.value, 10) || 30;
+                parseInt(userDialog.value.activityPeriodDays, 10) === 0 ? 3650 : parseInt(userDialog.value.activityPeriodDays, 10) || 30;
             const overlapView = await activityStore.loadOverlapView({
                 currentUserId: currentUser.value.id,
                 targetUserId: userId,
@@ -641,7 +609,7 @@
                     endHour: parseInt(excludeEndHour.value, 10)
                 }
             });
-            if (requestId !== activeOverlapRequestId || userDialog.value.id !== userId) {
+            if (requestId !== userActivity.value.activeOverlapRequestId || userDialog.value.id !== userId) {
                 return;
             }
             applyOverlapView(overlapView);
@@ -870,33 +838,35 @@
         }
     }
 
-    function loadOnlineFrequency(userId) {
+    async function loadOnlineFrequency(userId) {
         if (!userId || userDialog.value.id !== userId) {
             return;
         }
-        void loadForVisibleTab();
+        if (userId !== userActivity.value.lastLoadedUserId) {
+            resetActivityState();
+        }
+        else if (isLoading.value || filteredEventCount.value > 0) {
+            return;
+        }
+
+        await applySettingsAndRefresh();
     }
 
     watch(
         () => userDialog.value.id,
         async () => {
-            resetActivityState();
             rebuildCharts();
-            await applySettingsForCurrentContext();
-            if (userDialog.value.visible && userDialog.value.activeTab === 'Activity') {
-                void nextTick(() => loadForVisibleTab());
-            }
         }
     );
     watch([locale, isDarkMode, weekStartsOn], rebuildCharts);
     watch(
-        () => selectedPeriod.value,
-        () => {
+        () => userDialog.value.activityPeriodDays,
+        (period) => {
             if (isRestoringSettings.value) {
                 return;
             }
             if (userDialog.value.visible && userDialog.value.activeTab === 'Activity') {
-                void onPeriodChange();
+                void onPeriodChange(period);
             }
         }
     );
@@ -932,34 +902,6 @@
         },
         { deep: true }
     );
-    watch(
-        () => userDialog.value.visible,
-        (visible) => {
-            if (!visible) return;
-            nextTick(() => {
-                activityChart?.resize();
-                overlapChart?.resize();
-            });
-            if (userDialog.value.activeTab === 'Activity') {
-                void loadForVisibleTab();
-            }
-        }
-    );
-    watch(
-        () => userDialog.value.activeTab,
-        (activeTab) => {
-            if (activeTab === 'Activity' && userDialog.value.visible) {
-                void loadForVisibleTab();
-            }
-        }
-    );
-
-    onMounted(async () => {
-        await applySettingsForCurrentContext();
-        if (userDialog.value.visible && userDialog.value.activeTab === 'Activity') {
-            await loadForVisibleTab();
-        }
-    });
 
     onBeforeUnmount(() => {
         clearTimeout(easterEggTimer);

--- a/src/components/dialogs/UserDialog/activity/DailyPlaytime.vue
+++ b/src/components/dialogs/UserDialog/activity/DailyPlaytime.vue
@@ -100,8 +100,7 @@
         const rangeDays = props.rangeDays;
         const rangeStart = rangeDays > 0 ? now - rangeDays * 86400000 : sessions[0].start;
         const dayMap = new Map();
-        const ONE_DAY_MS = 86400000;
-        let lastDayStart = -1;
+        let lastDayStart;
         let lastDayKey = '';
 
         for (const session of sessions) {
@@ -111,16 +110,18 @@
 
             let cursor = clippedStart;
             while (cursor < clippedEnd) {
-                const dayStart = Math.floor(cursor / ONE_DAY_MS) * ONE_DAY_MS;
                 let dayKey;
-                if (dayStart === lastDayStart) {
+                if (cursor < lastDayStart) {
                     dayKey = lastDayKey;
                 } else {
+                    const dayStart = new Date(cursor);
+                    dayStart.setHours(0, 0, 0, 0);
                     dayKey = formatTimestampKey(dayStart);
-                    lastDayStart = dayStart;
+                    dayStart.setDate(dayStart.getDate() + 1);
+                    lastDayStart = dayStart.getTime();
                     lastDayKey = dayKey;
                 }
-                const nextDayStart = dayStart + ONE_DAY_MS;
+                const nextDayStart = lastDayStart;
                 const segmentEnd = Math.min(clippedEnd, nextDayStart);
                 dayMap.set(dayKey, (dayMap.get(dayKey) || 0) + (segmentEnd - cursor));
                 cursor = nextDayStart;
@@ -143,14 +144,19 @@
         const chartDom = chartRef.value;
         if (!chartDom) return;
 
+        let hasAnimated = false;
+
         if (!echartsInstance) {
             echartsInstance = echarts.init(chartDom, isDarkMode.value ? 'dark' : null);
             resizeObserver = new ResizeObserver((entries) => {
                 for (const entry of entries) {
                     echartsInstance?.resize({
                         width: entry.contentRect.width,
-                        animation: { duration: 300 }
+                        animation: {
+                            duration: hasAnimated ? 0 : 300
+                        }
                     });
+                    hasAnimated = true;
                 }
             });
             resizeObserver.observe(chartDom);

--- a/src/coordinators/userCoordinator.js
+++ b/src/coordinators/userCoordinator.js
@@ -587,8 +587,6 @@ export async function refreshUserDialogAvatars(fileId) {
     if (fileId) {
         D.loading = true;
     }
-    D.avatarSorting = 'update';
-    D.avatarReleaseStatus = 'all';
     const params = {
         n: 50,
         offset: 0,

--- a/src/shared/utils/activityEngine.js
+++ b/src/shared/utils/activityEngine.js
@@ -1,6 +1,5 @@
 export const ONLINE_SESSION_MERGE_GAP_MS = 5 * 60 * 1000;
 export const DEFAULT_MAX_SESSION_MS = 8 * 60 * 60 * 1000;
-const ONE_HOUR_MS = 60 * 60 * 1000;
 
 export function buildSessionsFromEvents(events, initialStart = null) {
     const sessions = [];
@@ -129,7 +128,7 @@ export function buildHeatmapBuckets(
         while (cursor < end) {
             const date = new Date(cursor);
             const slot = date.getDay() * 24 + date.getHours();
-            date.setUTCHours(date.getUTCHours() + 1, 0, 0, 0);
+            date.setHours(date.getHours() + 1, 0, 0, 0);
             const nextHourMs = date.getTime();
             const segmentEnd = Math.min(nextHourMs, end);
             buckets[slot] += (segmentEnd - cursor) / 60000;
@@ -432,23 +431,24 @@ export function buildDailySummary(
 ) {
     const dayMap = new Map();
     const clipped = clipSessionsToRange(sessions, rangeStartMs, rangeEndMs);
-    const ONE_DAY_MS = 86400000;
-    let lastDayStart = -1;
+    let lastDayStart;
     let lastDayKey = '';
 
     for (const session of clipped) {
         let cursor = session.start;
         while (cursor < session.end) {
-            const dayStart = Math.floor(cursor / ONE_DAY_MS) * ONE_DAY_MS;
             let dayKey;
-            if (dayStart === lastDayStart) {
+            if (cursor < lastDayStart) {
                 dayKey = lastDayKey;
             } else {
+                const dayStart = new Date(cursor);
+                dayStart.setHours(0, 0, 0, 0);
                 dayKey = formatTimestampKey(dayStart);
-                lastDayStart = dayStart;
+                dayStart.setDate(dayStart.getDate() + 1);
+                lastDayStart = dayStart.getTime();
                 lastDayKey = dayKey;
             }
-            const nextDayStart = dayStart + ONE_DAY_MS;
+            const nextDayStart = lastDayStart;
             const segmentEnd = Math.min(session.end, nextDayStart);
             const duration = segmentEnd - cursor;
             dayMap.set(dayKey, (dayMap.get(dayKey) || 0) + duration);
@@ -465,10 +465,9 @@ export function buildDailySummary(
 }
 
 export function formatTimestampKey(timestamp) {
-    const date = new Date(timestamp);
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(date.getUTCDate()).padStart(2, '0');
+    const year = timestamp.getFullYear();
+    const month = String(timestamp.getMonth() + 1).padStart(2, '0');
+    const day = String(timestamp.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
 }
 

--- a/src/stores/activity.js
+++ b/src/stores/activity.js
@@ -113,6 +113,13 @@ export const useActivityStore = defineStore('Activity', () => {
     let fullCacheBuildRunning = false;
     let fullCacheBuildAborted = false;
 
+    const userActivity = ref({
+        lastLoadedUserId: '',
+        activeRequestId: 0,
+        activeOverlapRequestId: 0,
+        activeTopWorldsRequestId: 0
+    });
+
     async function getCache(userId, isSelf = false) {
         const snapshot = await hydrateSnapshot(userId, isSelf);
         return {
@@ -244,27 +251,29 @@ export const useActivityStore = defineStore('Activity', () => {
         );
 
         let view = targetSnapshot.overlapViews.get(cacheKey);
-        if (view?.builtFromCursor === cursor) {
+        if (!forceRefresh && view?.builtFromCursor === cursor) {
             return view;
         }
 
-        const persisted = await database.getActivityBucketCacheV2({
-            ownerUserId: currentUserId,
-            targetUserId,
-            rangeDays,
-            viewKind: database.ACTIVITY_VIEW_KIND.OVERLAP,
-            excludeKey
-        });
-        if (persisted?.builtFromCursor === cursor) {
-            view = {
-                ...persisted.summary,
-                rawBuckets: persisted.rawBuckets,
-                normalizedBuckets: persisted.normalizedBuckets,
-                builtFromCursor: persisted.builtFromCursor,
-                builtAt: persisted.builtAt
-            };
-            targetSnapshot.overlapViews.set(cacheKey, view);
-            return view;
+        if (!forceRefresh) {
+            const persisted = await database.getActivityBucketCacheV2({
+                ownerUserId: currentUserId,
+                targetUserId,
+                rangeDays,
+                viewKind: database.ACTIVITY_VIEW_KIND.OVERLAP,
+                excludeKey
+            });
+            if (persisted?.builtFromCursor === cursor) {
+                view = {
+                    ...persisted.summary,
+                    rawBuckets: persisted.rawBuckets,
+                    normalizedBuckets: persisted.normalizedBuckets,
+                    builtFromCursor: persisted.builtFromCursor,
+                    builtAt: persisted.builtAt
+                };
+                targetSnapshot.overlapViews.set(cacheKey, view);
+                return view;
+            }
         }
 
         view = await workerCall('computeOverlapView', {
@@ -491,6 +500,7 @@ export const useActivityStore = defineStore('Activity', () => {
         getCache,
         getCachedDays,
         isRefreshing,
+        userActivity,
         loadActivity,
         loadActivityView,
         loadOverlap,

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -207,6 +207,7 @@ export const useUserStore = defineStore('User', () => {
         },
         avatarSorting: 'update',
         avatarReleaseStatus: 'all',
+        activityPeriodDays: '30',
         memo: '',
         $avatarInfo: {
             ownerId: '',


### PR DESCRIPTION
 - Fix several activity styling issues with the following changes:
   - Preparing Data hint no longer shows on refreshes
   - Hide Overlap if there's no data
   - Hide Worlds if there's no data
   - Don't hide "Exclude Hours" settings for the Overlap graph if there's no Overlap data outside the selected hours
   - Make "Daily Playtime" graph animation only occur once per user-dialog open and on period changes
     - This fixes the odd animation that happens if you switch into the Activity Tab a second time.
 - Fix activity period settings so it now properly saves for the current session.
   - User/friends no longer use two different variables, and now save under the same variable.
   - Other requestIds are also now using the activity store.
   - Additionally fixed the behavior where the data ignores the currently stored period.
 - Fix Overlap data shifting when excluded hours are selected and a force refresh occurs
 - Fix Daily Playtime and Heatmap graph so the data uses local time again.
   - This was a result of attempting to fix the freezing issue, which was a result of DST causing the cursor pointer to not progress, causing an infinite loop. This is now resolved and we return to local time, which now shows the data like it did before.
 - Cleanup Activity by removing several unneeded/duplicated watchers that resulted in duplicate calls
 
 Additional fixes not related to activity include: 
 - Self User Dialog Avatar tab no longer keeps resetting back to default sort settings when the user dialog is reopened
 - Removed a duplicated function in `api/group.js`
 
 Edit: Removed a slightly misleading note