### PR TITLE
Match Steam's compat tool search order when finding wine

### DIFF
--- a/Dotnet/AppApi/Electron/RegistryPlayerPrefs.cs
+++ b/Dotnet/AppApi/Electron/RegistryPlayerPrefs.cs
@@ -240,21 +240,12 @@ namespace VRCX
             }
 
             string steamPath = _steamPath;
-            string steamAppsCommonPath = Path.Join(steamPath, "steamapps", "common");
-            string compatabilityToolsPath = Path.Join(steamPath, "compatibilitytools.d");
-            string protonPath = Path.Join(steamAppsCommonPath, compatTool);
-            string compatToolPath = Path.Join(compatabilityToolsPath, compatTool);
             string winePath = "";
-            if (Directory.Exists(compatToolPath))
-            {
-                winePath = Path.Join(compatToolPath, "files", "bin", "wine");
-                if (!File.Exists(winePath))
-                {
-                    Console.WriteLine("Wine not found in CompatTool path");
-                    return null;
-                }
-            }
-            else if (Directory.Exists(protonPath))
+
+            // A Proton install in a Steam library uses a different layout than a
+            // registered compat tool, so check it on its own.
+            string protonPath = Path.Join(steamPath, "steamapps", "common", compatTool);
+            if (Directory.Exists(protonPath))
             {
                 winePath = Path.Join(protonPath, "dist", "bin", "wine");
                 if (!File.Exists(winePath))
@@ -263,32 +254,13 @@ namespace VRCX
                     return null;
                 }
             }
-            else if (Directory.Exists(compatabilityToolsPath))
-            {
-                var dirs = Directory.GetDirectories(compatabilityToolsPath);
-                foreach (var dir in dirs)
-                {
-                    if (dir.Contains(compatTool))
-                    {
-                        winePath = Path.Join(dir, "files", "bin", "wine");
-                        if (File.Exists(winePath))
-                        {
-                            break;
-                        }
-                    }
-                }
-                if (!File.Exists(winePath))
-                {
-                    Console.WriteLine("Wine not found in CompatTool path");
-                    return null;
-                }
-            }
             else
             {
-                // The checks above only cover Steam's own compatibilitytools.d, but Steam searches more locations than that.
-                // Fall back to the rest of its documented search order.
+                // Search every compatibilitytools.d Steam looks in, in its
+                // documented order.
                 // https://github.com/ValveSoftware/steam-for-linux/issues/6310#issuecomment-511630263
-                // Each root is a directory holding tool subdirs, except STEAM_EXTRA_COMPAT_TOOLS_PATHS entries which can also be a tool directory themselves, so check both forms.
+                // STEAM_EXTRA_COMPAT_TOOLS_PATHS entries can be a tool directory
+                // themselves rather than a parent of one, so check both forms.
                 var roots = new List<string>
                 {
                     "/usr/share/steam/compatibilitytools.d",
@@ -297,10 +269,11 @@ namespace VRCX
                 var extraPaths = Environment.GetEnvironmentVariable("STEAM_EXTRA_COMPAT_TOOLS_PATHS");
                 if (!string.IsNullOrEmpty(extraPaths))
                     roots.AddRange(extraPaths.Split(':', StringSplitOptions.RemoveEmptyEntries));
+                roots.Add(Path.Join(steamPath, "compatibilitytools.d"));
 
                 foreach (var root in roots)
                 {
-                    var candidates = new List<string> { root };
+                    var candidates = new List<string> { root, Path.Join(root, compatTool) };
                     if (Directory.Exists(root))
                         candidates.AddRange(Directory.GetDirectories(root, $"*{compatTool}*"));
 

--- a/Dotnet/AppApi/Electron/RegistryPlayerPrefs.cs
+++ b/Dotnet/AppApi/Electron/RegistryPlayerPrefs.cs
@@ -283,6 +283,38 @@ namespace VRCX
                     return null;
                 }
             }
+            else
+            {
+                // The checks above only cover Steam's own compatibilitytools.d, but Steam searches more locations than that.
+                // Fall back to the rest of its documented search order.
+                // https://github.com/ValveSoftware/steam-for-linux/issues/6310#issuecomment-511630263
+                // Each root is a directory holding tool subdirs, except STEAM_EXTRA_COMPAT_TOOLS_PATHS entries which can also be a tool directory themselves, so check both forms.
+                var roots = new List<string>
+                {
+                    "/usr/share/steam/compatibilitytools.d",
+                    "/usr/local/share/steam/compatibilitytools.d",
+                };
+                var extraPaths = Environment.GetEnvironmentVariable("STEAM_EXTRA_COMPAT_TOOLS_PATHS");
+                if (!string.IsNullOrEmpty(extraPaths))
+                    roots.AddRange(extraPaths.Split(':', StringSplitOptions.RemoveEmptyEntries));
+
+                foreach (var root in roots)
+                {
+                    var candidates = new List<string> { root };
+                    if (Directory.Exists(root))
+                        candidates.AddRange(Directory.GetDirectories(root, $"*{compatTool}*"));
+
+                    foreach (var candidate in candidates)
+                    {
+                        winePath = Path.Join(candidate, "files", "bin", "wine");
+                        if (File.Exists(winePath))
+                            break;
+                        winePath = "";
+                    }
+                    if (winePath != "")
+                        break;
+                }
+            }
 
             if (winePath == "")
             {


### PR DESCRIPTION
`GetVRChatWinePath()` looks for the compat tool under `steamapps/common` and the Steam install's `compatibilitytools.d`. But Steam searches more locations than that, so VRCX misses tools registered the other ways Steam supports.
  
Per [ValveSoftware/steam-for-linux#6310](https://github.com/ValveSoftware/steam-for-linux/issues/6310#issuecomment-511630263), Steam searches these in order:

- `/usr/share/steam/compatibilitytools.d`
- `/usr/local/share/steam/compatibilitytools.d`
- colon-separated paths in `$STEAM_EXTRA_COMPAT_TOOLS_PATHS`
- `~/.steam/root/compatibilitytools.d`

VRCX only covered the last of those (it's the same dir as the Steam install's `compatibilitytools.d`). This searches all of them, in that order, so a tool registered in any location Steam supports is found.

I hit this on NixOS, where my compat tool of choice is installed out-of-tree and registered via `STEAM_EXTRA_COMPAT_TOOLS_PATHS`, so none of the previously-checked paths existed and registry reads failed with `Wine not found in CompatTool path`. But it applies to anyone using those supported locations.

The `steamapps/common` Proton check is unchanged. The compat-tool lookup is refactored into a single ordered scan over the locations above instead of the previous per-location branches. Existing setups resolve the same wine they did before, since their location is still in the list. The env-var entries are checked both as a tool directory directly and as a parent of tool subdirs, since both forms appear in practice.

When a tool is registered in more than one location, this now follows Steam's documented precedence (env paths before the local install dir).