### PR TITLE
Fix: instance user counter randomly missing in user dialog

### DIFF
--- a/src/components/InstanceActionBar.vue
+++ b/src/components/InstanceActionBar.vue
@@ -309,14 +309,14 @@
     const showLastJoinIndicator = computed(() => props.showLastJoin && lastJoin.value);
     const hasInstanceMetadata = computed(() => {
         return !!(
-            props.instance.value?.queueSize ||
+            props.instance?.queueSize ||
             instanceInfoState.isAgeGated ||
-            (props.instance.minimumAvatarPerformance && props.instance.minimumAvatarPerformance !== 'None')
+            (props.instance?.minimumAvatarPerformance && props.instance.minimumAvatarPerformance !== 'None')
         );
     });
 
     const performanceIcon = computed(() => {
-        const rank = props.instance.minimumAvatarPerformance?.toLowerCase();
+        const rank = props.instance?.minimumAvatarPerformance?.toLowerCase();
         if (!rank || rank === 'none') return null;
         return `/images/performance_ranks/${rank}.png`;
     });
@@ -418,7 +418,10 @@
 
     watch(() => resolvedLastJoinLocation.value, parseLastJoin, { immediate: true });
     watch(() => props.currentlocation, parseLastJoin);
+    // deep: the instance object is updated in place (Object.assign) when the
+    // getInstance response arrives, so a shallow watch would miss it
     watch([resolvedInstanceLocation, () => props.instance, () => props.friendcount], parseInstanceInfo, {
-        immediate: true
+        immediate: true,
+        deep: true
     });
 </script>

