### PR TITLE
Check wine reg exit code instead of filtering stderr

### DIFF
--- a/Dotnet/AppApi/Electron/RegistryPlayerPrefs.cs
+++ b/Dotnet/AppApi/Electron/RegistryPlayerPrefs.cs
@@ -330,11 +330,9 @@ namespace VRCX
             string error = process.StandardError.ReadToEnd();
             process.WaitForExit();
 
-            if (!string.IsNullOrEmpty(error) &&
-                !error.Contains("wineserver: using server-side synchronization.") &&
-                !error.Contains("fixme:wineusb:query_id"))
+            if (process.ExitCode != 0)
             {
-                logger.Error($"Wine reg command error: {error}");
+                logger.Error($"Wine reg command failed (exit {process.ExitCode}): {error}");
                 return null;
             }
 


### PR DESCRIPTION
`GetWineRegCommand` treats a `wine reg` query as failed if stderr contains anything other than two hardcoded lines (`wineserver: using server-side synchronization.` and `fixme:wineusb:query_id`). But wine writes plenty of unrelated warnings to stderr on a *successful* run, especially when invoked outside the Steam runtime, so the whitelist can't keep up and good results get thrown away.

I hit this running wine from a compat tool registered out-of-tree (#1792). The `reg query` succeeded and returned the data on stdout, but stderr also had lines like:

`_r_debug not found in ld.so`
`Wine cannot find the FreeType font library.`
`fixme:ntoskrnl:... stub!`

None match the whitelist, so VRCX logged `Wine reg command error` and discarded the result. `GetVRChatRegistryJson` then threw `Failed to get VRC registry data`, breaking registry/PlayerPrefs reads even though the query worked.

Every wine version and host configuration emits different messages on stderr. so the check for whether the command succeeded should be its exit code, which I was able to verify:

| query | exit code |
|---|---|
| existing value | `0` |
| missing value | `1` |
| missing key | `1` |
| missing/broken prefix | `1` |

So this switches the check to `process.ExitCode != 0` and keeps stderr only as context in the failure log. Successful queries with stderr messages now return their output and actual failures still return `null`. Output is still parsed downstream and rejects unparseable values, so malformed output is still caught.

Companion to #1792. That one lets VRCX find the wine binary, this lets it use the result once it does.