### PR TITLE
Add Windows ARM64 build, installer, auto-sync and automated releases

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -1,7 +1,13 @@
 name: VRCX
 
 on:
-    - workflow_dispatch
+    workflow_dispatch:
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
 
 concurrency:
     group: ${{ github.ref }}
@@ -32,6 +38,9 @@ jobs:
             run:
                 shell: bash
         needs: [set_version, build_node]
+        strategy:
+            matrix:
+                arch: [x64, ARM64]
         steps:
             - uses: actions/checkout@v6
             - name: Setup .NET 10
@@ -46,11 +55,11 @@ jobs:
             - uses: actions/cache@v5
               with:
                   path: ~/.nuget/packages
-                  key: ${{ runner.os }}-nuget-${{ hashFiles('**/Dotnet/VRCX-Cef.csproj') }}
+                  key: ${{ runner.os }}-nuget-${{ matrix.arch }}-${{ hashFiles('**/Dotnet/VRCX-Cef.csproj') }}
                   restore-keys: |
                       ${{ runner.os }}-nuget-
-            - name: Build Cef .NET Application
-              run: dotnet build Dotnet/VRCX-Cef.csproj -p:Configuration=Release -p:WarningLevel=0 -p:Platform=x64 -p:PlatformTarget=x64 -p:RestorePackagesConfig=true -t:"Restore;Clean;Build" -m -a x64 --self-contained
+            - name: Build Cef .NET Application (${{ matrix.arch }})
+              run: dotnet build Dotnet/VRCX-Cef.csproj -p:Configuration=Release -p:WarningLevel=0 -p:Platform=${{ matrix.arch }} -p:RestorePackagesConfig=true -t:"Restore;Clean;Build" -m -a ${{ matrix.arch }} --self-contained
             - name: Check if we want to sign
               id: check_sign
               run: |
@@ -97,16 +106,17 @@ jobs:
                   path: build/Cef/html
             - name: Install NSIS
               run: choco install nsis -y
-            - name: Create NSIS installer
+            - name: Create NSIS installer (${{ matrix.arch }})
               uses: joncloud/makensis-action@v5.0
               with:
                   script-file: Installer/installer.nsi
                   additional-plugin-paths: Installer/Plugins
+                  args: /DARCH=${{ matrix.arch }}
             - name: Rename setup
               run: |
-                  file_name="VRCX_${{ needs.set_version.outputs.version }}_Setup.exe"
+                  file_name="VRCX_${{ needs.set_version.outputs.version }}_${{ matrix.arch }}_Setup.exe"
                   echo "Setup FileName: ${file_name}"
-                  mv Installer/VRCX_Setup.exe $file_name
+                  mv "Installer/VRCX_${{ matrix.arch }}_Setup.exe" "$file_name"
             - name: Sign Cef setup
               uses: azure/trusted-signing-action@v1
               if: steps.check_sign.outputs.sign == 'true'
@@ -121,18 +131,18 @@ jobs:
                   timestamp-rfc3161: http://timestamp.acs.microsoft.com
                   timestamp-digest: SHA256
                   files: |
-                      ${{ github.workspace }}\VRCX_${{ needs.set_version.outputs.version }}_Setup.exe
+                      ${{ github.workspace }}\VRCX_${{ needs.set_version.outputs.version }}_${{ matrix.arch }}_Setup.exe
 
-            - name: Upload Cef dotnet artifacts
+            - name: Upload Cef dotnet artifacts (${{ matrix.arch }})
               uses: actions/upload-artifact@v7
               with:
-                  name: Cef-Release
+                  name: Cef-Release-${{ matrix.arch }}
                   path: build/Cef
-            - name: Upload setup artifact
+            - name: Upload setup artifact (${{ matrix.arch }})
               uses: actions/upload-artifact@v7
               with:
-                  name: Cef-Setup
-                  path: VRCX_${{ needs.set_version.outputs.version }}_Setup.exe
+                  name: Cef-Setup-${{ matrix.arch }}
+                  path: VRCX_${{ needs.set_version.outputs.version }}_${{ matrix.arch }}_Setup.exe
 
     build_dotnet_linux:
         runs-on: ubuntu-latest
@@ -349,17 +359,21 @@ jobs:
                 build_dotnet_linux,
                 build_dotnet_macos,
                 build_node,
-                build_macos
+                build_macos,
             ]
         steps:
-            - name: Download Cef-Setup artifacts
+            - name: Download Cef-Setup (x64) artifacts
               uses: actions/download-artifact@v8
               with:
-                  name: Cef-Setup
-            - name: Download Cef dotnet artifacts
+                  name: Cef-Setup-x64
+            - name: Download Cef-Setup (ARM64) artifacts
               uses: actions/download-artifact@v8
               with:
-                  name: Cef-Release
+                  name: Cef-Setup-ARM64
+            - name: Download Cef dotnet (x64) artifacts
+              uses: actions/download-artifact@v8
+              with:
+                  name: Cef-Release-x64
                   path: build/Cef
             - name: Download Cef-html artifacts
               uses: actions/download-artifact@v8
@@ -379,3 +393,29 @@ jobs:
               with:
                   name: VRCX-Zip
                   path: 'VRCX_${{ needs.set_version.outputs.version }}.zip'
