### PR TITLE
Popular Groups chart (& misc fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ obj1/
 .idea/
 *.log
 *.DotSettings.user
+*.csproj.user
 .vs/
 Installer/version_define.nsh
 bun.lock

--- a/Dotnet/SQLite.cs
+++ b/Dotnet/SQLite.cs
@@ -54,7 +54,8 @@ namespace VRCX
 
         public object[][] Execute(string sql, IDictionary<string, object>? args = null)
         {
-            m_ConnectionLock.EnterReadLock();
+            // Must use the write lock: System.Data.SQLite's SQLiteConnection isn't thread-safe, so concurrent reads on this shared connection can corrupt its internal caches and throw.
+            m_ConnectionLock.EnterWriteLock();
             try
             {
                 using var command = new SQLiteCommand(sql, m_Connection);
@@ -81,7 +82,7 @@ namespace VRCX
             }
             finally
             {
-                m_ConnectionLock.ExitReadLock();
+                m_ConnectionLock.ExitWriteLock();
             }
         }
 

--- a/src/components/nav-menu/__tests__/navMenuUtils.test.js
+++ b/src/components/nav-menu/__tests__/navMenuUtils.test.js
@@ -15,6 +15,7 @@ const testDefinitions = [
     { key: 'charts-instance', routeName: 'charts-instance' },
     { key: 'charts-mutual', routeName: 'charts-mutual' },
     { key: 'charts-hot-worlds', routeName: 'charts-hot-worlds' },
+    { key: 'charts-popular-groups', routeName: 'charts-popular-groups' },
     { key: 'notification', routeName: 'notification' },
     { key: 'direct-access', action: 'direct-access' }
 ];
@@ -285,7 +286,8 @@ describe('sanitizeLayout', () => {
         expect(chartsFolder.items).toEqual([
             'charts-instance',
             'charts-mutual',
-            'charts-hot-worlds'
+            'charts-hot-worlds',
+            'charts-popular-groups'
         ]);
     });
 

--- a/src/components/nav-menu/navLayoutDefaults.js
+++ b/src/components/nav-menu/navLayoutDefaults.js
@@ -31,7 +31,7 @@ export function createBaseDefaultNavLayout(t) {
             nameKey: 'nav_tooltip.charts',
             name: t('nav_tooltip.charts'),
             icon: 'ri-pie-chart-line',
-            items: ['charts-instance', 'charts-mutual', 'charts-hot-worlds']
+            items: ['charts-instance', 'charts-mutual', 'charts-hot-worlds', 'charts-popular-groups']
         },
         { type: 'item', key: 'tools' },
         { type: 'item', key: 'direct-access' }

--- a/src/components/nav-menu/navMenuUtils.js
+++ b/src/components/nav-menu/navMenuUtils.js
@@ -47,7 +47,8 @@ export function sanitizeLayout(
     const chartsKeys = [
         'charts-instance',
         'charts-mutual',
-        'charts-hot-worlds'
+        'charts-hot-worlds',
+        'charts-popular-groups'
     ];
 
     const appendItemEntry = (key, target = normalized) => {

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -636,6 +636,51 @@
                 },
                 "no_friend_data": "No friend visit data",
                 "friend_visits": "{count} visits"
+            },
+            "popular_groups": {
+                "tab_label": "Popular Groups",
+                "header": "Popular Groups",
+                "search_placeholder": "Search groups",
+                "hide_joined": "Hide joined",
+                "joined": "Joined",
+                "never_fetched": "No data yet. Fetch to see which groups are most popular among your friends.",
+                "no_friend_data": "No friend data",
+                "last_fetched": "Last fetched {time}",
+                "tips": {
+                    "description": "Shows groups your friends have made visible to you, ranked by how many friends are members. Only groups friends have chosen to show are counted. Fetching is manual and rate-limited to respect the VRChat API."
+                },
+                "actions": {
+                    "start_fetch": "Start Fetch",
+                    "fetch_again": "Fetch Again",
+                    "stop": "Stop",
+                    "stop_fetching": "Stop fetching"
+                },
+                "status": {
+                    "no_friends_to_process": "You have no friends to process"
+                },
+                "progress": {
+                    "friends_processed": "Friends processed"
+                },
+                "messages": {
+                    "fetch_cancelled": "Fetch cancelled"
+                },
+                "notifications": {
+                    "start_fetching": "Started fetching",
+                    "ready_title": "Popular Groups",
+                    "ready_message": "Popular groups list is ready",
+                    "friend_list_changed": "Friend list changed. Please fetch again."
+                },
+                "stats": {
+                    "total_groups": "groups",
+                    "skipped_friends": "friends skipped"
+                },
+                "stats_line": {
+                    "friends": "{count} friends",
+                    "members": "{count} members"
+                },
+                "sheet": {
+                    "friends_in_group": "Friends in this group"
+                }
             }
         },
         "tools": {

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -115,6 +115,12 @@ const routes = [
                 component: () =>
                     import('./../views/Charts/components/HotWorlds.vue')
             },
+            {
+                path: 'charts/popular-groups',
+                name: 'charts-popular-groups',
+                component: () =>
+                    import('./../views/Charts/components/PopularGroups.vue')
+            },
             { path: 'tools', name: 'tools', component: Tools },
             {
                 path: 'tools/gallery',

--- a/src/services/database/__tests__/friendGroups.test.js
+++ b/src/services/database/__tests__/friendGroups.test.js
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    execute: vi.fn(),
+    executeNonQuery: vi.fn()
+}));
+
+vi.mock('../../sqlite.js', () => ({
+    default: {
+        execute: mocks.execute,
+        executeNonQuery: mocks.executeNonQuery
+    }
+}));
+vi.mock('../index.js', () => ({
+    dbVars: {
+        userPrefix: 'testuser'
+    }
+}));
+
+import { friendGroups } from '../friendGroups.js';
+
+describe('friendGroups.saveFriendGroupsSnapshot', () => {
+    beforeEach(() => {
+        mocks.execute.mockReset();
+        mocks.executeNonQuery.mockReset();
+        mocks.executeNonQuery.mockResolvedValue(undefined);
+    });
+
+    test('never inlines group text fields into the SQL string, always binds them as parameters', async () => {
+        const trickyName = "Bob's ❤️🧡💛💚💙💜🖤 Group; DROP TABLE testuser_friend_groups_info;--";
+        const links = new Map([['usr_friend1', ['grp_1']]]);
+        const groupInfos = new Map([
+            [
+                'grp_1',
+                {
+                    name: trickyName,
+                    shortCode: 'ABC',
+                    discriminator: '0000',
+                    iconUrl: 'https://example.com/icon.png',
+                    bannerUrl: '',
+                    memberCount: 42,
+                    ownerId: 'usr_owner'
+                }
+            ]
+        ]);
+
+        await friendGroups.saveFriendGroupsSnapshot(links, groupInfos);
+
+        const infoCall = mocks.executeNonQuery.mock.calls.find(([sql]) =>
+            sql.includes('testuser_friend_groups_info')
+        );
+        expect(infoCall).toBeDefined();
+        const [sql, args] = infoCall;
+
+        // The raw name text must never appear inlined in the SQL string itself.
+        expect(sql.includes(trickyName)).toBe(false);
+        // Only @-prefixed placeholders should appear in the VALUES clause.
+        expect(sql).toMatch(/VALUES \(@p0_0, @p0_1, @p0_2, @p0_3, @p0_4, @p0_5, @p0_6, @p0_7, @p0_8\)/);
+        // The value is bound as a parameter instead.
+        expect(Object.values(args)).toContain(trickyName);
+    });
+
+    test('binds friend_id/group_id link rows as parameters', async () => {
+        const links = new Map([['usr_friend1', ['grp_1', 'grp_2']]]);
+
+        await friendGroups.saveFriendGroupsSnapshot(links, new Map());
+
+        const linkInsertCall = mocks.executeNonQuery.mock.calls.find(
+            ([sql]) =>
+                sql.includes('INSERT OR REPLACE INTO testuser_friend_groups_links')
+        );
+        expect(linkInsertCall).toBeDefined();
+        const [sql, args] = linkInsertCall;
+        expect(sql).toContain('VALUES (@p0_0, @p0_1), (@p1_0, @p1_1)');
+        expect(args).toMatchObject({
+            '@p0_0': 'usr_friend1',
+            '@p0_1': 'grp_1',
+            '@p1_0': 'usr_friend1',
+            '@p1_1': 'grp_2'
+        });
+    });
+
+    test('batches inserts in chunks so parameter counts stay bounded', async () => {
+        const groupIds = Array.from({ length: 150 }, (_, i) => `grp_${i}`);
+        const links = new Map([['usr_friend1', groupIds]]);
+
+        await friendGroups.saveFriendGroupsSnapshot(links, new Map());
+
+        const linkInsertCalls = mocks.executeNonQuery.mock.calls.filter(
+            ([sql]) =>
+                sql.includes('INSERT OR REPLACE INTO testuser_friend_groups_links')
+        );
+        // 150 rows at 100/batch => 2 batches
+        expect(linkInsertCalls).toHaveLength(2);
+    });
+
+    test('does nothing when userPrefix is not set', async () => {
+        const { dbVars } = await import('../index.js');
+        dbVars.userPrefix = '';
+
+        await friendGroups.saveFriendGroupsSnapshot(new Map(), new Map());
+
+        expect(mocks.executeNonQuery).not.toHaveBeenCalled();
+
+        dbVars.userPrefix = 'testuser';
+    });
+});
+
+describe('friendGroups.upsertFriendGroupsMeta / bulkUpsertFriendGroupsMeta', () => {
+    beforeEach(() => {
+        mocks.executeNonQuery.mockReset();
+        mocks.executeNonQuery.mockResolvedValue(undefined);
+    });
+
+    test('upsertFriendGroupsMeta binds values as parameters', async () => {
+        await friendGroups.upsertFriendGroupsMeta('usr_friend1', {
+            unavailable: true
+        });
+
+        expect(mocks.executeNonQuery).toHaveBeenCalledTimes(1);
+        const [sql, args] = mocks.executeNonQuery.mock.calls[0];
+        expect(sql).toContain(
+            'VALUES (@friend_id, @last_fetched_at, @unavailable)'
+        );
+        expect(args['@friend_id']).toBe('usr_friend1');
+        expect(args['@unavailable']).toBe(1);
+    });
+
+    test('bulkUpsertFriendGroupsMeta binds friend ids as parameters', async () => {
+        const entries = new Map([
+            ['usr_friend1', { unavailable: false }],
+            ['usr_friend2', { unavailable: true }]
+        ]);
+
+        await friendGroups.bulkUpsertFriendGroupsMeta(entries);
+
+        expect(mocks.executeNonQuery).toHaveBeenCalledTimes(1);
+        const [sql, args] = mocks.executeNonQuery.mock.calls[0];
+        expect(sql).toContain('VALUES (@p0_0, @p0_1, @p0_2), (@p1_0, @p1_1, @p1_2)');
+        expect(args).toMatchObject({
+            '@p0_0': 'usr_friend1',
+            '@p0_2': 0,
+            '@p1_0': 'usr_friend2',
+            '@p1_2': 1
+        });
+    });
+});

