### PR TITLE
Add missing migration

### DIFF
--- a/build-scripts/build-all.ps1
+++ b/build-scripts/build-all.ps1
@@ -2,7 +2,7 @@ cd ..
 
 $ErrorActionPreference = "Stop"
 
-$installPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -version 16.0 -property installationpath
+$installPath = (&"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -version 16.0 -property installationpath) | Select-Object -Last 1
 Import-Module (Join-Path $installPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
 Enter-VsDevShell -VsInstallPath $installPath -SkipAutomaticLocation
 

--- a/src/stores/settings/general.js
+++ b/src/stores/settings/general.js
@@ -166,33 +166,18 @@ export const useGeneralSettingsStore = defineStore('GeneralSettings', () => {
             autoAcceptInviteGroupsStrConfig
         );
 
-        // When "Custom Favorite Groups" was first added to the auto-accept dialog, users
-        // who had previously used the "VRCX Favorites" option (stored internally as
-        // 'Selected Favorites') found that nobody was being auto-accepted anymore.
-        // The cause: the old setting stored only the mode string (VRCX_autoAcceptInviteRequests),
-        // and "VRCX Favorites" implicitly meant "use whatever groups are in
-        // VRCX_localFavoriteFriendsGroups". The new UI introduced a dedicated
-        // VRCX_autoAcceptInviteGroups key for the group picker, but no migration was written —
-        // so on first launch after the update it defaulted to an empty array and silently
-        // accepted nobody.
-        //
-        // Fix: if someone has 'Selected Favorites' set but the groups list is still at its
-        // default empty value, we know they're coming from the old version and migrate them.
         if (
             autoAcceptInviteRequestsConfig === 'Selected Favorites' &&
             autoAcceptInviteGroupsStrConfig === '[]'
         ) {
             const oldGroups = JSON.parse(localFavoriteFriendsGroupsStrConfig);
             if (oldGroups.length === 0) {
-                // They had no group filter before, meaning all local favorites were accepted.
-                // "All Favorites" covers that now (and also includes VRChat API favorites).
                 autoAcceptInviteRequests.value = 'All Favorites';
                 configRepository.setString(
                     'VRCX_autoAcceptInviteRequests',
                     'All Favorites'
                 );
             } else {
-                // They had specific local groups selected — carry those over with the local: prefix.
                 const migratedGroups = oldGroups.map((g) => `local:${g}`);
                 autoAcceptInviteGroups.value = migratedGroups;
                 configRepository.setString(

--- a/src/stores/settings/general.js
+++ b/src/stores/settings/general.js
@@ -165,6 +165,43 @@ export const useGeneralSettingsStore = defineStore('GeneralSettings', () => {
         autoAcceptInviteGroups.value = JSON.parse(
             autoAcceptInviteGroupsStrConfig
         );
+
+        // When "Custom Favorite Groups" was first added to the auto-accept dialog, users
+        // who had previously used the "VRCX Favorites" option (stored internally as
+        // 'Selected Favorites') found that nobody was being auto-accepted anymore.
+        // The cause: the old setting stored only the mode string (VRCX_autoAcceptInviteRequests),
+        // and "VRCX Favorites" implicitly meant "use whatever groups are in
+        // VRCX_localFavoriteFriendsGroups". The new UI introduced a dedicated
+        // VRCX_autoAcceptInviteGroups key for the group picker, but no migration was written —
+        // so on first launch after the update it defaulted to an empty array and silently
+        // accepted nobody.
+        //
+        // Fix: if someone has 'Selected Favorites' set but the groups list is still at its
+        // default empty value, we know they're coming from the old version and migrate them.
+        if (
+            autoAcceptInviteRequestsConfig === 'Selected Favorites' &&
+            autoAcceptInviteGroupsStrConfig === '[]'
+        ) {
+            const oldGroups = JSON.parse(localFavoriteFriendsGroupsStrConfig);
+            if (oldGroups.length === 0) {
+                // They had no group filter before, meaning all local favorites were accepted.
+                // "All Favorites" covers that now (and also includes VRChat API favorites).
+                autoAcceptInviteRequests.value = 'All Favorites';
+                configRepository.setString(
+                    'VRCX_autoAcceptInviteRequests',
+                    'All Favorites'
+                );
+            } else {
+                // They had specific local groups selected — carry those over with the local: prefix.
+                const migratedGroups = oldGroups.map((g) => `local:${g}`);
+                autoAcceptInviteGroups.value = migratedGroups;
+                configRepository.setString(
+                    'VRCX_autoAcceptInviteGroups',
+                    JSON.stringify(migratedGroups)
+                );
+            }
+        }
+
         recentActionCooldownEnabled.value = recentActionCooldownEnabledConfig;
         recentActionCooldownMinutes.value = recentActionCooldownMinutesConfig;
     }


### PR DESCRIPTION
When updating to 2026.05.03 build, favorites gets moved to Tools->Auto Status & Invites. However, there was never a migration to move the array from "Only Accept From" field to the new format which caused the array to become null. This caused all requests from favorites silently to be not accepted as there is no favorite groups to accept.