+
+    release:
+        runs-on: ubuntu-latest
+        needs: [create_setup]
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+        permissions:
+            contents: write
+        steps:
+            - name: Download all artifacts
+              uses: actions/download-artifact@v8
+              with:
+                  path: artifacts
+            - name: Create Release
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: v${{ needs.set_version.outputs.version }}
+                  name: VRCX ${{ needs.set_version.outputs.version }} (Windows ARM64 Build)
+                  body: |
+                      Automated build of VRCX ${{ needs.set_version.outputs.version }} including Windows ARM64 installer.
+
+                      This release is published from the fork and tracks upstream VRCX releases.
+                  files: |
+                      artifacts/Cef-Setup-x64/*.exe
+                      artifacts/Cef-Setup-ARM64/*.exe
+                      artifacts/VRCX-Zip/*.zip
+                  make_latest: true

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,68 @@
+name: Sync from upstream VRCX
+
+on:
+    schedule:
+        # Run every 6 hours
+        - cron: '0 */6 * * *'
+    workflow_dispatch:
+
+permissions:
+    contents: write
+    actions: write
+
+jobs:
+    sync:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout fork
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Configure Git
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            - name: Fetch upstream
+              run: |
+                  git remote add upstream https://github.com/vrcx-team/VRCX.git || true
+                  git fetch upstream --tags
+
+            - name: Get latest upstream tag
+              id: upstream_tag
+              run: |
+                  LATEST_TAG=$(git tag -l --sort=-v:refname | head -n 1)
+                  if [ -z "$LATEST_TAG" ]; then
+                    LATEST_TAG=$(git ls-remote --tags upstream | awk -F/ '{print $NF}' | sort -V | tail -n 1)
+                  fi
+                  echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
+                  echo "Latest upstream tag: ${LATEST_TAG}"
+
+            - name: Check if already synced
+              id: check_sync
+              run: |
+                  UPSTREAM_TAG="${{ steps.upstream_tag.outputs.tag }}"
+                  git fetch origin
+                  if git rev-parse "refs/tags/${UPSTREAM_TAG}" >/dev/null 2>&1; then
+                    echo "already_synced=true" >> $GITHUB_OUTPUT
+                    echo "Tag ${UPSTREAM_TAG} already exists on fork."
+                  else
+                    echo "already_synced=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Merge upstream changes
+              if: steps.check_sync.outputs.already_synced == 'false'
+              run: |
+                  UPSTREAM_TAG="${{ steps.upstream_tag.outputs.tag }}"
+                  git checkout master
+                  git merge --no-edit "upstream/master" || git merge --abort
+                  git push origin master
+
+            - name: Trigger release workflow
+              if: steps.check_sync.outputs.already_synced == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh workflow run github_actions.yml --ref master

--- a/Dotnet/VRCX-Cef.csproj
+++ b/Dotnet/VRCX-Cef.csproj
@@ -6,8 +6,9 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
-    <Platforms>x64</Platforms>
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64;ARM64</Platforms>
+    <PlatformTarget Condition="'$(Platform)' == 'x64'">x64</PlatformTarget>
+    <PlatformTarget Condition="'$(Platform)' == 'ARM64'">ARM64</PlatformTarget>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationRevision>0</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
@@ -38,7 +39,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugType>full</DebugType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
 
@@ -51,7 +58,8 @@
     <CefSharpExcludeSubProcessExe>true</CefSharpExcludeSubProcessExe>
   </PropertyGroup>
   <PropertyGroup>
-    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(Platform)' == 'x64'">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
     <SelfContained Condition="'$(SelfContained)' == ''">false</SelfContained>
   </PropertyGroup>
   <PropertyGroup>

--- a/Installer/installer.nsi
+++ b/Installer/installer.nsi
@@ -14,6 +14,11 @@
     !define PRODUCT_VERSION ${PRODUCT_VERSION_FROM_FILE}
     !define VERSION ${PRODUCT_VERSION_FROM_FILE}
 
+    ; Allow architecture to be passed via /DARCH=arm64 or default to x64
+    !ifndef ARCH
+        !define ARCH "x64"
+    !endif
+
     VIProductVersion "${PRODUCT_VERSION}"
     VIFileVersion "${VERSION}"
     VIAddVersionKey "FileVersion" "${VERSION}"
@@ -36,7 +41,7 @@
     SetCompressorDictSize 16
     Unicode True
     Name "VRCX"
-    OutFile "VRCX_Setup.exe"
+    OutFile "VRCX_${ARCH}_Setup.exe"
     InstallDir "$PROGRAMFILES64\VRCX"
     InstallDirRegKey HKLM "Software\VRCX" "InstallDir"
     RequestExecutionLevel admin
@@ -159,9 +164,9 @@ Section "Install" SecInstall
         Goto afterUpgrade
     noUpgrade:
 
-    inetc::get "https://aka.ms/vs/17/release/vc_redist.x64.exe" $TEMP\vcredist_x64.exe
-    ExecWait "$TEMP\vcredist_x64.exe /install /quiet /norestart"
-    Delete "$TEMP\vcredist_x64.exe"
+    inetc::get "https://aka.ms/vs/17/release/vc_redist.${ARCH}.exe" $TEMP\vcredist_${ARCH}.exe
+    ExecWait "$TEMP\vcredist_${ARCH}.exe /install /quiet /norestart"
+    Delete "$TEMP\vcredist_${ARCH}.exe"
 
     afterUpgrade:
 
@@ -174,7 +179,7 @@ Section "Install" SecInstall
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "DisplayName" "VRCX"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "Publisher" "vrcx-team"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "DisplayVersion" "${VERSION}"
-    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "DisplayArch" "x64"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "DisplayArch" "${ARCH}"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "InstallLocation" "$INSTDIR"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "DisplayIcon" "$\"$INSTDIR\VRCX.ico$\""


### PR DESCRIPTION
This PR adds full Windows ARM64 support to VRCX and automates builds/releases.

### Changes
- : support x64 and ARM64 platforms with correct runtime identifiers
- : architecture-specific installer output ( / )
- : matrix Windows build for x64/ARM64 + auto GitHub Release
- : auto-sync from upstream  and trigger builds on new releases

After merge, pushing to master or a new upstream release will automatically build and publish installers.