### PR TITLE
Fix (quick-search) : trigger search on paste and IME composition events

### DIFF
--- a/src/components/QuickSearchSync.vue
+++ b/src/components/QuickSearchSync.vue
@@ -58,6 +58,7 @@
             //         filterState.filtered.groups.add(groupId);
             //     }
             // }
-        }
+        },
+        { flush: 'sync' }
     );
 </script>


### PR DESCRIPTION
## Description

The Quick Search bar showed no results when text was pasted or confirmed via an IME (e.g. Japanese, Chinese) without a subsequent keystroke. The user had to type or delete a character to force the results to appear.

## Root Cause

The `QuickSearchSync` component watches `filterState.search` to sync the input value to the search store. Vue's default watch scheduler (`flush: 'pre'`) batches and defers reactivity updates to the next microtask tick. This means that when a value is set all at once — via `Ctrl+V` paste or IME `compositionend` — the watcher callback is not invoked until the next keystroke triggers a new reactive cycle.

## Fix

Adding `{ flush: 'sync' }` to the watcher ensures the query is dispatched to the store synchronously as soon as `filterState.search` changes, regardless of how the value was set.

```diff
- watch(
-     () => filterState.search,
-     async (value) => {
-         ...
-     }
- );
+ watch(
+     () => filterState.search,
+     async (value) => {
+         ...
+     },
+     { flush: 'sync' }
+ );
```

## Testing

- [ ] Paste a known friend/avatar/world name into the Quick Search bar → results appear immediately without needing an extra keystroke
- [ ] Type normally → behaviour unchanged
- [ ] Use an IME to input a full word and confirm → results appear immediately

Closes #1721