--- a/src/components/__tests__/InstanceActionBar.test.js
+++ b/src/components/__tests__/InstanceActionBar.test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { nextTick } from 'vue';
+import { nextTick, reactive } from 'vue';
 
 const mocks = vi.hoisted(() => ({
     checkCanInviteSelf: vi.fn(() => true),
@@ -127,8 +127,12 @@ vi.mock('lucide-vue-next', () => ({
     LogIn: { template: '<i data-testid="icon-login" />' },
     Mail: { template: '<i data-testid="icon-mail" />' },
     MapPin: { template: '<i data-testid="icon-map" />' },
+    PowerIcon: { template: '<i data-testid="icon-power" />' },
     RefreshCw: { template: '<i data-testid="icon-refresh" />' },
-    UsersRound: { template: '<i data-testid="icon-users" />' }
+    UsersRound: { template: '<i data-testid="icon-users" />' },
+    UserPlus2: { template: '<i data-testid="icon-user-plus" />' },
+    SquareStack: { template: '<i data-testid="icon-queue" />' },
+    IdCard: { template: '<i data-testid="icon-age-gate" />' }
 }));
 
 import InstanceActionBar from '../InstanceActionBar.vue';
@@ -331,9 +335,7 @@ describe('InstanceActionBar.vue', () => {
 
         const closeBtn = wrapper
             .findAll('button')
-            .find((btn) =>
-                btn.text().includes('dialog.user.info.close_instance')
-            );
+            .find((btn) => btn.find('[data-testid="icon-power"]').exists());
         expect(closeBtn).toBeTruthy();
 
         await closeBtn.trigger('click');
@@ -350,6 +352,37 @@ describe('InstanceActionBar.vue', () => {
         expect(mocks.toastSuccess).toHaveBeenCalledWith(
             'message.instance.closed'
         );
+    });
+
+    it('shows user counter once instance data arrives via in-place update', async () => {
+        // simulates the getInstance response being merged into the same
+        // object after mount (vrcx-team/VRCX#1641)
+        const instance = reactive({});
+        const wrapper = mountBar({
+            instance,
+            friendcount: 0,
+            showLaunch: false,
+            showInvite: false,
+            showRefresh: false,
+            showHistory: false,
+            showLastJoin: false
+        });
+
+        expect(wrapper.text()).not.toContain('4/16');
+
+        Object.assign(instance, {
+            ownerId: 'usr_owner',
+            capacity: 16,
+            userCount: 4,
+            hasCapacityForYou: true,
+            platforms: { standalonewindows: 3, android: 1, ios: 0 },
+            gameServerVersion: 123,
+            $disabledContentSettings: []
+        });
+        await nextTick();
+        await nextTick();
+
+        expect(wrapper.text()).toContain('4/16');
     });
 
     it('hides launch and invite buttons when invite-self is not allowed', () => {

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -537,8 +537,9 @@ export const useUserStore = defineStore('User', () => {
                 ref: {}
             };
         }
-        const instanceRef = instanceStore.cachedInstances.get(L.tag) || {};
-        Object.assign(D.instance.ref, instanceRef);
+        // replace instead of merging into the old ref, otherwise stale data
+        // from a previously viewed instance lingers when the dialog updates
+        D.instance.ref = instanceStore.cachedInstances.get(L.tag) || {};
         D.instance.friendCount = friendCount;
     }
 


### PR DESCRIPTION
## Introduction to the PR

Hi. I have been bothered with issue #1641 for more than 3 months and it's never fixed so far so I had to try to fix it myself.
However I am completely new to NodeJS and Visual C++ -- I cannot even build this project due to unable to install all dependencies properly.
So this PR is completely generated by Claude Code Fable 5 (which got released 2 days earlier) and I have no way to verify this works, but I really hope this provides any help.
If this PR does not meet the requirements of this repo, please close it. But I really hope this bug gets fixed soon because I encounter this more than 50 times per day.

Below are generated by Fable 5.

## Summary

Fixes #1641 — the instance user counter / capacity indicator in the user dialog randomly disappears, and reopening the dialog usually brings it back.

## Root cause

`InstanceActionBar.vue` decides whether to render the counter (`instanceInfoState.isValidInstance`) inside a **shallow** watcher on the `instance` prop:

1. When the user dialog opens for an instance that is not yet in `cachedInstances`, `userDialog.instance.ref` is `{}` and a `getInstance` request is fired. The watcher runs once with the empty object and hides the counter.
2. When the response arrives, `applyInstance` → `applyUserDialogLocation()` merged it into the **same object** via `Object.assign(D.instance.ref, instanceRef)`. The prop reference never changed, so the shallow watcher never re-ran and the counter stayed hidden.
3. Reopening the dialog fixed it because the instance was now cached, so the freshly created `ref` object was already populated when the watcher first ran — hence the randomness (cold cache → broken, warm cache → works).

## Changes

- **`InstanceActionBar.vue`**: watch the `instance` prop with `deep: true` so in-place updates re-run `parseInstanceInfo`. This also covers the World/Group dialog instance lists, which pass cached instance objects that are mutated in place the same way. Also fixed a `props.instance.value` typo (it is not a ref) and missing null-safety in `hasInstanceMetadata`/`performanceIcon` (the `instance` prop defaults to `null`).
- **`stores/user.js`**: `applyUserDialogLocation` now replaces `D.instance.ref` instead of merging into the old object, so stale data from a previously viewed instance cannot linger when the dialog target moves between instances.
- **`InstanceActionBar.test.js`**: added a regression test simulating the late `getInstance` response (counter must appear after an in-place update of the instance object), and repaired two tests that were already failing on master: added missing lucide icon mocks (`PowerIcon`, `UserPlus2`, `SquareStack`, `IdCard`) and changed the close-instance button lookup to find it by icon instead of tooltip text (the tooltip text renders as a sibling of the button, not inside it).

## Testing

- `vitest run` on `InstanceActionBar.test.js` and `UserDialogInfoTab.test.js`: 11/11 pass (the two pre-existing failures in `InstanceActionBar.test.js` are fixed as part of this PR)
- oxlint / eslint / oxfmt clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)