### PR TITLE
Fix (linux) : prevent false crash detection on graceful VRChat exit

### DIFF
--- a/src/coordinators/gameCoordinator.js
+++ b/src/coordinators/gameCoordinator.js
@@ -162,6 +162,10 @@ export async function runDeleteVRChatCacheFlow(ref) {
 
 /**
  * Checks if VRChat crashed and attempts to relaunch.
+ *
+ * On Linux the graceful-exit flag may not be written in time before this
+ * function runs (race condition with SIGTERM). A 500 ms deferred
+ * double-check is performed before committing to a relaunch.
  */
 export function runCheckIfGameCrashedFlow() {
     const advancedSettingsStore = useAdvancedSettingsStore();
@@ -176,26 +180,44 @@ export function runCheckIfGameCrashedFlow() {
         if (result || !isRealInstance(location)) {
             return;
         }
-        // check if relaunched less than 2mins ago (prevent crash loop)
-        if (
-            gameStore.state.lastCrashedTime &&
-            new Date().getTime() - gameStore.state.lastCrashedTime.getTime() <
-                120_000
-        ) {
-            console.log('VRChat was recently crashed, not relaunching');
-            return;
-        }
-        gameStore.setLastCrashedTime(new Date());
-        // wait a bit for SteamVR to potentially close before deciding to relaunch
-        let restartDelay = 8000;
-        if (gameStore.isGameNoVR) {
-            // wait for game to close before relaunching
-            restartDelay = 2000;
-        }
-        workerTimers.setTimeout(
-            () => runRestartCrashedGameFlow(location),
-            restartDelay
-        );
+
+        // On Linux, VrcClosedGracefully() can return false even after a clean
+        // exit (SIGTERM race condition). Re-check after a short delay to
+        // confirm the exit was indeed a crash before attempting a relaunch.
+        workerTimers.setTimeout(() => {
+            AppApi.VrcClosedGracefully().then((confirmedGraceful) => {
+                if (confirmedGraceful) {
+                    console.log(
+                        'VRChat exited gracefully (confirmed on second check), skipping relaunch'
+                    );
+                    return;
+                }
+
+                // check if relaunched less than 2mins ago (prevent crash loop)
+                if (
+                    gameStore.state.lastCrashedTime &&
+                    new Date().getTime() -
+                        gameStore.state.lastCrashedTime.getTime() <
+                        120_000
+                ) {
+                    console.log(
+                        'VRChat was recently crashed, not relaunching'
+                    );
+                    return;
+                }
+                gameStore.setLastCrashedTime(new Date());
+                // wait a bit for SteamVR to potentially close before deciding to relaunch
+                let restartDelay = 8000;
+                if (gameStore.isGameNoVR) {
+                    // wait for game to close before relaunching
+                    restartDelay = 2000;
+                }
+                workerTimers.setTimeout(
+                    () => runRestartCrashedGameFlow(location),
+                    restartDelay
+                );
+            });
+        }, 500);
     });
 }
 


### PR DESCRIPTION
## Description

On Linux, VRCX incorrectly detects a normal VRChat exit (Alt+F4, in-game exit button, SIGTERM) as a crash and attempts to relaunch the game. This is a Linux-specific regression that does not affect Windows.

## Root Cause

`AppApi.VrcClosedGracefully()` reads a flag written by the native layer when VRChat exits cleanly. On Linux, there is a race condition: when the process receives SIGTERM, it is torn down faster than on Windows, and the graceful-exit flag may not be flushed to disk before `runCheckIfGameCrashedFlow()` reads it. The flag therefore returns `false` even though the exit was clean, causing VRCX to treat it as a crash.

This was reported in #1707 and the exact location in the code was identified by the reporter at `gameCoordinator.js:179`.

## Fix

A 500 ms deferred double-check of `VrcClosedGracefully()` is added before committing to a relaunch. If the second check confirms the exit was clean, the relaunch is aborted. The 500 ms overhead is negligible given the existing `restartDelay` of 2–8 seconds that follows.

```diff
  AppApi.VrcClosedGracefully().then((result) => {
      if (result || !isRealInstance(location)) {
          return;
      }
-     // check if relaunched less than 2mins ago (prevent crash loop)
-     if (...) { ... }
-     gameStore.setLastCrashedTime(new Date());
-     workerTimers.setTimeout(() => runRestartCrashedGameFlow(location), restartDelay);
+     // Re-check after 500ms to guard against the SIGTERM race condition on Linux
+     workerTimers.setTimeout(() => {
+         AppApi.VrcClosedGracefully().then((confirmedGraceful) => {
+             if (confirmedGraceful) { return; }
+             // check if relaunched less than 2mins ago (prevent crash loop)
+             if (...) { ... }
+             gameStore.setLastCrashedTime(new Date());
+             workerTimers.setTimeout(() => runRestartCrashedGameFlow(location), restartDelay);
+         });
+     }, 500);
  });
```

## Testing

- [ ] Linux: exit VRChat normally (in-game button, Alt+F4) with "Relaunch after crash" enabled → VRCX should **not** attempt to relaunch
- [ ] Linux: kill VRChat with `kill -9` (SIGKILL) → VRCX **should** attempt to relaunch after the delay
- [ ] Windows: exit and crash behaviour unchanged

Fixes #1707