--- a/src/services/database/friendGroups.js
+++ b/src/services/database/friendGroups.js
@@ -2,8 +2,38 @@ import { dbVars } from '../database';
 
 import sqliteService from '../sqlite.js';
 
-function escapeSql(value) {
-    return String(value ?? '').replace(/'/g, "''");
+// Keep well under SQLite's SQLITE_MAX_VARIABLE_NUMBER (999 on older builds)
+// even with several columns per row.
+const INSERT_BATCH_SIZE = 100;
+
+/**
+ * Insert rows using fully parameterized placeholders (no manual string
+ * escaping/concatenation of values) so arbitrary text - e.g. group names -
+ * can never be misinterpreted as SQL syntax.
+ * @param {string} table
+ * @param {string[]} columns
+ * @param {any[][]} rows
+ */
+async function insertRowsParameterized(table, columns, rows) {
+    if (rows.length === 0) {
+        return;
+    }
+    for (let start = 0; start < rows.length; start += INSERT_BATCH_SIZE) {
+        const batch = rows.slice(start, start + INSERT_BATCH_SIZE);
+        const args = {};
+        const valueClauses = batch.map((row, rowIndex) => {
+            const placeholders = row.map((value, colIndex) => {
+                const paramName = `@p${rowIndex}_${colIndex}`;
+                args[paramName] = value;
+                return paramName;
+            });
+            return `(${placeholders.join(', ')})`;
+        });
+        await sqliteService.executeNonQuery(
+            `INSERT OR REPLACE INTO ${table} (${columns.join(', ')}) VALUES ${valueClauses.join(', ')}`,
+            args
+        );
+    }
 }
 
 const friendGroups = {
@@ -84,40 +114,40 @@ const friendGroups = {
             }
             // Also clean links for friends in the new entries even if they were
             // previously marked unavailable - we have fresh data for them now.
-            let idsToClean = '';
-            links.forEach((_, friendId) => {
-                if (!friendId) return;
-                idsToClean += `'${escapeSql(friendId)}',`;
-            });
-            if (idsToClean) {
-                idsToClean = idsToClean.slice(0, -1);
+            const friendIdsToClean = Array.from(links.keys()).filter(Boolean);
+            if (friendIdsToClean.length > 0) {
+                const args = {};
+                const placeholders = friendIdsToClean.map((friendId, i) => {
+                    const paramName = `@f${i}`;
+                    args[paramName] = friendId;
+                    return paramName;
+                });
                 await sqliteService.executeNonQuery(
-                    `DELETE FROM ${linkTable} WHERE friend_id IN (${idsToClean})`
+                    `DELETE FROM ${linkTable} WHERE friend_id IN (${placeholders.join(', ')})`,
+                    args
                 );
             }
-            let linkValues = '';
+            const linkRows = [];
             links.forEach((groupIds, friendId) => {
                 if (!friendId) {
                     return;
                 }
-                const safeFriendId = escapeSql(friendId);
                 const collection = Array.isArray(groupIds) ? groupIds : [];
                 for (const groupId of collection) {
                     if (!groupId) {
                         continue;
                     }
-                    linkValues += `('${safeFriendId}', '${escapeSql(groupId)}'),`;
+                    linkRows.push([friendId, groupId]);
                 }
             });
-            if (linkValues) {
-                linkValues = linkValues.slice(0, -1);
-                await sqliteService.executeNonQuery(
-                    `INSERT OR REPLACE INTO ${linkTable} (friend_id, group_id) VALUES ${linkValues}`
-                );
-            }
+            await insertRowsParameterized(
+                linkTable,
+                ['friend_id', 'group_id'],
+                linkRows
+            );
             if (groupInfos.size > 0) {
                 const now = new Date().toISOString();
-                let infoValues = '';
+                const infoRows = [];
                 groupInfos.forEach((info, groupId) => {
                     if (!groupId) {
                         return;
@@ -125,18 +155,33 @@ const friendGroups = {
                     const memberCount = Number.isFinite(info?.memberCount)
                         ? info.memberCount
                         : 0;
-                    infoValues +=
-                        `('${escapeSql(groupId)}', '${escapeSql(info?.name)}', ` +
-                        `'${escapeSql(info?.shortCode)}', '${escapeSql(info?.discriminator)}', ` +
-                        `'${escapeSql(info?.iconUrl)}', '${escapeSql(info?.bannerUrl)}', ` +
-                        `${memberCount}, '${escapeSql(info?.ownerId)}', '${escapeSql(now)}'),`;
+                    infoRows.push([
+                        groupId,
+                        info?.name || '',
+                        info?.shortCode || '',
+                        info?.discriminator || '',
+                        info?.iconUrl || '',
+                        info?.bannerUrl || '',
+                        memberCount,
+                        info?.ownerId || '',
+                        now
+                    ]);
                 });
-                if (infoValues) {
-                    infoValues = infoValues.slice(0, -1);
-                    await sqliteService.executeNonQuery(
-                        `INSERT OR REPLACE INTO ${infoTable} (group_id, name, short_code, discriminator, icon_url, banner_url, member_count, owner_id, updated_at) VALUES ${infoValues}`
-                    );
-                }
+                await insertRowsParameterized(
+                    infoTable,
+                    [
+                        'group_id',
+                        'name',
+                        'short_code',
+                        'discriminator',
+                        'icon_url',
+                        'banner_url',
+                        'member_count',
+                        'owner_id',
+                        'updated_at'
+                    ],
+                    infoRows
+                );
             }
             await sqliteService.executeNonQuery('COMMIT');
         } catch (err) {
@@ -150,10 +195,13 @@ const friendGroups = {
             return;
         }
         const metaTable = `${dbVars.userPrefix}_friend_groups_meta`;
-        const time = escapeSql(lastFetchedAt || new Date().toISOString());
-        const unavailableInt = unavailable ? 1 : 0;
         await sqliteService.executeNonQuery(
-            `INSERT OR REPLACE INTO ${metaTable} (friend_id, last_fetched_at, unavailable) VALUES ('${escapeSql(friendId)}', '${time}', ${unavailableInt})`
+            `INSERT OR REPLACE INTO ${metaTable} (friend_id, last_fetched_at, unavailable) VALUES (@friend_id, @last_fetched_at, @unavailable)`,
+            {
+                '@friend_id': friendId,
+                '@last_fetched_at': lastFetchedAt || new Date().toISOString(),
+                '@unavailable': unavailable ? 1 : 0
+            }
         );
     },
 
@@ -162,19 +210,17 @@ const friendGroups = {
             return;
         }
         const metaTable = `${dbVars.userPrefix}_friend_groups_meta`;
-        let values = '';
         const now = new Date().toISOString();
+        const rows = [];
         entries.forEach(({ unavailable }, friendId) => {
             if (!friendId) return;
-            const unavailableInt = unavailable ? 1 : 0;
-            values += `('${escapeSql(friendId)}', '${escapeSql(now)}', ${unavailableInt}),`;
+            rows.push([friendId, now, unavailable ? 1 : 0]);
         });
-        if (values) {
-            values = values.slice(0, -1);
-            await sqliteService.executeNonQuery(
-                `INSERT OR REPLACE INTO ${metaTable} (friend_id, last_fetched_at, unavailable) VALUES ${values}`
-            );
-        }
+        await insertRowsParameterized(
+            metaTable,
+            ['friend_id', 'last_fetched_at', 'unavailable'],
+            rows
+        );
     },
 
     async getFriendGroupsMeta() {

--- a/src/services/database/friendGroups.js
+++ b/src/services/database/friendGroups.js
@@ -1,0 +1,199 @@
+import { dbVars } from '../database';
+
+import sqliteService from '../sqlite.js';
+
+function escapeSql(value) {
+    return String(value ?? '').replace(/'/g, "''");
+}
+
+const friendGroups = {
+    async getFriendGroupsSnapshot() {
+        const snapshot = {
+            links: new Map(),
+            groups: new Map(),
+            meta: new Map()
+        };
+        if (!dbVars.userPrefix) {
+            return snapshot;
+        }
+        const linkTable = `${dbVars.userPrefix}_friend_groups_links`;
+        const infoTable = `${dbVars.userPrefix}_friend_groups_info`;
+        const metaTable = `${dbVars.userPrefix}_friend_groups_meta`;
+        await sqliteService.execute((dbRow) => {
+            const friendId = dbRow[0];
+            const groupId = dbRow[1];
+            if (!friendId || !groupId) {
+                return;
+            }
+            let list = snapshot.links.get(friendId);
+            if (!list) {
+                list = [];
+                snapshot.links.set(friendId, list);
+            }
+            list.push(groupId);
+        }, `SELECT friend_id, group_id FROM ${linkTable}`);
+        await sqliteService.execute((dbRow) => {
+            const groupId = dbRow[0];
+            if (!groupId) {
+                return;
+            }
+            snapshot.groups.set(groupId, {
+                name: dbRow[1] || '',
+                shortCode: dbRow[2] || '',
+                discriminator: dbRow[3] || '',
+                iconUrl: dbRow[4] || '',
+                bannerUrl: dbRow[5] || '',
+                memberCount: Number(dbRow[6]) || 0,
+                ownerId: dbRow[7] || '',
+                updatedAt: dbRow[8] || ''
+            });
+        }, `SELECT group_id, name, short_code, discriminator, icon_url, banner_url, member_count, owner_id, updated_at FROM ${infoTable}`);
+        await sqliteService.execute((dbRow) => {
+            const friendId = dbRow[0];
+            if (!friendId) {
+                return;
+            }
+            snapshot.meta.set(friendId, {
+                lastFetchedAt: dbRow[1] || null,
+                unavailable: dbRow[2] === 1
+            });
+        }, `SELECT friend_id, last_fetched_at, unavailable FROM ${metaTable}`);
+        return snapshot;
+    },
+
+    async saveFriendGroupsSnapshot(linkEntries, groupInfoEntries) {
+        if (!dbVars.userPrefix) {
+            return;
+        }
+        const linkTable = `${dbVars.userPrefix}_friend_groups_links`;
+        const infoTable = `${dbVars.userPrefix}_friend_groups_info`;
+        const metaTable = `${dbVars.userPrefix}_friend_groups_meta`;
+        const links = linkEntries instanceof Map ? linkEntries : new Map();
+        const groupInfos =
+            groupInfoEntries instanceof Map ? groupInfoEntries : new Map();
+        await sqliteService.executeNonQuery('BEGIN');
+        try {
+            // Keep links for friends we know are currently unavailable (private/blocked),
+            // remove everything else so stale links don't linger.
+            await sqliteService.executeNonQuery(
+                `DELETE FROM ${linkTable} WHERE friend_id NOT IN (SELECT friend_id FROM ${metaTable} WHERE unavailable = 1)`
+            );
+            if (links.size === 0 && groupInfos.size === 0) {
+                await sqliteService.executeNonQuery('COMMIT');
+                return;
+            }
+            // Also clean links for friends in the new entries even if they were
+            // previously marked unavailable - we have fresh data for them now.
+            let idsToClean = '';
+            links.forEach((_, friendId) => {
+                if (!friendId) return;
+                idsToClean += `'${escapeSql(friendId)}',`;
+            });
+            if (idsToClean) {
+                idsToClean = idsToClean.slice(0, -1);
+                await sqliteService.executeNonQuery(
+                    `DELETE FROM ${linkTable} WHERE friend_id IN (${idsToClean})`
+                );
+            }
+            let linkValues = '';
+            links.forEach((groupIds, friendId) => {
+                if (!friendId) {
+                    return;
+                }
+                const safeFriendId = escapeSql(friendId);
+                const collection = Array.isArray(groupIds) ? groupIds : [];
+                for (const groupId of collection) {
+                    if (!groupId) {
+                        continue;
+                    }
+                    linkValues += `('${safeFriendId}', '${escapeSql(groupId)}'),`;
+                }
+            });
+            if (linkValues) {
+                linkValues = linkValues.slice(0, -1);
+                await sqliteService.executeNonQuery(
+                    `INSERT OR REPLACE INTO ${linkTable} (friend_id, group_id) VALUES ${linkValues}`
+                );
+            }
+            if (groupInfos.size > 0) {
+                const now = new Date().toISOString();
+                let infoValues = '';
+                groupInfos.forEach((info, groupId) => {
+                    if (!groupId) {
+                        return;
+                    }
+                    const memberCount = Number.isFinite(info?.memberCount)
+                        ? info.memberCount
+                        : 0;
+                    infoValues +=
+                        `('${escapeSql(groupId)}', '${escapeSql(info?.name)}', ` +
+                        `'${escapeSql(info?.shortCode)}', '${escapeSql(info?.discriminator)}', ` +
+                        `'${escapeSql(info?.iconUrl)}', '${escapeSql(info?.bannerUrl)}', ` +
+                        `${memberCount}, '${escapeSql(info?.ownerId)}', '${escapeSql(now)}'),`;
+                });
+                if (infoValues) {
+                    infoValues = infoValues.slice(0, -1);
+                    await sqliteService.executeNonQuery(
+                        `INSERT OR REPLACE INTO ${infoTable} (group_id, name, short_code, discriminator, icon_url, banner_url, member_count, owner_id, updated_at) VALUES ${infoValues}`
+                    );
+                }
+            }
+            await sqliteService.executeNonQuery('COMMIT');
+        } catch (err) {
+            await sqliteService.executeNonQuery('ROLLBACK');
+            throw err;
+        }
+    },
+
+    async upsertFriendGroupsMeta(friendId, { lastFetchedAt, unavailable }) {
+        if (!dbVars.userPrefix || !friendId) {
+            return;
+        }
+        const metaTable = `${dbVars.userPrefix}_friend_groups_meta`;
+        const time = escapeSql(lastFetchedAt || new Date().toISOString());
+        const unavailableInt = unavailable ? 1 : 0;
+        await sqliteService.executeNonQuery(
+            `INSERT OR REPLACE INTO ${metaTable} (friend_id, last_fetched_at, unavailable) VALUES ('${escapeSql(friendId)}', '${time}', ${unavailableInt})`
+        );
+    },
+
+    async bulkUpsertFriendGroupsMeta(entries) {
+        if (!dbVars.userPrefix || !entries || entries.size === 0) {
+            return;
+        }
+        const metaTable = `${dbVars.userPrefix}_friend_groups_meta`;
+        let values = '';
+        const now = new Date().toISOString();
+        entries.forEach(({ unavailable }, friendId) => {
+            if (!friendId) return;
+            const unavailableInt = unavailable ? 1 : 0;
+            values += `('${escapeSql(friendId)}', '${escapeSql(now)}', ${unavailableInt}),`;
+        });
+        if (values) {
+            values = values.slice(0, -1);
+            await sqliteService.executeNonQuery(
+                `INSERT OR REPLACE INTO ${metaTable} (friend_id, last_fetched_at, unavailable) VALUES ${values}`
+            );
+        }
+    },
+
+    async getFriendGroupsMeta() {
+        const metaMap = new Map();
+        if (!dbVars.userPrefix) {
+            return metaMap;
+        }
+        const metaTable = `${dbVars.userPrefix}_friend_groups_meta`;
+        await sqliteService.execute((dbRow) => {
+            const friendId = dbRow[0];
+            if (friendId) {
+                metaMap.set(friendId, {
+                    lastFetchedAt: dbRow[1] || null,
+                    unavailable: dbRow[2] === 1
+                });
+            }
+        }, `SELECT friend_id, last_fetched_at, unavailable FROM ${metaTable}`);
+        return metaMap;
+    }
+};
+
+export { friendGroups };

--- a/src/services/database/index.js
+++ b/src/services/database/index.js
@@ -3,6 +3,7 @@ import { avatarFavorites } from './avatarFavorites.js';
 import { avatarTags } from './avatarTags.js';
 import { feed } from './feed.js';
 import { friendFavorites } from './friendFavorites.js';
+import { friendGroups } from './friendGroups.js';
 import { friendLogCurrent } from './friendLogCurrent.js';
 import { friendLogHistory } from './friendLogHistory.js';
 import { gameLog } from './gameLog.js';
@@ -41,6 +42,7 @@ const database = {
     ...tableFixes,
     ...tableSize,
     ...mutualGraph,
+    ...friendGroups,
 
     setMaxTableSize(limit) {
         dbVars.maxTableSize = limit;
@@ -149,6 +151,15 @@ const database = {
         );
         await sqliteService.executeNonQuery(
             `CREATE TABLE IF NOT EXISTS ${dbVars.userPrefix}_mutual_graph_meta (friend_id TEXT PRIMARY KEY, last_fetched_at TEXT, opted_out INTEGER DEFAULT 0)`
+        );
+        await sqliteService.executeNonQuery(
+            `CREATE TABLE IF NOT EXISTS ${dbVars.userPrefix}_friend_groups_links (friend_id TEXT NOT NULL, group_id TEXT NOT NULL, PRIMARY KEY(friend_id, group_id))`
+        );
+        await sqliteService.executeNonQuery(
+            `CREATE TABLE IF NOT EXISTS ${dbVars.userPrefix}_friend_groups_info (group_id TEXT PRIMARY KEY, name TEXT, short_code TEXT, discriminator TEXT, icon_url TEXT, banner_url TEXT, member_count INTEGER, owner_id TEXT, updated_at TEXT)`
+        );
+        await sqliteService.executeNonQuery(
+            `CREATE TABLE IF NOT EXISTS ${dbVars.userPrefix}_friend_groups_meta (friend_id TEXT PRIMARY KEY, last_fetched_at TEXT, unavailable INTEGER DEFAULT 0)`
         );
     },
 

--- a/src/services/request.js
+++ b/src/services/request.js
@@ -311,6 +311,14 @@ export function shouldIgnoreError(code, endpoint) {
     if (endpoint?.endsWith('/mutuals') && (code === 403 || code === -1)) {
         return true;
     }
+    if (
+        (code === 403 || code === 404 || code === -1) &&
+        typeof endpoint === 'string' &&
+        endpoint.startsWith('users/') &&
+        endpoint.endsWith('/groups')
+    ) {
+        return true;
+    }
     return false;
 }
 

--- a/src/shared/constants/dashboard.js
+++ b/src/shared/constants/dashboard.js
@@ -8,5 +8,6 @@ export const DASHBOARD_BLOCKED_PANEL_KEYS = new Set([
     'charts-instance',
     'charts-mutual',
     'charts-hot-worlds',
+    'charts-popular-groups',
     'tools'
 ]);

--- a/src/shared/constants/ui.js
+++ b/src/shared/constants/ui.js
@@ -114,6 +114,13 @@ const navDefinitions = [
         routeName: 'charts-hot-worlds'
     },
     {
+        key: 'charts-popular-groups',
+        icon: 'ri-team-line',
+        tooltip: 'view.charts.popular_groups.tab_label',
+        labelKey: 'view.charts.popular_groups.tab_label',
+        routeName: 'charts-popular-groups'
+    },
+    {
         key: 'tools',
         icon: 'ri-tools-line',
         tooltip: 'nav_tooltip.tools',

--- a/src/shared/utils/__tests__/popularGroups.test.js
+++ b/src/shared/utils/__tests__/popularGroups.test.js
@@ -1,0 +1,107 @@
+import { aggregateFriendGroups } from '../popularGroups';
+
+describe('aggregateFriendGroups', () => {
+    it('returns an empty array when there are no links', () => {
+        expect(aggregateFriendGroups(new Map(), new Map())).toEqual([]);
+    });
+
+    it('counts unique friends per group', () => {
+        const links = new Map([
+            ['friend1', ['grp_a', 'grp_b']],
+            ['friend2', ['grp_a']],
+            ['friend3', ['grp_a', 'grp_b']]
+        ]);
+        const groups = new Map([
+            ['grp_a', { name: 'Group A', memberCount: 100 }],
+            ['grp_b', { name: 'Group B', memberCount: 50 }]
+        ]);
+
+        const result = aggregateFriendGroups(links, groups);
+
+        expect(result).toHaveLength(2);
+        const groupA = result.find((g) => g.groupId === 'grp_a');
+        expect(groupA.friendCount).toBe(3);
+        expect(groupA.friendIds.sort()).toEqual(['friend1', 'friend2', 'friend3']);
+    });
+
+    it('sorts by friend count descending', () => {
+        const links = new Map([
+            ['friend1', ['grp_small']],
+            ['friend2', ['grp_big']],
+            ['friend3', ['grp_big']]
+        ]);
+        const groups = new Map([
+            ['grp_small', { name: 'Small', memberCount: 10 }],
+            ['grp_big', { name: 'Big', memberCount: 10 }]
+        ]);
+
+        const result = aggregateFriendGroups(links, groups);
+
+        expect(result[0].groupId).toBe('grp_big');
+        expect(result[1].groupId).toBe('grp_small');
+    });
+
+    it('breaks friend-count ties by ascending member count', () => {
+        const links = new Map([
+            ['friend1', ['grp_niche', 'grp_huge']],
+            ['friend2', ['grp_niche', 'grp_huge']]
+        ]);
+        const groups = new Map([
+            ['grp_niche', { name: 'Niche', memberCount: 20 }],
+            ['grp_huge', { name: 'Huge', memberCount: 5000 }]
+        ]);
+
+        const result = aggregateFriendGroups(links, groups);
+
+        expect(result[0].groupId).toBe('grp_niche');
+        expect(result[1].groupId).toBe('grp_huge');
+    });
+
+    it('breaks remaining ties alphabetically by name', () => {
+        const links = new Map([
+            ['friend1', ['grp_z']],
+            ['friend2', ['grp_a']]
+        ]);
+        const groups = new Map([
+            ['grp_z', { name: 'Zebra', memberCount: 10 }],
+            ['grp_a', { name: 'Alpha', memberCount: 10 }]
+        ]);
+
+        const result = aggregateFriendGroups(links, groups);
+
+        expect(result[0].groupId).toBe('grp_a');
+        expect(result[1].groupId).toBe('grp_z');
+    });
+
+    it('marks groups the current user has already joined', () => {
+        const links = new Map([['friend1', ['grp_a']]]);
+        const groups = new Map([['grp_a', { name: 'Group A' }]]);
+
+        const result = aggregateFriendGroups(links, groups, {
+            joinedGroupIds: new Set(['grp_a'])
+        });
+
+        expect(result[0].isJoined).toBe(true);
+    });
+
+    it('ignores friends with no groupIds array and empty group ids', () => {
+        const links = new Map([
+            ['friend1', null],
+            ['friend2', ['', null, 'grp_a']]
+        ]);
+        const groups = new Map([['grp_a', { name: 'Group A' }]]);
+
+        const result = aggregateFriendGroups(links, groups);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].friendIds).toEqual(['friend2']);
+    });
+
+    it('falls back to an empty info object for unknown groups', () => {
+        const links = new Map([['friend1', ['grp_unknown']]]);
+
+        const result = aggregateFriendGroups(links, new Map());
+
+        expect(result[0].info).toEqual({});
+    });
+});

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -20,6 +20,7 @@ export * from './gallery';
 export * from './location';
 export * from './invite';
 export * from './world';
+export * from './popularGroups';
 export * from './throttle';
 export * from './retry';
 export * from './gameLog';

--- a/src/shared/utils/popularGroups.js
+++ b/src/shared/utils/popularGroups.js
@@ -1,0 +1,66 @@
+/**
+ * Aggregate friend -> groupIds links and cached group metadata into a ranked list of groups
+ * sorted by how many friends are in each group.
+ * @param {Map<string, string[]>} links friendId -> groupId[]
+ * @param {Map<string, object>} groupInfoMap groupId -> { name, shortCode, discriminator, iconUrl, bannerUrl, memberCount, ownerId }
+ * @param {object} [options]
+ * @param {Set<string>} [options.joinedGroupIds] group ids the current user is already a member of
+ * @returns {Array<{ groupId: string, friendIds: string[], friendCount: number, info: object, isJoined: boolean }>}
+ */
+export function aggregateFriendGroups(links, groupInfoMap, options = {}) {
+    const joinedGroupIds =
+        options.joinedGroupIds instanceof Set ? options.joinedGroupIds : new Set();
+    const groups = groupInfoMap instanceof Map ? groupInfoMap : new Map();
+    const membership = new Map();
+
+    if (links instanceof Map) {
+        links.forEach((groupIds, friendId) => {
+            if (!friendId || !Array.isArray(groupIds)) {
+                return;
+            }
+            for (const groupId of groupIds) {
+                if (!groupId) {
+                    continue;
+                }
+                let friendIds = membership.get(groupId);
+                if (!friendIds) {
+                    friendIds = new Set();
+                    membership.set(groupId, friendIds);
+                }
+                friendIds.add(friendId);
+            }
+        });
+    }
+
+    const ranked = [];
+    membership.forEach((friendIdSet, groupId) => {
+        const info = groups.get(groupId) || {};
+        ranked.push({
+            groupId,
+            friendIds: Array.from(friendIdSet),
+            friendCount: friendIdSet.size,
+            info,
+            isJoined: joinedGroupIds.has(groupId)
+        });
+    });
+
+    ranked.sort((a, b) => {
+        if (b.friendCount !== a.friendCount) {
+            return b.friendCount - a.friendCount;
+        }
+        const memberA = Number.isFinite(a.info.memberCount)
+            ? a.info.memberCount
+            : Infinity;
+        const memberB = Number.isFinite(b.info.memberCount)
+            ? b.info.memberCount
+            : Infinity;
+        if (memberA !== memberB) {
+            return memberA - memberB;
+        }
+        const nameA = a.info.name || '';
+        const nameB = b.info.name || '';
+        return nameA.localeCompare(nameB);
+    });
+
+    return ranked;
+}

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -28,6 +28,7 @@ import { useModerationStore } from './moderation';
 import { useNotificationStore } from './notification';
 import { useNotificationsSettingsStore } from './settings/notifications';
 import { usePhotonStore } from './photon';
+import { usePopularGroupsStore } from './popularGroups';
 import { useSearchStore } from './search';
 import { useSharedFeedStore } from './sharedFeed';
 import { useUiStore } from './ui';
@@ -160,6 +161,7 @@ export function createGlobalStores() {
         auth: useAuthStore(),
         vrcStatus: useVrcStatusStore(),
         charts: useChartsStore(),
+        popularGroups: usePopularGroupsStore(),
         dashboard: useDashboardStore(),
         modal: useModalStore(),
         quickSearch: useQuickSearchStore()
@@ -184,6 +186,7 @@ export {
     useModerationStore,
     useNotificationStore,
     usePhotonStore,
+    usePopularGroupsStore,
     useSearchStore,
     useChartsStore,
     useDashboardStore,

--- a/src/stores/popularGroups.js
+++ b/src/stores/popularGroups.js
@@ -1,0 +1,299 @@
+import { computed, reactive, ref, watch } from 'vue';
+import { defineStore } from 'pinia';
+import { toast } from 'vue-sonner';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+
+import {
+    aggregateFriendGroups,
+    createRateLimiter,
+    executeWithBackoff
+} from '../shared/utils';
+import { database } from '../services/database';
+import { useFriendStore } from './friend';
+import { useGroupStore } from './group';
+import { groupRequest } from '../api';
+
+function createDefaultFetchState() {
+    return {
+        processedFriends: 0
+    };
+}
+
+function normalizeIdentifier(value) {
+    if (typeof value === 'string') return value;
+    if (value === undefined || value === null) return '';
+    return String(value);
+}
+
+export const usePopularGroupsStore = defineStore('PopularGroups', () => {
+    const friendStore = useFriendStore();
+    const groupStore = useGroupStore();
+
+    const { t } = useI18n();
+    const router = useRouter();
+
+    const fetchState = reactive(createDefaultFetchState());
+    const status = reactive({
+        isFetching: false,
+        hasFetched: false,
+        completionNotified: false,
+        friendSignature: 0,
+        needsRefetch: false,
+        cancelRequested: false
+    });
+
+    const groupRanking = ref([]);
+    const lastFetchedAt = ref(null);
+    const skippedFriendCount = ref(0);
+
+    const friendCount = computed(() => friendStore.friends.size || 0);
+
+    function showInfoMessage(message, type) {
+        const toastFn = toast[type] ?? toast;
+        toastFn(message, { duration: 4000 });
+    }
+
+    watch(friendCount, (count) => {
+        if (
+            !status.hasFetched ||
+            status.isFetching ||
+            !status.friendSignature ||
+            status.needsRefetch
+        ) {
+            return;
+        }
+        if (count !== status.friendSignature) {
+            status.needsRefetch = true;
+            showInfoMessage(
+                t('view.charts.popular_groups.notifications.friend_list_changed'),
+                'warning'
+            );
+        }
+    });
+
+    function resetState() {
+        Object.assign(fetchState, createDefaultFetchState());
+        status.isFetching = false;
+        status.hasFetched = false;
+        status.completionNotified = false;
+        status.friendSignature = 0;
+        status.needsRefetch = false;
+        status.cancelRequested = false;
+        groupRanking.value = [];
+        lastFetchedAt.value = null;
+        skippedFriendCount.value = 0;
+    }
+
+    function requestCancel() {
+        if (status.isFetching) {
+            status.cancelRequested = true;
+        }
+    }
+
+    function buildRanking(links, groups) {
+        const joinedGroupIds = new Set(groupStore.currentUserGroups.keys());
+        groupRanking.value = aggregateFriendGroups(links, groups, {
+            joinedGroupIds
+        });
+    }
+
+    async function loadFromDatabase() {
+        try {
+            const snapshot = await database.getFriendGroupsSnapshot();
+            buildRanking(snapshot.links, snapshot.groups);
+            skippedFriendCount.value = Array.from(
+                snapshot.meta.values()
+            ).filter((meta) => meta.unavailable).length;
+            if (snapshot.links.size > 0 || snapshot.groups.size > 0) {
+                status.hasFetched = true;
+                status.completionNotified = true;
+            }
+        } catch (err) {
+            console.error('[PopularGroups] Failed to load cached data', err);
+        }
+    }
+
+    async function fetchFriendGroups() {
+        if (status.isFetching) {
+            return null;
+        }
+
+        if (!friendCount.value) {
+            showInfoMessage(
+                t('view.charts.popular_groups.status.no_friends_to_process'),
+                'info'
+            );
+            return null;
+        }
+
+        const rateLimiter = createRateLimiter({
+            limitPerInterval: 5,
+            intervalMs: 1000
+        });
+        const isCancelled = () => status.cancelRequested === true;
+
+        status.isFetching = true;
+        status.completionNotified = false;
+        status.needsRefetch = false;
+        status.cancelRequested = false;
+        Object.assign(fetchState, { processedFriends: 0 });
+
+        showInfoMessage(
+            t('view.charts.popular_groups.notifications.start_fetching'),
+            'info'
+        );
+
+        const friendSnapshot = Array.from(friendStore.friends.values());
+        const links = new Map();
+        const groupInfo = new Map();
+        const metaEntries = new Map();
+        let skipped = 0;
+        let cancelled = false;
+
+        try {
+            for (let index = 0; index < friendSnapshot.length; index += 1) {
+                const friend = friendSnapshot[index];
+                if (!friend?.id) continue;
+
+                if (isCancelled()) {
+                    cancelled = true;
+                    break;
+                }
+
+                await rateLimiter.wait();
+                if (isCancelled()) {
+                    cancelled = true;
+                    break;
+                }
+
+                try {
+                    const args = await executeWithBackoff(
+                        () => {
+                            if (isCancelled()) throw new Error('cancelled');
+                            return groupRequest.getGroups({ userId: friend.id });
+                        },
+                        {
+                            maxRetries: 4,
+                            baseDelay: 500,
+                            shouldRetry: (err) =>
+                                err?.status === 429 ||
+                                (err?.message || '').includes('429')
+                        }
+                    );
+
+                    const groupIds = [];
+                    for (const group of args.json || []) {
+                        // The `users/{userId}/groups` endpoint returns list items where
+                        // `id` is the group *membership* ID (gmem_...) and `groupId` is
+                        // the actual group ID (grp_...). Using `id` here would pass a
+                        // membership ID to getGroup()/showGroupDialog() and 404.
+                        const groupId = normalizeIdentifier(
+                            group?.groupId || group?.id
+                        );
+                        if (!groupId) continue;
+                        groupIds.push(groupId);
+                        groupInfo.set(groupId, {
+                            name: group.name || '',
+                            shortCode: group.shortCode || '',
+                            discriminator: group.discriminator || '',
+                            iconUrl: group.iconUrl || '',
+                            bannerUrl: group.bannerUrl || '',
+                            memberCount: Number(group.memberCount) || 0,
+                            ownerId: group.ownerId || ''
+                        });
+                    }
+                    links.set(friend.id, groupIds);
+                    metaEntries.set(friend.id, { unavailable: false });
+                } catch (err) {
+                    if ((err?.message || '') === 'cancelled' || isCancelled()) {
+                        cancelled = true;
+                        break;
+                    }
+                    const statusCode = err?.status;
+                    if (statusCode === 403 || statusCode === 404) {
+                        metaEntries.set(friend.id, { unavailable: true });
+                        skipped += 1;
+                    } else {
+                        console.warn(
+                            '[PopularGroups] Skipping friend due to fetch error',
+                            friend.id,
+                            err
+                        );
+                    }
+                }
+
+                fetchState.processedFriends = index + 1;
+                if (status.cancelRequested) {
+                    cancelled = true;
+                    break;
+                }
+            }
+
+            if (cancelled) {
+                status.hasFetched = groupRanking.value.length > 0;
+                showInfoMessage(
+                    t('view.charts.popular_groups.messages.fetch_cancelled'),
+                    'warning'
+                );
+                return null;
+            }
+
+            status.friendSignature = friendCount.value;
+            status.needsRefetch = false;
+            skippedFriendCount.value = skipped;
+
+            // Write meta first so saveFriendGroupsSnapshot's DELETE uses
+            // up-to-date unavailable flags to decide what to preserve.
+            if (metaEntries.size > 0) {
+                await database.bulkUpsertFriendGroupsMeta(metaEntries);
+            }
+
+            try {
+                await database.saveFriendGroupsSnapshot(links, groupInfo);
+            } catch (persistErr) {
+                console.error('[PopularGroups] Failed to cache data', persistErr);
+            }
+
+            buildRanking(links, groupInfo);
+            lastFetchedAt.value = new Date().toISOString();
+            status.hasFetched = true;
+            status.completionNotified = true;
+
+            toast.success(
+                t('view.charts.popular_groups.notifications.ready_title'),
+                {
+                    description: t(
+                        'view.charts.popular_groups.notifications.ready_message'
+                    ),
+                    action: {
+                        label: t('common.actions.open'),
+                        onClick: () =>
+                            router.push({ name: 'charts-popular-groups' })
+                    }
+                }
+            );
+
+            return groupRanking.value;
+        } catch (err) {
+            console.error('[PopularGroups] fetch aborted', err);
+            return null;
+        } finally {
+            status.isFetching = false;
+            status.cancelRequested = false;
+        }
+    }
+
+    return {
+        fetchState,
+        status,
+        groupRanking,
+        lastFetchedAt,
+        skippedFriendCount,
+        friendCount,
+        resetState,
+        requestCancel,
+        loadFromDatabase,
+        fetchFriendGroups
+    };
+});

--- a/src/stores/settings/appearance.js
+++ b/src/stores/settings/appearance.js
@@ -111,7 +111,8 @@ export const useAppearanceSettingsStore = defineStore(
                 'friend-list',
                 'charts-instance',
                 'charts-mutual',
-                'charts-hot-worlds'
+                'charts-hot-worlds',
+                'charts-popular-groups'
             ].includes(currentRouteName);
         });
 

--- a/src/views/Charts/components/PopularGroups.vue
+++ b/src/views/Charts/components/PopularGroups.vue
@@ -1,0 +1,391 @@
+<template>
+    <div id="chart" class="x-container">
+        <div ref="popularGroupsRef" class="pt-4">
+            <BackToTop :target="popularGroupsRef" :right="30" :bottom="30" :teleport="false" />
+
+            <div class="options-container mt-0 flex flex-wrap items-center justify-between gap-2">
+                <div class="flex items-center gap-2 mb-4">
+                    <span class="shrink-0">{{ t('view.charts.popular_groups.header') }}</span>
+                    <HoverCard>
+                        <HoverCardTrigger as-child>
+                            <Info class="ml-1 text-xs opacity-70" />
+                        </HoverCardTrigger>
+                        <HoverCardContent side="bottom" align="start" class="w-75">
+                            <div class="text-xs">
+                                {{ t('view.charts.popular_groups.tips.description') }}
+                            </div>
+                        </HoverCardContent>
+                    </HoverCard>
+                </div>
+
+                <div class="flex items-center gap-2 mb-4">
+                    <Input
+                        v-model="searchQuery"
+                        class="h-8 w-48"
+                        :placeholder="t('view.charts.popular_groups.search_placeholder')" />
+                    <label class="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+                        <Checkbox :model-value="hideJoined" @update:modelValue="(v) => (hideJoined = !!v)" />
+                        {{ t('view.charts.popular_groups.hide_joined') }}
+                    </label>
+
+                    <TooltipWrapper
+                        v-if="isFetching"
+                        :content="t('view.charts.popular_groups.actions.stop_fetching')"
+                        side="top">
+                        <Button variant="destructive" size="sm" :disabled="status.cancelRequested" @click="cancelFetch">
+                            <Spinner />
+                            {{ t('view.charts.popular_groups.actions.stop') }}
+                        </Button>
+                    </TooltipWrapper>
+                    <TooltipWrapper v-else :content="fetchButtonLabel" side="top">
+                        <Button size="sm" :disabled="fetchButtonDisabled" @click="startFetch">
+                            {{ fetchButtonLabel }}
+                        </Button>
+                    </TooltipWrapper>
+                </div>
+            </div>
+
+            <div
+                v-if="isFetching"
+                class="mx-auto mb-3 flex max-w-[1100px] items-center gap-3 rounded-lg border px-3 py-2">
+                <span class="text-sm shrink-0">
+                    {{ t('view.charts.popular_groups.progress.friends_processed') }}:
+                    <strong>{{ fetchState.processedFriends }} / {{ totalFriends }}</strong>
+                </span>
+                <Progress :model-value="progressPercent" class="h-3 flex-1" />
+            </div>
+
+            <div
+                v-if="status.needsRefetch"
+                class="mx-auto mb-3 max-w-[1100px] rounded-lg border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-xs">
+                {{ t('view.charts.popular_groups.notifications.friend_list_changed') }}
+            </div>
+
+            <div v-if="isLoading" class="mt-[100px] flex items-center justify-center">
+                <RefreshCcw class="size-6 animate-spin text-muted-foreground" />
+            </div>
+
+            <Empty v-else-if="!status.hasFetched" class="mt-[60px]">
+                <EmptyHeader>
+                    <EmptyDescription>{{ t('view.charts.popular_groups.never_fetched') }}</EmptyDescription>
+                </EmptyHeader>
+            </Empty>
+
+            <div v-else-if="filteredRanking.length === 0" class="mt-[100px] flex items-center justify-center">
+                <DataTableEmpty type="nodata" />
+            </div>
+
+            <template v-else>
+                <div class="mx-auto mt-1 flex max-w-[1100px] items-center gap-3">
+                    <div class="flex items-center gap-2 rounded-lg border px-3 py-2">
+                        <Users class="size-3.5 text-muted-foreground" />
+                        <span class="text-sm font-medium">{{ filteredRanking.length }}</span>
+                        <span class="text-xs text-muted-foreground">{{
+                            t('view.charts.popular_groups.stats.total_groups')
+                        }}</span>
+                    </div>
+                    <div v-if="skippedFriendCount > 0" class="flex items-center gap-2 rounded-lg border px-3 py-2">
+                        <EyeOff class="size-3.5 text-muted-foreground" />
+                        <span class="text-sm font-medium">{{ skippedFriendCount }}</span>
+                        <span class="text-xs text-muted-foreground">{{
+                            t('view.charts.popular_groups.stats.skipped_friends')
+                        }}</span>
+                    </div>
+                    <span v-if="formattedLastFetched" class="ml-auto text-xs text-muted-foreground/50">
+                        {{ t('view.charts.popular_groups.last_fetched', { time: formattedLastFetched }) }}
+                    </span>
+                </div>
+
+                <div class="mx-auto mt-3 flex max-w-[1100px] gap-x-6">
+                    <div v-for="(column, colIdx) in columns" :key="colIdx" class="min-w-0 flex-1">
+                        <button
+                            v-for="group in column"
+                            :key="group.groupId"
+                            type="button"
+                            class="group flex w-full items-start gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-accent cursor-pointer"
+                            :class="group._rank === 1 ? 'bg-primary/[0.04]' : ''"
+                            @click="openDetail(group)">
+                            <span
+                                class="mt-0.5 w-6 shrink-0 text-right font-mono text-sm font-bold"
+                                :class="group._rank === 1 ? 'text-primary' : 'text-muted-foreground'">
+                                #{{ group._rank }}
+                            </span>
+
+                            <div class="relative inline-block flex-none size-9 mt-0.5">
+                                <Avatar class="size-9">
+                                    <AvatarImage :src="group.info.iconUrl" class="object-cover" />
+                                    <AvatarFallback>
+                                        <Users class="size-4 text-muted-foreground" />
+                                    </AvatarFallback>
+                                </Avatar>
+                            </div>
+
+                            <div class="min-w-0 flex-1">
+                                <div class="flex items-center gap-1.5">
+                                    <span
+                                        class="block max-w-[300px] truncate text-sm font-medium hover:underline cursor-pointer"
+                                        @click.stop="showGroupDialog(group.groupId)">
+                                        {{ group.info.name || group.groupId }}
+                                    </span>
+                                    <Badge v-if="group.isJoined" variant="secondary" class="shrink-0 text-[10px]">
+                                        {{ t('view.charts.popular_groups.joined') }}
+                                    </Badge>
+                                </div>
+
+                                <div class="mt-0.5 text-xs text-muted-foreground">
+                                    {{
+                                        t('view.charts.popular_groups.stats_line.friends', {
+                                            count: group.friendCount
+                                        })
+                                    }}
+                                    <span class="text-muted-foreground/50">
+                                        ({{
+                                            t('view.charts.popular_groups.stats_line.members', {
+                                                count: group.info.memberCount || 0
+                                            })
+                                        }})
+                                    </span>
+                                </div>
+
+                                <div
+                                    class="mt-1.5 h-2 w-full overflow-hidden rounded-full"
+                                    :class="isDarkMode ? 'bg-white/[0.08]' : 'bg-black/[0.06]'">
+                                    <div
+                                        class="h-full rounded-full transition-all duration-500"
+                                        :class="isDarkMode ? 'bg-white/[0.45]' : 'bg-black/[0.25]'"
+                                        :style="{ width: getBarWidth(group.friendCount) }"></div>
+                                </div>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+            </template>
+        </div>
+    </div>
+
+    <Sheet :open="isSheetOpen" @update:open="handleSheetClose">
+        <SheetContent side="right" class="w-[340px] sm:max-w-[340px]">
+            <SheetHeader class="px-5">
+                <SheetTitle class="text-left">
+                    <button
+                        type="button"
+                        class="text-left text-base font-semibold hover:underline cursor-pointer"
+                        @click="handleGroupClick">
+                        {{ selectedGroup?.info?.name || selectedGroup?.groupId }}
+                    </button>
+                </SheetTitle>
+            </SheetHeader>
+
+            <div v-if="selectedGroup" class="flex flex-col gap-4 overflow-y-auto px-5">
+                <div class="flex flex-wrap items-center gap-2">
+                    <span
+                        class="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium">
+                        <Users class="size-3" />
+                        {{
+                            t('view.charts.popular_groups.stats_line.friends', { count: selectedGroup.friendCount })
+                        }}
+                    </span>
+                    <span
+                        class="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 text-xs text-muted-foreground">
+                        {{
+                            t('view.charts.popular_groups.stats_line.members', {
+                                count: selectedGroup.info.memberCount || 0
+                            })
+                        }}
+                    </span>
+                    <span
+                        v-if="selectedGroup.isJoined"
+                        class="inline-flex items-center gap-1 rounded-full bg-green-500/10 px-2.5 py-1 text-xs text-green-500/70">
+                        {{ t('view.charts.popular_groups.joined') }}
+                    </span>
+                </div>
+
+                <Separator />
+
+                <div>
+                    <div class="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground/70">
+                        {{ t('view.charts.popular_groups.sheet.friends_in_group') }}
+                    </div>
+                    <div v-if="selectedGroupFriends.length === 0" class="py-6 text-center text-xs text-muted-foreground">
+                        {{ t('view.charts.popular_groups.no_friend_data') }}
+                    </div>
+                    <div v-else class="space-y-0.5">
+                        <button
+                            v-for="friend in selectedGroupFriends"
+                            :key="friend.userId"
+                            type="button"
+                            class="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm transition-colors hover:bg-accent cursor-pointer"
+                            @click="openUserDialog(friend.userId)">
+                            <span class="min-w-0 flex-1 truncate">{{ friend.displayName }}</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </SheetContent>
+    </Sheet>
+</template>
+
+<script setup>
+    defineOptions({ name: 'ChartsPopularGroups' });
+
+    import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+    import { storeToRefs } from 'pinia';
+    import { useI18n } from 'vue-i18n';
+    import { EyeOff, Info, RefreshCcw, Users } from 'lucide-vue-next';
+
+    import BackToTop from '@/components/BackToTop.vue';
+    import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+    import { Badge } from '@/components/ui/badge';
+    import { Button } from '@/components/ui/button';
+    import { Checkbox } from '@/components/ui/checkbox';
+    import { DataTableEmpty } from '@/components/ui/data-table';
+    import { Empty, EmptyDescription, EmptyHeader } from '@/components/ui/empty';
+    import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
+    import { Input } from '@/components/ui/input';
+    import { Progress } from '@/components/ui/progress';
+    import { Separator } from '@/components/ui/separator';
+    import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+    import { Spinner } from '@/components/ui/spinner';
+    import TooltipWrapper from '@/components/ui/tooltip/TooltipWrapper.vue';
+
+    import { showGroupDialog } from '@/coordinators/groupCoordinator';
+    import { showUserDialog } from '@/coordinators/userCoordinator';
+    import { useAppearanceSettingsStore, usePopularGroupsStore, useUserStore } from '@/stores';
+
+    const { t } = useI18n();
+    const { isDarkMode } = storeToRefs(useAppearanceSettingsStore());
+    const userStore = useUserStore();
+    const popularGroupsStore = usePopularGroupsStore();
+
+    const cachedUsers = userStore.cachedUsers;
+
+    const fetchState = popularGroupsStore.fetchState;
+    const status = popularGroupsStore.status;
+
+    const popularGroupsRef = ref(null);
+    const isLoading = ref(true);
+    const searchQuery = ref('');
+    const hideJoined = ref(false);
+
+    const isSheetOpen = ref(false);
+    const selectedGroup = ref(null);
+
+    const isFetching = computed(() => status.isFetching);
+    const totalFriends = computed(() => popularGroupsStore.friendCount);
+    const skippedFriendCount = computed(() => popularGroupsStore.skippedFriendCount);
+    const lastFetchedAt = computed(() => popularGroupsStore.lastFetchedAt);
+
+    const fetchButtonDisabled = computed(
+        () => isFetching.value || totalFriends.value === 0 || isLoading.value
+    );
+    const fetchButtonLabel = computed(() =>
+        status.hasFetched
+            ? t('view.charts.popular_groups.actions.fetch_again')
+            : t('view.charts.popular_groups.actions.start_fetch')
+    );
+    const progressPercent = computed(() =>
+        totalFriends.value
+            ? Math.min(100, Math.round((fetchState.processedFriends / totalFriends.value) * 100))
+            : 0
+    );
+    const formattedLastFetched = computed(() =>
+        lastFetchedAt.value ? new Date(lastFetchedAt.value).toLocaleString() : ''
+    );
+
+    const filteredRanking = computed(() => {
+        const query = searchQuery.value.trim().toLowerCase();
+        return popularGroupsStore.groupRanking.filter((group) => {
+            if (hideJoined.value && group.isJoined) return false;
+            if (!query) return true;
+            return (group.info.name || '').toLowerCase().includes(query);
+        });
+    });
+
+    const displayed = computed(() => filteredRanking.value.slice(0, 40));
+
+    const columns = computed(() => {
+        const items = displayed.value.map((group, i) => ({ ...group, _rank: i + 1 }));
+        const mid = Math.ceil(items.length / 2);
+        return [items.slice(0, mid), items.slice(mid)];
+    });
+
+    const maxFriendCount = computed(() => {
+        if (displayed.value.length === 0) return 1;
+        return displayed.value[0].friendCount || 1;
+    });
+
+    const selectedGroupFriends = computed(() => {
+        if (!selectedGroup.value) return [];
+        return selectedGroup.value.friendIds
+            .map((userId) => ({
+                userId,
+                displayName: cachedUsers.get(userId)?.displayName || userId
+            }))
+            .sort((a, b) => a.displayName.localeCompare(b.displayName));
+    });
+
+    function getBarWidth(friendCount) {
+        return `${Math.max(4, (friendCount / maxFriendCount.value) * 100)}%`;
+    }
+
+    function setContainerHeight() {
+        if (popularGroupsRef.value) {
+            const availableHeight = window.innerHeight - 110;
+            popularGroupsRef.value.style.height = `${availableHeight}px`;
+            popularGroupsRef.value.style.overflowY = 'auto';
+        }
+    }
+
+    const containerResizeObserver = new ResizeObserver(() => {
+        setContainerHeight();
+    });
+
+    async function startFetch() {
+        await popularGroupsStore.fetchFriendGroups();
+    }
+
+    function cancelFetch() {
+        popularGroupsStore.requestCancel();
+    }
+
+    function openDetail(group) {
+        selectedGroup.value = group;
+        isSheetOpen.value = true;
+    }
+
+    function handleSheetClose(open) {
+        if (!open) {
+            isSheetOpen.value = false;
+            selectedGroup.value = null;
+        }
+    }
+
+    function handleGroupClick() {
+        if (selectedGroup.value?.groupId) {
+            showGroupDialog(selectedGroup.value.groupId);
+        }
+    }
+
+    function openUserDialog(userId) {
+        showUserDialog(userId);
+    }
+
+    onMounted(async () => {
+        if (popularGroupsRef.value) {
+            containerResizeObserver.observe(popularGroupsRef.value);
+        }
+        setContainerHeight();
+        isLoading.value = true;
+        try {
+            await popularGroupsStore.loadFromDatabase();
+        } finally {
+            isLoading.value = false;
+        }
+    });
+
+    onBeforeUnmount(() => {
+        if (popularGroupsRef.value) {
+            containerResizeObserver.unobserve(popularGroupsRef.value);
+        }
+    });
+</script>

--- a/src/views/Dashboard/components/panelRegistry.js
+++ b/src/views/Dashboard/components/panelRegistry.js
@@ -38,6 +38,9 @@ export const panelComponentMap = {
     'charts-hot-worlds': defineAsyncComponent(
         () => import('../../Charts/components/HotWorlds.vue')
     ),
+    'charts-popular-groups': defineAsyncComponent(
+        () => import('../../Charts/components/PopularGroups.vue')
+    ),
     tools: Tools,
     'widget:feed': defineAsyncComponent(
         () => import('../widgets/FeedWidget.vue')


### PR DESCRIPTION
Adds a new Popular Groups view under Charts that ranks friends' public VRChat groups by how many friends are members.

Closes #1739.

**How it works:**
- On-demand "Fetch" button walks the friends list and calls `users/{userId}/groups` per friend, rate-limited to 5 req/s with exponential backoff on 429s (same budget as the existing Mutual Friend Network feature)
- Results are aggregated (friend count per group) and persisted to per-user SQLite tables so the ranking loads instantly on next visit without refetching
- Cards show member/friend counts, joined-group badge, search, and a side panel listing which friends are in a group
- Fetch is manual/opt-in only, no background polling, so it stays within the 1,000 to 4,000 friends performance baseline (worst case about 4,000 requests, roughly 13 minutes, entirely user-initiated)

**Also fixes:** a related bug where the API's list endpoint returns a group membership ID (`gmem_...`) rather than the group ID (`grp_...`), which caused "failed to load group" when opening a card.

## Fix sqlite read-lock crash (dab43a061856efe0e40ec935fae01b4db83821b1)

Unrelated crash fix bundled in. `SQLite.Execute()` (reads) only took a `ReaderWriterLockSlim` read lock, allowing concurrent threads to run queries on the single shared `SQLiteConnection` at once. `System.Data.SQLite` lazily populates a non-thread-safe internal type cache on first use, so concurrent reads could corrupt it and throw `NullReferenceException` (`Dictionary.TryInsert` via `SetCachedSetting`). Now serialized with the same exclusive lock as writes.

## Testing

- Unit tests added for the ranking/aggregation logic (`popularGroups.test.js`) and updated nav-menu tests for the new chart entry
- `dotnet build Dotnet\VRCX-Electron.csproj` verified clean (0 warnings/errors)
- Manually verified fetch, cancel, cached reload, and opening group/user dialogs from cards

| | master | HEAD |
|---|---|---|
| Test Files | 26 failed, 165 passed (191) | 26 failed, 166 passed (192) |
| Tests | 125 failed, 1979 passed (2104) | 125 failed, 1987 passed (2112) |
| Errors | 3 | 3 |