### PR TITLE
Modify vswhere command in build-all.ps1

### DIFF
--- a/build-scripts/build-all.ps1
+++ b/build-scripts/build-all.ps1
@@ -2,7 +2,7 @@ cd ..
 
 $ErrorActionPreference = "Stop"
 
-$installPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -version 16.0 -property installationpath
+$installPath = (&"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -version 16.0 -property installationpath) | Select-Object -Last 1
 Import-Module (Join-Path $installPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
 Enter-VsDevShell -VsInstallPath $installPath -SkipAutomaticLocation
 


### PR DESCRIPTION
Fixes detection issue when there is multiple Visual Studio installs on same machine.