### PR TITLE
Enforced accessibility on icon-only buttons

### DIFF
--- a/src/components/BackToTop.vue
+++ b/src/components/BackToTop.vue
@@ -128,7 +128,7 @@
                             size="icon"
                             variant="secondary"
                             class="rounded-full shadow"
-                            aria-label="Back to top"
+                            :ariaLabel="t('accessibility.back_to_top')"
                             @click="scrollToTop">
                             <ArrowUp class="h-4 w-4" />
                         </Button>
@@ -143,7 +143,7 @@
                     size="icon"
                     variant="secondary"
                     class="rounded-full shadow"
-                    aria-label="Back to top"
+                    :ariaLabel="t('accessibility.back_to_top')"
                     @click="scrollToTop">
                     <ArrowUp class="h-4 w-4" />
                 </Button>
@@ -159,7 +159,7 @@
                         size="icon"
                         variant="secondary"
                         class="rounded-full shadow"
-                        aria-label="Back to top"
+                        :ariaLabel="t('accessibility.back_to_top')"
                         @click="scrollToTop">
                         <ArrowUp class="h-4 w-4" />
                     </Button>
@@ -174,7 +174,7 @@
                 size="icon"
                 variant="secondary"
                 class="rounded-full shadow"
-                aria-label="Back to top"
+                :ariaLabel="t('accessibility.back_to_top')"
                 @click="scrollToTop">
                 <ArrowUp class="h-4 w-4" />
             </Button>
@@ -209,3 +209,4 @@
         }
     }
 </style>
+

--- a/src/components/FullscreenImagePreview.vue
+++ b/src/components/FullscreenImagePreview.vue
@@ -20,7 +20,7 @@
                             class="h-8 w-8"
                             :disabled="!imageUrl"
                             @click="copyImageToClipboard(imageUrl)"
-                            aria-label="Copy">
+                            :ariaLabel="t('common.actions.copy')">
                             <Copy class="h-4 w-4" />
                         </Button>
 
@@ -30,7 +30,7 @@
                             class="h-8 w-8"
                             :disabled="!imageUrl"
                             @click="downloadAndSaveImage(imageUrl, fullscreenImageDialog.fileName)"
-                            aria-label="Download">
+                            :ariaLabel="t('dialog.vrcx_updater.download')">
                             <Download class="h-4 w-4" />
                         </Button>
 
@@ -41,10 +41,15 @@
                             size="icon"
                             class="h-8 w-8"
                             @click="zoomOutCenter"
-                            aria-label="Zoom out">
+                            :ariaLabel="t('dialog.image_crop.zoom_out')">
                             <ZoomOut class="h-4 w-4" />
                         </Button>
-                        <Button variant="ghost" size="icon" class="h-8 w-8" @click="zoomInCenter" aria-label="Zoom in">
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            class="h-8 w-8"
+                            @click="zoomInCenter"
+                            :ariaLabel="t('dialog.image_crop.zoom_in')">
                             <ZoomIn class="h-4 w-4" />
                         </Button>
 
@@ -53,7 +58,7 @@
                             size="icon"
                             class="h-8 w-8"
                             @click="rotateCW"
-                            aria-label="Rotate clockwise">
+                            :ariaLabel="t('dialog.image_crop.rotate_right')">
                             <RotateCw class="h-4 w-4" />
                         </Button>
                         <Button
@@ -61,17 +66,27 @@
                             size="icon"
                             class="h-8 w-8"
                             @click="rotateCCW"
-                            aria-label="Rotate counterclockwise">
+                            :ariaLabel="t('dialog.image_crop.rotate_left')">
                             <RotateCcw class="h-4 w-4" />
                         </Button>
 
-                        <Button variant="ghost" size="icon" class="h-8 w-8" @click="resetTransform" aria-label="Reset">
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            class="h-8 w-8"
+                            @click="resetTransform"
+                            :ariaLabel="t('dialog.image_crop.reset')">
                             <RefreshCcw class="h-4 w-4" />
                         </Button>
 
                         <div class="mx-1 h-5 w-px bg-border" />
 
-                        <Button variant="ghost" size="icon" class="h-8 w-8" @click="closeDialog" aria-label="Close">
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            class="h-8 w-8"
+                            @click="closeDialog"
+                            :ariaLabel="t('dialog.shared_feed_filters.close')">
                             <X class="h-4 w-4" />
                         </Button>
                     </div>
@@ -348,3 +363,4 @@
         cursor: grabbing;
     }
 </style>
+

--- a/src/components/InstanceActionBar.vue
+++ b/src/components/InstanceActionBar.vue
@@ -7,6 +7,7 @@
                         class="rounded-full w-6 h-6 text-xs text-muted-foreground hover:text-foreground"
                         size="icon-sm"
                         variant="outline"
+                        :ariaLabel="t('dialog.user.info.launch_invite_tooltip')"
                         @click="confirmLaunch">
                         <LogIn />
                     </Button>
@@ -21,6 +22,7 @@
                         class="rounded-full h-6 w-6 text-xs text-muted-foreground hover:text-foreground"
                         size="icon-sm"
                         variant="outline"
+                        :ariaLabel="t('dialog.user.info.self_invite_tooltip')"
                         @click="confirmInvite">
                         <Mail class="h-4 w-4" />
                     </Button>
@@ -30,6 +32,7 @@
                         class="rounded-full h-6 w-6 text-xs text-muted-foreground hover:text-foreground"
                         size="icon-sm"
                         variant="outline"
+                        :ariaLabel="t('dialog.user.info.open_in_vrchat_tooltip')"
                         v-if="isOpeningInstance">
                         <Loader2 class="h-4 w-4 animate-spin" />
                     </Button>
@@ -37,6 +40,7 @@
                         class="rounded-full h-6 w-6 text-xs text-muted-foreground hover:text-foreground"
                         size="icon-sm"
                         variant="outline"
+                        :ariaLabel="t('dialog.user.info.open_in_vrchat_tooltip')"
                         v-else
                         @click="openInstance">
                         <Mail class="h-4 w-4" />
@@ -48,6 +52,7 @@
                     class="rounded-full w-6 h-6 text-xs text-muted-foreground hover:text-foreground"
                     size="icon"
                     variant="outline"
+                    :ariaLabel="t('common.actions.refresh')"
                     @click="handleRefresh">
                     <RefreshCw class="h-4 w-4" />
                 </Button>
@@ -57,6 +62,7 @@
                     class="rounded-full w-6 h-6 text-xs text-muted-foreground hover:text-foreground"
                     size="icon-sm"
                     variant="outline"
+                    :ariaLabel="t('dialog.social_status.history')"
                     @click="handleHistory">
                     <History class="h-4 w-4" />
                 </Button>
@@ -103,6 +109,7 @@
                                 class="w-12 h-6 text-xs hover:text-muted-foreground"
                                 size="icon-sm"
                                 variant="destructive"
+                                :ariaLabel="t('dialog.user.info.close_instance')"
                                 @click="closeInstance(resolvedInstanceLocation)">
                                 <PowerIcon class="h-4 w-4" />
                             </Button>
@@ -422,3 +429,4 @@
         immediate: true
     });
 </script>
+

--- a/src/components/dialogs/AvatarDialog/AvatarDialog.vue
+++ b/src/components/dialogs/AvatarDialog/AvatarDialog.vue
@@ -192,6 +192,7 @@
                                 variant="outline"
                                 :disabled="isGameRunning && avatarDialog.cacheLocked"
                                 @click="deleteVRChatCache(avatarDialog.ref)"
+                                :ariaLabel="t('dialog.avatar.actions.delete_cache_tooltip')"
                                 ><Trash2
                             /></Button>
                         </TooltipWrapper>
@@ -200,7 +201,7 @@
                             v-if="avatarDialog.isFavorite"
                             side="top"
                             :content="t('dialog.avatar.actions.favorite_tooltip')">
-                            <Button class="rounded-full" size="icon-lg" @click="avatarDialogCommand('Add Favorite')"
+                            <Button class="rounded-full" size="icon-lg" @click="avatarDialogCommand('Add Favorite')" :ariaLabel="t('dialog.avatar.actions.favorite_tooltip')"
                                 ><Star
                             /></Button>
                         </TooltipWrapper>
@@ -209,7 +210,8 @@
                                 class="rounded-full"
                                 size="icon-lg"
                                 variant="outline"
-                                @click="avatarDialogCommand('Add Favorite')"
+                                @click="avatarDialogCommand('Add Favorite')" 
+                                :ariaLabel="t('dialog.avatar.actions.favorite_tooltip')"
                                 ><Star
                             /></Button>
                         </TooltipWrapper>
@@ -220,7 +222,8 @@
                                 size="icon-lg"
                                 variant="outline"
                                 :disabled="currentUser.currentAvatar === avatarDialog.id"
-                                @click="selectAvatarWithoutConfirmation(avatarDialog.id)">
+                                @click="selectAvatarWithoutConfirmation(avatarDialog.id)"
+                                :aria-label="t('dialog.avatar.actions.select')">
                                 <CheckCircle
                             /></Button>
                         </TooltipWrapper>
@@ -229,7 +232,8 @@
                                 <Button
                                     class="rounded-full ml-2"
                                     :variant="avatarDialog.isBlocked ? 'destructive' : 'outline'"
-                                    size="icon-lg">
+                                    size="icon-lg" 
+                                    :ariaLabel="t('nav_tooltip.manage')">
                                     <Ellipsis />
                                 </Button>
                             </DropdownMenuTrigger>
@@ -354,7 +358,8 @@
                                 size="sm"
                                 :disabled="avatarDialog.galleryLoading"
                                 class="ml-1"
-                                @click="displayAvatarGalleryUpload">
+                                @click="displayAvatarGalleryUpload"
+                                :ariaLabel="t('dialog.screenshot_metadata.upload')">
                                 <Upload />
                                 {{ t('dialog.screenshot_metadata.upload') }}
                             </Button>
@@ -445,6 +450,7 @@
                                                     size="icon-sm"
                                                     variant="ghost"
                                                     @click.stop
+                                                    :ariaLabel="t('dialog.avatar.info.id_tooltip')"
                                                     ><Copy class="h-4 w-4" />
                                                 </Button>
                                             </DropdownMenuTrigger>

--- a/src/components/dialogs/AvatarDialog/AvatarDialog.vue
+++ b/src/components/dialogs/AvatarDialog/AvatarDialog.vue
@@ -201,7 +201,11 @@
                             v-if="avatarDialog.isFavorite"
                             side="top"
                             :content="t('dialog.avatar.actions.favorite_tooltip')">
-                            <Button class="rounded-full" size="icon-lg" @click="avatarDialogCommand('Add Favorite')" :ariaLabel="t('dialog.avatar.actions.favorite_tooltip')"
+                            <Button
+                                class="rounded-full"
+                                size="icon-lg"
+                                @click="avatarDialogCommand('Add Favorite')"
+                                :ariaLabel="t('dialog.avatar.actions.favorite_tooltip')"
                                 ><Star
                             /></Button>
                         </TooltipWrapper>
@@ -210,7 +214,7 @@
                                 class="rounded-full"
                                 size="icon-lg"
                                 variant="outline"
-                                @click="avatarDialogCommand('Add Favorite')" 
+                                @click="avatarDialogCommand('Add Favorite')"
                                 :ariaLabel="t('dialog.avatar.actions.favorite_tooltip')"
                                 ><Star
                             /></Button>
@@ -223,7 +227,7 @@
                                 variant="outline"
                                 :disabled="currentUser.currentAvatar === avatarDialog.id"
                                 @click="selectAvatarWithoutConfirmation(avatarDialog.id)"
-                                :aria-label="t('dialog.avatar.actions.select')">
+                                :ariaLabel="t('dialog.avatar.actions.select')">
                                 <CheckCircle
                             /></Button>
                         </TooltipWrapper>
@@ -232,7 +236,7 @@
                                 <Button
                                     class="rounded-full ml-2"
                                     :variant="avatarDialog.isBlocked ? 'destructive' : 'outline'"
-                                    size="icon-lg" 
+                                    size="icon-lg"
                                     :ariaLabel="t('nav_tooltip.manage')">
                                     <Ellipsis />
                                 </Button>
@@ -1047,3 +1051,4 @@
         }
     }
 </script>
+

--- a/src/components/dialogs/DialogJsonTab.vue
+++ b/src/components/dialogs/DialogJsonTab.vue
@@ -36,10 +36,20 @@
 </script>
 
 <template>
-    <Button class="rounded-full mr-2" size="icon-sm" variant="ghost" @click="emit('refresh')">
+    <Button
+        class="rounded-full mr-2"
+        size="icon-sm"
+        variant="ghost"
+        @click="emit('refresh')"
+        :ariaLabel="t('common.actions.refresh')">
         <RefreshCw />
     </Button>
-    <Button class="rounded-full" size="icon-sm" variant="ghost" @click="downloadAndSaveJson(dialogId, dialogRef)">
+    <Button
+        class="rounded-full"
+        size="icon-sm"
+        variant="ghost"
+        @click="downloadAndSaveJson(dialogId, dialogRef)"
+        :ariaLabel="t('dialog.vrcx_updater.download')">
         <Download />
     </Button>
     <vue-json-pretty :key="treeDataKey" :data="treeData" :deep="2" :theme="isDarkMode ? 'dark' : 'light'" show-icon />
@@ -48,3 +58,4 @@
         <vue-json-pretty :data="fileAnalysis" :deep="2" :theme="isDarkMode ? 'dark' : 'light'" show-icon />
     </template>
 </template>
+

--- a/src/components/dialogs/GroupDialog/GroupDialog.vue
+++ b/src/components/dialogs/GroupDialog/GroupDialog.vue
@@ -138,6 +138,7 @@
                                     variant="secondary"
                                     size="icon-lg"
                                     style="margin-left: 6px"
+                                    :ariaLabel="t('dialog.group.actions.unrepresent_tooltip')"
                                     @click="clearGroupRepresentation(groupDialog.id)">
                                     <BookmarkCheck />
                                 </Button>
@@ -148,6 +149,7 @@
                                         class="rounded-full mr-2"
                                         variant="outline"
                                         size="icon-lg"
+                                        :ariaLabel="t('dialog.group.actions.represent_tooltip')"
                                         :disabled="groupDialog.ref.privacy === 'private'"
                                         @click="setGroupRepresentation(groupDialog.id)">
                                         <Bookmark />
@@ -162,6 +164,7 @@
                                         class="rounded-full mr-2"
                                         variant="outline"
                                         size="icon-lg"
+                                        :ariaLabel="t('dialog.group.actions.cancel_join_request_tooltip')"
                                         @click="cancelGroupRequest(groupDialog.id)">
                                         <X />
                                     </Button>
@@ -175,6 +178,7 @@
                                         class="rounded-full mr-2"
                                         variant="outline"
                                         size="icon-lg"
+                                        :ariaLabel="t('dialog.group.actions.pending_request_tooltip')"
                                         @click="joinGroup(groupDialog.id)">
                                         <Check />
                                     </Button>
@@ -190,6 +194,7 @@
                                     class="rounded-full mr-2"
                                     variant="outline"
                                     size="icon-lg"
+                                    :ariaLabel="t('dialog.group.actions.request_join_tooltip')"
                                     @click="joinGroup(groupDialog.id)">
                                     <MessageSquare />
                                 </Button>
@@ -199,7 +204,12 @@
                                 side="top"
                                 :content="t('dialog.group.actions.invite_required_tooltip')">
                                 <span>
-                                    <Button class="rounded-full mr-2" variant="outline" size="icon-lg" disabled>
+                                    <Button
+                                        class="rounded-full mr-2"
+                                        variant="outline"
+                                        size="icon-lg"
+                                        :ariaLabel="t('dialog.group.actions.invite_required_tooltip')"
+                                        disabled>
                                         <MessageSquare />
                                     </Button>
                                 </span>
@@ -212,6 +222,7 @@
                                     class="rounded-full mr-2"
                                     variant="outline"
                                     size="icon-lg"
+                                    :ariaLabel="t('dialog.group.actions.join_group_tooltip')"
                                     @click="joinGroup(groupDialog.id)">
                                     <Check />
                                 </Button>
@@ -224,7 +235,8 @@
                                     :variant="
                                         groupDialog.ref.membershipStatus === 'userblocked' ? 'destructive' : 'outline'
                                     "
-                                    size="icon-lg">
+                                    size="icon-lg"
+                                    :ariaLabel="t('nav_tooltip.manage')">
                                     <MoreHorizontal />
                                 </Button>
                             </DropdownMenuTrigger>
@@ -762,3 +774,4 @@
         };
     }
 </script>
+

--- a/src/components/dialogs/GroupDialog/GroupDialogInfoTab.vue
+++ b/src/components/dialogs/GroupDialog/GroupDialogInfoTab.vue
@@ -142,6 +142,7 @@
                             <Button
                                 size="sm"
                                 variant="ghost"
+                                :ariaLabel="t('dialog.group.posts.edit_tooltip')"
                                 style="margin-left: 6px; padding: 0"
                                 @click="showGroupPostEditDialog(groupDialog.id, groupDialog.announcement)"></Button>
                         </TooltipWrapper>
@@ -149,6 +150,7 @@
                             <Button
                                 size="sm"
                                 variant="ghost"
+                                :ariaLabel="t('dialog.group.posts.delete_tooltip')"
                                 style="margin-left: 6px; padding: 0"
                                 @click="confirmDeleteGroupPost(groupDialog.announcement)"></Button>
                         </TooltipWrapper>
@@ -274,6 +276,7 @@
                                 class="rounded-full ml-1 text-xs"
                                 size="icon-sm"
                                 variant="ghost"
+                                :ariaLabel="t('dialog.group.info.url_tooltip')"
                                 @click="copyToClipboard(groupDialog.ref.$url)"
                                 ><Copy class="h-4 w-4" />
                             </Button> </TooltipWrapper
@@ -290,6 +293,7 @@
                                 class="rounded-full ml-1 text-xs"
                                 size="icon-sm"
                                 variant="ghost"
+                                :ariaLabel="t('dialog.group.info.id_tooltip')"
                                 @click="copyToClipboard(groupDialog.id)"
                                 ><Copy class="h-4 w-4" />
                             </Button> </TooltipWrapper
@@ -424,3 +428,4 @@
         instanceStore.showPreviousInstancesListDialog('group', groupRef);
     }
 </script>
+

--- a/src/components/dialogs/GroupDialog/GroupDialogPostsTab.vue
+++ b/src/components/dialogs/GroupDialog/GroupDialogPostsTab.vue
@@ -85,6 +85,7 @@
                                     size="icon-sm"
                                     class="h-6 w-6 text-xs text-muted-foreground hover:text-foreground"
                                     variant="ghost"
+                                    :ariaLabel="t('dialog.group.posts.edit_tooltip')"
                                     @click="showGroupPostEditDialog(groupDialog.id, post)"
                                     ><Pencil class="h-4 w-4" />
                                 </Button>
@@ -94,6 +95,7 @@
                                     size="icon-sm"
                                     class="h-6 w-6 text-xs text-muted-foreground hover:text-foreground"
                                     variant="ghost"
+                                    :ariaLabel="t('dialog.group.posts.delete_tooltip')"
                                     @click="confirmDeleteGroupPost(post)"
                                     ><Trash2 class="h-4 w-4" />
                                 </Button>
@@ -133,3 +135,4 @@
     const { updateGroupPostSearch } = useGroupStore();
     const { showFullscreenImageDialog } = useGalleryStore();
 </script>
+

--- a/src/components/dialogs/GroupDialog/GroupModerationBulkActions.vue
+++ b/src/components/dialogs/GroupDialog/GroupModerationBulkActions.vue
@@ -25,6 +25,7 @@
             size="icon-sm"
             variant="outline"
             style="margin-left: 6px"
+            :ariaLabel="t('common.actions.delete')"
             @click="$emit('clear-all')">
             <Trash2 />
         </Button>
@@ -43,6 +44,7 @@
             <span v-text="user.user?.displayName || user.userId" style="font-weight: bold; margin-left: 6px"></span>
             <button
                 type="button"
+                :ariaLabel="t('common.actions.delete')"
                 style="
                     margin-left: 8px;
                     border: none;
@@ -184,3 +186,4 @@
 
     const { t } = useI18n();
 </script>
+

--- a/src/components/dialogs/ImageCropDialog.vue
+++ b/src/components/dialogs/ImageCropDialog.vue
@@ -31,6 +31,7 @@
                             variant="outline"
                             class="rounded-full h-8 w-8"
                             :disabled="loading"
+                            :ariaLabel="t('dialog.image_crop.rotate_left')"
                             @click="cropperRef?.rotate(-90)">
                             <RotateCcw class="h-4 w-4" />
                         </Button>
@@ -41,6 +42,7 @@
                             variant="outline"
                             class="rounded-full h-8 w-8"
                             :disabled="loading"
+                            :ariaLabel="t('dialog.image_crop.rotate_right')"
                             @click="cropperRef?.rotate(90)">
                             <RotateCw class="h-4 w-4" />
                         </Button>
@@ -54,6 +56,7 @@
                             variant="outline"
                             class="rounded-full h-8 w-8"
                             :disabled="loading"
+                            :ariaLabel="t('dialog.image_crop.flip_h')"
                             @click="cropperRef?.flip(true, false)">
                             <FlipHorizontal class="h-4 w-4" />
                         </Button>
@@ -64,6 +67,7 @@
                             variant="outline"
                             class="rounded-full h-8 w-8"
                             :disabled="loading"
+                            :ariaLabel="t('dialog.image_crop.flip_v')"
                             @click="cropperRef?.flip(false, true)">
                             <FlipVertical class="h-4 w-4" />
                         </Button>
@@ -77,6 +81,7 @@
                             variant="ghost"
                             class="rounded-full h-7 w-7"
                             :disabled="loading"
+                            :ariaLabel="t('dialog.image_crop.zoom_out')"
                             @click="cropperRef?.zoom(0.8)">
                             <ZoomOut class="h-3.5 w-3.5" />
                         </Button>
@@ -95,6 +100,7 @@
                             variant="ghost"
                             class="rounded-full h-7 w-7"
                             :disabled="loading"
+                            :ariaLabel="t('dialog.image_crop.zoom_in')"
                             @click="cropperRef?.zoom(1.2)">
                             <ZoomIn class="h-3.5 w-3.5" />
                         </Button>
@@ -110,6 +116,7 @@
                             :variant="freeMode ? 'default' : 'outline'"
                             class="rounded-full h-8 w-8"
                             :disabled="loading"
+                            :ariaLabel="freeMode ? t('dialog.image_crop.mode_fit') : t('dialog.image_crop.mode_free')"
                             @click="toggleMode">
                             <Expand v-if="freeMode" class="h-4 w-4" />
                             <Frame v-else class="h-4 w-4" />
@@ -122,6 +129,7 @@
                             variant="outline"
                             class="rounded-full h-8 w-8"
                             :disabled="loading"
+                            :ariaLabel="t('dialog.image_crop.reset')"
                             @click="handleReset">
                             <RefreshCw class="h-4 w-4" />
                         </Button>
@@ -342,3 +350,4 @@
         }
     }
 </script>
+

--- a/src/components/dialogs/LaunchDialog.vue
+++ b/src/components/dialogs/LaunchDialog.vue
@@ -18,6 +18,7 @@
                                 class="rounded-full"
                                 size="icon-sm"
                                 variant="ghost"
+                                :ariaLabel="t('dialog.launch.copy_tooltip')"
                                 @click="copyInstanceMessage(launchDialog.url)"
                                 ><Copy
                             /></Button>
@@ -29,7 +30,7 @@
                         <span class="flex items-center gap-1">
                             <span>{{ t('dialog.launch.short_url') }}</span>
                             <TooltipWrapper side="top" :content="t('dialog.launch.short_url_notice')">
-                                <Info class="text-muted-foreground" />
+                                <Info class="text-muted-foreground" :ariaLabel="t('dialog.launch.short_url_notice')" />
                             </TooltipWrapper>
                         </span>
                     </FieldLabel>
@@ -43,6 +44,7 @@
                                 class="rounded-full"
                                 size="icon-sm"
                                 variant="ghost"
+                                :ariaLabel="t('dialog.launch.copy_tooltip')"
                                 @click="copyInstanceMessage(launchDialog.shortUrl)"
                                 ><Copy
                             /></Button>
@@ -61,6 +63,7 @@
                                 class="rounded-full"
                                 size="icon-sm"
                                 variant="ghost"
+                                :ariaLabel="t('dialog.launch.copy_tooltip')"
                                 @click="copyInstanceMessage(launchDialog.location)"
                                 ><Copy
                             /></Button>
@@ -99,7 +102,10 @@
                     </Button>
                     <DropdownMenu>
                         <DropdownMenuTrigger as-child>
-                            <Button size="icon" :disabled="!launchDialog.secureOrShortName" aria-label="More options">
+                            <Button
+                                size="icon"
+                                :disabled="!launchDialog.secureOrShortName"
+                                :ariaLabel="t('dialog.new_instance.launch')">
                                 <MoreHorizontal class="size-4" />
                             </Button>
                         </DropdownMenuTrigger>
@@ -417,3 +423,4 @@
         }
     }
 </script>
+

--- a/src/components/dialogs/SortableTreeNode.vue
+++ b/src/components/dialogs/SortableTreeNode.vue
@@ -106,6 +106,7 @@
                     <Button
                         size="icon-sm"
                         variant="ghost"
+                        :ariaLabel="t('nav_tooltip.manage')"
                         class="ml-auto size-6 shrink-0 opacity-0 group-hover:opacity-100"
                         @click.stop>
                         <Ellipsis class="size-3.5" />
@@ -138,3 +139,4 @@
         </template>
     </TreeItem>
 </template>
+

--- a/src/components/dialogs/UserDialog/BioDialog.vue
+++ b/src/components/dialogs/UserDialog/BioDialog.vue
@@ -30,7 +30,11 @@
                         <div v-else style="width: 16px; height: 16px" />
                     </template>
                     <template #actions>
-                        <Button variant="ghost" size="icon-sm" @click="bioDialog.bioLinks.splice(index, 1)"
+                        <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            @click="bioDialog.bioLinks.splice(index, 1)"
+                            :ariaLabel="t('common.actions.delete')"
                             ><Trash2 class="size-4"
                         /></Button>
                     </template>
@@ -98,3 +102,4 @@
             });
     }
 </script>
+

--- a/src/components/dialogs/UserDialog/UserActionDropdown.vue
+++ b/src/components/dialogs/UserDialog/UserActionDropdown.vue
@@ -8,7 +8,7 @@
                 <Button class="rounded-full" size="icon-lg" @click="userDialogCommand('Add Favorite')" :ariaLabel="t('dialog.user.actions.favorites_tooltip')"><Star /></Button>
             </TooltipWrapper>
             <TooltipWrapper v-else side="top" :content="t('dialog.user.actions.favorites_tooltip')">
-                <Button class="rounded-full" size="icon-lg" variant="outline" @click="userDialogCommand('Add Favorite')" :ariaLabel="t('dialog.user.actions.favorites_tooltip')">
+                <Button class="rounded-full" size="icon-lg" variant="outline" @click="userDialogCommand('Add Favorite')" :ariaLabel="t('dialog.user.actions.favorites_tooltip')"
                     ><Star
                 /></Button>
             </TooltipWrapper>

--- a/src/components/dialogs/UserDialog/UserActionDropdown.vue
+++ b/src/components/dialogs/UserDialog/UserActionDropdown.vue
@@ -5,10 +5,10 @@
                 v-if="userDialog.isFavorite"
                 side="top"
                 :content="t('dialog.user.actions.favorites_tooltip')">
-                <Button class="rounded-full" size="icon-lg" @click="userDialogCommand('Add Favorite')"><Star /></Button>
+                <Button class="rounded-full" size="icon-lg" @click="userDialogCommand('Add Favorite')" :ariaLabel="t('dialog.user.actions.favorites_tooltip')"><Star /></Button>
             </TooltipWrapper>
             <TooltipWrapper v-else side="top" :content="t('dialog.user.actions.favorites_tooltip')">
-                <Button class="rounded-full" size="icon-lg" variant="outline" @click="userDialogCommand('Add Favorite')"
+                <Button class="rounded-full" size="icon-lg" variant="outline" @click="userDialogCommand('Add Favorite')" :ariaLabel="t('dialog.user.actions.favorites_tooltip')">
                     ><Star
                 /></Button>
             </TooltipWrapper>
@@ -20,7 +20,8 @@
                         :variant="hasRisk ? 'destructive' : 'outline'"
                         size="icon-lg"
                         class="rounded-full"
-                        :class="{ 'dot-indicator': hasRequest }">
+                        :class="{ 'dot-indicator': hasRequest }"
+                        :ariaLabel="t('nav_tooltip.manage')">
                         <MoreHorizontal />
                     </Button>
                 </div>

--- a/src/components/dialogs/UserDialog/UserDialogGroupsTab.vue
+++ b/src/components/dialogs/UserDialog/UserDialogGroupsTab.vue
@@ -114,6 +114,7 @@
                         <Button
                             size="icon-sm"
                             variant="ghost"
+                            :ariaLabel="t('dialog.vrcx_updater.download')"
                             style="display: block; padding: 7px; font-size: 9px; margin-left: 0; rotate: 180deg"
                             @click="moveGroupTop(group.id)">
                             <DownloadIcon />
@@ -121,6 +122,7 @@
                         <Button
                             size="icon-sm"
                             variant="ghost"
+                            :ariaLabel="t('dialog.vrcx_updater.download')"
                             style="display: block; padding: 7px; font-size: 9px; margin-left: 0"
                             @click="moveGroupBottom(group.id)">
                             <DownloadIcon />
@@ -221,6 +223,7 @@
                             variant="outline"
                             v-if="shiftHeld"
                             style="margin-left: 6px"
+                            :ariaLabel="t('dialog.user.groups.leave_group_tooltip')"
                             @click.stop="leaveGroup(group.id)">
                             <LogOut />
                         </Button>
@@ -230,6 +233,7 @@
                             variant="outline"
                             v-else
                             style="margin-left: 6px"
+                            :ariaLabel="t('dialog.user.groups.leave_group_tooltip')"
                             @click.stop="leaveGroupPrompt(group.id)">
                             <LogOut />
                         </Button>
@@ -650,3 +654,4 @@
 
     defineExpose({ getUserGroups });
 </script>
+

--- a/src/components/dialogs/UserDialog/UserDialogInfoTab.vue
+++ b/src/components/dialogs/UserDialog/UserDialogInfoTab.vue
@@ -445,7 +445,7 @@
                     <TooltipWrapper side="top" :content="t('dialog.user.info.id_tooltip')">
                         <DropdownMenu>
                             <DropdownMenuTrigger as-child>
-                                <Button class="rounded-full ml-1 text-xs" size="icon-sm" variant="ghost" @click.stop
+                                <Button class="rounded-full ml-1 text-xs" size="icon-sm" variant="ghost" @click.stop :ariaLabel="t('dialog.avatar.info.id_tooltip')"
                                     ><Copy class="h-4 w-4" />
                                 </Button>
                             </DropdownMenuTrigger>

--- a/src/components/dialogs/UserDialog/UserDialogInfoTab.vue
+++ b/src/components/dialogs/UserDialog/UserDialogInfoTab.vue
@@ -431,7 +431,12 @@
                 <span class="block truncate font-medium leading-[18px]">{{ t('dialog.user.info.home_location') }}</span>
                 <span class="block truncate text-xs">
                     <span v-text="userDialog.$homeLocationName"></span>
-                    <Button class="rounded-full ml-1 text-xs" size="icon-sm" variant="ghost" @click.stop="resetHome()"
+                    <Button
+                        class="rounded-full ml-1 text-xs"
+                        size="icon-sm"
+                        variant="ghost"
+                        @click.stop="resetHome()"
+                        :ariaLabel="t('common.actions.delete')"
                         ><Trash2 class="h-4 w-4" />
                     </Button>
                 </span>
@@ -445,7 +450,12 @@
                     <TooltipWrapper side="top" :content="t('dialog.user.info.id_tooltip')">
                         <DropdownMenu>
                             <DropdownMenuTrigger as-child>
-                                <Button class="rounded-full ml-1 text-xs" size="icon-sm" variant="ghost" @click.stop :ariaLabel="t('dialog.avatar.info.id_tooltip')"
+                                <Button
+                                    class="rounded-full ml-1 text-xs"
+                                    size="icon-sm"
+                                    variant="ghost"
+                                    @click.stop
+                                    :ariaLabel="t('dialog.avatar.info.id_tooltip')"
                                     ><Copy class="h-4 w-4" />
                                 </Button>
                             </DropdownMenuTrigger>
@@ -699,3 +709,4 @@
         showEditNoteAndMemoDialog
     });
 </script>
+

--- a/src/components/dialogs/WorldDialog/WorldDialog.vue
+++ b/src/components/dialogs/WorldDialog/WorldDialog.vue
@@ -164,6 +164,7 @@
                                 class="rounded-full mr-2"
                                 size="icon-lg"
                                 variant="outline"
+                                :ariaLabel="t('common.actions.delete')"
                                 :disabled="isGameRunning && worldDialog.cacheLocked"
                                 @click="deleteVRChatCache(worldDialog.ref)"
                                 ><Trash2
@@ -173,7 +174,11 @@
                             v-if="worldDialog.isFavorite"
                             side="top"
                             :content="t('dialog.world.actions.favorites_tooltip')">
-                            <Button class="rounded-full" size="icon-lg" @click="worldDialogCommand('Add Favorite')"
+                            <Button
+                                class="rounded-full"
+                                size="icon-lg"
+                                @click="worldDialogCommand('Add Favorite')"
+                                :ariaLabel="t('dialog.world.actions.favorites_tooltip')"
                                 ><Star
                             /></Button>
                         </TooltipWrapper>
@@ -182,6 +187,7 @@
                                 class="rounded-full"
                                 size="icon-lg"
                                 variant="outline"
+                                :ariaLabel="t('dialog.world.actions.favorites_tooltip')"
                                 @click="worldDialogCommand('Add Favorite')"
                                 ><Star
                             /></Button>
@@ -599,3 +605,4 @@
         }
     );
 </script>
+

--- a/src/components/dialogs/WorldDialog/WorldDialogInfoTab.vue
+++ b/src/components/dialogs/WorldDialog/WorldDialogInfoTab.vue
@@ -26,7 +26,12 @@
                     <TooltipWrapper side="top" :content="t('dialog.world.info.id_tooltip')">
                         <DropdownMenu>
                             <DropdownMenuTrigger as-child>
-                                <Button class="rounded-full text-xs" size="icon-sm" variant="ghost" @click.stop
+                                <Button
+                                    class="rounded-full text-xs"
+                                    size="icon-sm"
+                                    variant="ghost"
+                                    @click.stop
+                                    :ariaLabel="t('dialog.world.info.id_tooltip')"
                                     ><Copy class="h-4 w-4" />
                                 </Button>
                             </DropdownMenuTrigger>
@@ -304,3 +309,4 @@
         openPreviousInstancesListDialog('world', worldRef);
     }
 </script>
+

--- a/src/components/ui/button/Button.vue
+++ b/src/components/ui/button/Button.vue
@@ -11,10 +11,15 @@
         class: { type: null, required: false },
         disabled: { type: Boolean, required: false },
         asChild: { type: Boolean, required: false },
-        as: { type: null, required: false, default: 'button' }
+        as: { type: null, required: false, default: 'button' },
+        ariaLabel: { type: String, required: false }
     });
 
     const isNativeButton = computed(() => props.as === 'button' && !props.asChild);
+
+    const computedAriaLabel = computed(() => {
+        return props.ariaLabel;
+    });
 </script>
 
 <template>
@@ -25,7 +30,10 @@
         :disabled="isNativeButton ? props.disabled : undefined"
         :data-disabled="props.disabled ? '' : undefined"
         :aria-disabled="props.disabled || undefined"
+        :aria-label="computedAriaLabel"
+        v-bind="$attrs"
         :class="cn(buttonVariants({ variant, size }), props.class)">
         <slot />
     </Primitive>
 </template>
+

--- a/src/components/ui/switch/Switch.vue
+++ b/src/components/ui/switch/Switch.vue
@@ -2,6 +2,7 @@
     import { SwitchRoot, SwitchThumb, useForwardPropsEmits } from 'reka-ui';
     import { cn } from '@/lib/utils';
     import { reactiveOmit } from '@vueuse/core';
+    import { computed } from 'vue';
 
     const props = defineProps({
         defaultValue: { type: Boolean, required: false },
@@ -13,7 +14,8 @@
         as: { type: null, required: false },
         name: { type: String, required: false },
         required: { type: Boolean, required: false },
-        class: { type: null, required: false }
+        class: { type: null, required: false },
+        ariaLabel: { type: String, required: false }
     });
 
     const emits = defineEmits(['update:modelValue']);
@@ -21,6 +23,10 @@
     const delegatedProps = reactiveOmit(props, 'class');
 
     const forwarded = useForwardPropsEmits(delegatedProps, emits);
+
+    const computedAriaLabel = computed(() => {
+        return props.ariaLabel;
+    });
 </script>
 
 <template>
@@ -28,6 +34,7 @@
         v-slot="slotProps"
         data-slot="switch"
         v-bind="forwarded"
+        :aria-label="computedAriaLabel"
         :class="
             cn(
                 'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer',

--- a/src/components/ui/toggle/Toggle.vue
+++ b/src/components/ui/toggle/Toggle.vue
@@ -2,6 +2,7 @@
     import { Toggle, useForwardPropsEmits } from 'reka-ui';
     import { cn } from '@/lib/utils';
     import { reactiveOmit } from '@vueuse/core';
+    import { computed } from 'vue';
 
     import { toggleVariants } from '.';
 
@@ -15,13 +16,18 @@
         required: { type: Boolean, required: false },
         class: { type: null, required: false },
         variant: { type: null, required: false, default: 'default' },
-        size: { type: null, required: false, default: 'default' }
+        size: { type: null, required: false, default: 'default' },
+        ariaLabel: { type: String, required: false }
     });
 
     const emits = defineEmits(['update:modelValue']);
 
     const delegatedProps = reactiveOmit(props, 'class', 'size', 'variant');
     const forwarded = useForwardPropsEmits(delegatedProps, emits);
+
+    const computedAriaLabel = computed(() => {
+        return props.ariaLabel;
+    });
 </script>
 
 <template>
@@ -29,7 +35,9 @@
         v-slot="slotProps"
         data-slot="toggle"
         v-bind="forwarded"
+        :aria-label="computedAriaLabel"
         :class="cn(toggleVariants({ variant, size }), props.class)">
         <slot v-bind="slotProps" />
     </Toggle>
 </template>
+

--- a/src/views/Dashboard/components/DashboardPanel.vue
+++ b/src/views/Dashboard/components/DashboardPanel.vue
@@ -14,7 +14,11 @@
                     <div class="flex items-center gap-2 text-base text-muted-foreground">
                         <i v-if="panelIcon" :class="panelIcon" class="text-base" />
                         <span>{{ panelLabel }}</span>
-                        <Button variant="ghost" size="icon-sm" @click="clearPanel">
+                        <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            :ariaLabel="t('common.actions.delete')"
+                            @click="clearPanel">
                             <Trash2 class="size-3.5" />
                         </Button>
                     </div>
@@ -192,3 +196,4 @@
         height: 1.75rem;
     }
 </style>
+

--- a/src/views/Favorites/FavoritesAvatar.vue
+++ b/src/views/Favorites/FavoritesAvatar.vue
@@ -39,6 +39,7 @@
                                         variant="ghost"
                                         size="icon-sm"
                                         :disabled="isFavoriteLoading"
+                                        :ariaLabel="t('view.favorite.refresh_favorites_tooltip')"
                                         @click.stop="handleRefreshFavorites">
                                         <Spinner v-if="isFavoriteLoading" />
                                         <RefreshCw v-else />
@@ -76,6 +77,7 @@
                                                         class="rounded-full"
                                                         variant="ghost"
                                                         size="icon-sm"
+                                                        :ariaLabel="t('nav_tooltip.manage')"
                                                         @click.stop>
                                                         <MoreHorizontal />
                                                     </Button>
@@ -146,6 +148,7 @@
                                         class="rounded-full"
                                         size="icon"
                                         variant="ghost"
+                                        :ariaLabel="t('common.actions.refresh')"
                                         @click.stop="refreshLocalAvatarFavorites"
                                         ><RefreshCcw
                                     /></Button>

--- a/src/views/Favorites/FavoritesFriend.vue
+++ b/src/views/Favorites/FavoritesFriend.vue
@@ -39,6 +39,7 @@
                                         variant="ghost"
                                         size="icon-sm"
                                         :disabled="isFavoriteLoading"
+                                        :ariaLabel="t('view.favorite.refresh_favorites_tooltip')"
                                         @click.stop="handleRefreshFavorites">
                                         <Spinner v-if="isFavoriteLoading" />
                                         <RefreshCw v-else />
@@ -76,6 +77,7 @@
                                                         class="rounded-full"
                                                         variant="ghost"
                                                         size="icon-sm"
+                                                        :ariaLabel="t('nav_tooltip.manage')"
                                                         @click.stop>
                                                         <MoreHorizontal />
                                                     </Button>
@@ -130,6 +132,7 @@
                                     class="rounded-full"
                                     size="icon-sm"
                                     variant="ghost"
+                                    :ariaLabel="t('common.actions.refresh')"
                                     @click.stop="getLocalFriendFavorites"
                                     ><RefreshCcw />
                                 </Button>

--- a/src/views/Favorites/FavoritesWorld.vue
+++ b/src/views/Favorites/FavoritesWorld.vue
@@ -42,6 +42,7 @@
                                         variant="ghost"
                                         size="icon-sm"
                                         :disabled="isFavoriteLoading"
+                                        :ariaLabel="t('view.favorite.refresh_favorites_tooltip')"
                                         @click.stop="handleRefreshFavorites">
                                         <Spinner v-if="isFavoriteLoading" />
                                         <RefreshCw v-else />
@@ -79,6 +80,7 @@
                                                         class="rounded-full"
                                                         variant="ghost"
                                                         size="icon-sm"
+                                                        :ariaLabel="t('nav_tooltip.manage')"
                                                         @click.stop>
                                                         <MoreHorizontal />
                                                     </Button>
@@ -148,6 +150,7 @@
                                     class="rounded-full"
                                     size="icon-sm"
                                     variant="ghost"
+                                    :ariaLabel="t('common.actions.refresh')"
                                     v-if="!refreshingLocalFavorites"
                                     @click.stop="refreshLocalWorldFavorites"
                                     ><RefreshCcw

--- a/src/views/Favorites/components/FavoritesAvatarItem.vue
+++ b/src/views/Favorites/components/FavoritesAvatarItem.vue
@@ -40,7 +40,7 @@
                     <ItemActions v-else-if="!editMode">
                         <DropdownMenu>
                             <DropdownMenuTrigger as-child>
-                                <Button size="icon-sm" variant="ghost" class="rounded-full" @click.stop>
+                                <Button size="icon-sm" variant="ghost" class="rounded-full" @click.stop :ariaLabel="t('nav_tooltip.manage')">
                                     <MoreHorizontal class="h-4 w-4" />
                                 </Button>
                             </DropdownMenuTrigger>

--- a/src/views/Favorites/components/FavoritesContentHeader.vue
+++ b/src/views/Favorites/components/FavoritesContentHeader.vue
@@ -8,6 +8,7 @@
             <Switch
                 :model-value="editMode"
                 :disabled="editModeDisabled"
+                :ariaLabel="t('view.favorite.edit_mode')"
                 @update:modelValue="$emit('update:editMode', $event)" />
         </div>
     </div>

--- a/src/views/Favorites/components/FavoritesFriendItem.vue
+++ b/src/views/Favorites/components/FavoritesFriendItem.vue
@@ -42,7 +42,7 @@
                 </ItemActions>
                 <DropdownMenu v-else>
                     <DropdownMenuTrigger as-child>
-                        <Button size="icon-sm" variant="ghost" class="rounded-full" @click.stop>
+                        <Button size="icon-sm" variant="ghost" class="rounded-full" @click.stop :ariaLabel="t('nav_tooltip.manage')">
                             <MoreHorizontal class="h-4 w-4" />
                         </Button>
                     </DropdownMenuTrigger>

--- a/src/views/Favorites/components/FavoritesWorldItem.vue
+++ b/src/views/Favorites/components/FavoritesWorldItem.vue
@@ -38,7 +38,7 @@
                 </ItemActions>
                 <DropdownMenu v-else-if="!editMode">
                     <DropdownMenuTrigger as-child>
-                        <Button size="icon-sm" variant="ghost" class="rounded-full" @click.stop>
+                        <Button size="icon-sm" variant="ghost" class="rounded-full" @click.stop :ariaLabel="t('nav_tooltip.manage')">
                             <MoreHorizontal class="h-4 w-4" />
                         </Button>
                     </DropdownMenuTrigger>

--- a/src/views/Feed/Feed.vue
+++ b/src/views/Feed/Feed.vue
@@ -46,6 +46,7 @@
                                     variant="outline"
                                     size="sm"
                                     :model-value="feedTable.vip"
+                                    :ariaLabel="t('view.feed.favorites_only_tooltip')"
                                     @update:modelValue="
                                         (v) => {
                                             feedTable.vip = v;
@@ -254,3 +255,4 @@
         border-radius: 4px;
     }
 </style>
+

--- a/src/views/FriendList/FriendList.vue
+++ b/src/views/FriendList/FriendList.vue
@@ -20,6 +20,7 @@
                                         variant="outline"
                                         size="sm"
                                         :model-value="friendsListSearchFilterVIP"
+                                        :ariaLabel="t('view.friend_list.favorites_only_tooltip')"
                                         @update:modelValue="
                                             (v) => {
                                                 friendsListSearchFilterVIP = v;
@@ -75,6 +76,7 @@
                                 <span class="name mr-2 text-xs">{{ t('view.friend_list.bulk_unfriend') }}</span>
                                 <Switch
                                     v-model="friendsListBulkUnfriendMode"
+                                    :ariaLabel="t('view.friend_list.bulk_unfriend')"
                                     @update:modelValue="toggleFriendsListBulkUnfriendMode" />
                             </div>
                             <div class="flex items-center">

--- a/src/views/FriendsLocations/FriendsLocations.vue
+++ b/src/views/FriendsLocations/FriendsLocations.vue
@@ -17,7 +17,7 @@
                     <div>
                         <Popover>
                             <PopoverTrigger asChild>
-                                <Button class="rounded-full mr-2" size="icon" variant="ghost">
+                                <Button class="rounded-full mr-2" size="icon" variant="ghost" :ariaLabel="t('view.charts.instance_activity.settings.header')">
                                     <Settings />
                                 </Button>
                             </PopoverTrigger>

--- a/src/views/GameLog/GameLog.vue
+++ b/src/views/GameLog/GameLog.vue
@@ -14,7 +14,8 @@
                             <ToggleGroupItem
                                 value="sessions"
                                 class="px-2"
-                                :class="sessionsViewMode === 'sessions' && 'bg-accent text-accent-foreground'">
+                                :class="sessionsViewMode === 'sessions' && 'bg-accent text-accent-foreground'"
+                                :ariaLabel="t('view.game_log.sessions.switch_to_sessions')">
                                 <Logs class="size-4" />
                             </ToggleGroupItem>
                         </TooltipWrapper>
@@ -22,7 +23,8 @@
                             <ToggleGroupItem
                                 value="table"
                                 class="px-2"
-                                :class="sessionsViewMode === 'table' && 'bg-accent text-accent-foreground'">
+                                :class="sessionsViewMode === 'table' && 'bg-accent text-accent-foreground'"
+                                :ariaLabel="t('view.game_log.sessions.switch_to_table')">
                                 <Table2 class="size-4" />
                             </ToggleGroupItem>
                         </TooltipWrapper>
@@ -53,7 +55,8 @@
                                     <ToggleGroupItem
                                         value="sessions"
                                         class="px-2"
-                                        :class="sessionsViewMode === 'sessions' && 'bg-accent text-accent-foreground'">
+                                        :class="sessionsViewMode === 'sessions' && 'bg-accent text-accent-foreground'"
+                                        :ariaLabel="t('view.game_log.sessions.switch_to_sessions')">
                                         <Logs class="size-4" />
                                     </ToggleGroupItem>
                                 </TooltipWrapper>
@@ -61,7 +64,8 @@
                                     <ToggleGroupItem
                                         value="table"
                                         class="px-2"
-                                        :class="sessionsViewMode === 'table' && 'bg-accent text-accent-foreground'">
+                                        :class="sessionsViewMode === 'table' && 'bg-accent text-accent-foreground'"
+                                        :ariaLabel="t('view.game_log.sessions.switch_to_table')">
                                         <Table2 class="size-4" />
                                     </ToggleGroupItem>
                                 </TooltipWrapper>
@@ -72,6 +76,7 @@
                                         variant="outline"
                                         size="sm"
                                         :model-value="gameLogTable.vip"
+                                        :ariaLabel="t('view.feed.favorites_only_tooltip')"
                                         @update:modelValue="
                                             (v) => {
                                                 gameLogTable.vip = v;

--- a/src/views/GameLog/components/GameLogSessions.vue
+++ b/src/views/GameLog/components/GameLogSessions.vue
@@ -10,6 +10,7 @@
                             variant="outline"
                             size="sm"
                             :model-value="sessionsVipFilter"
+                            :ariaLabel="t('view.feed.favorites_only_tooltip')"
                             @update:modelValue="gameLogStore.toggleSessionsVipFilter()">
                             <Star />
                         </Toggle>
@@ -22,7 +23,8 @@
                             variant="outline"
                             size="sm"
                             class="h-8 shrink-0 gap-1.5"
-                            :class="hasDateFilter && 'bg-accent text-accent-foreground'">
+                            :class="hasDateFilter && 'bg-accent text-accent-foreground'"
+                            :ariaLabel="t('view.tools.group.calendar')">
                             <CalendarRange class="size-4" />
                             <Badge
                                 v-if="hasDateFilter"

--- a/src/views/MyAvatars/MyAvatars.vue
+++ b/src/views/MyAvatars/MyAvatars.vue
@@ -10,7 +10,8 @@
                     <ToggleGroupItem
                         value="grid"
                         class="px-2"
-                        :class="viewMode === 'grid' && 'bg-accent text-accent-foreground'">
+                        :class="viewMode === 'grid' && 'bg-accent text-accent-foreground'"
+                        :ariaLabel="t('view.my_avatars.grid_view')">
                         <LayoutGrid class="size-4" />
                     </ToggleGroupItem>
                 </TooltipWrapper>
@@ -18,7 +19,8 @@
                     <ToggleGroupItem
                         value="table"
                         class="px-2"
-                        :class="viewMode === 'table' && 'bg-accent text-accent-foreground'">
+                        :class="viewMode === 'table' && 'bg-accent text-accent-foreground'"
+                        :ariaLabel="t('view.my_avatars.table_view')">
                         <List class="size-4" />
                     </ToggleGroupItem>
                 </TooltipWrapper>
@@ -128,7 +130,7 @@
 
             <DropdownMenu v-if="viewMode === 'grid'">
                 <DropdownMenuTrigger as-child>
-                    <Button class="rounded-full" size="icon-sm" variant="ghost">
+                    <Button class="rounded-full" size="icon-sm" variant="ghost" :ariaLabel="t('view.settings.appearance.appearance.header')">
                         <SettingsIcon class="size-4" />
                     </Button>
                 </DropdownMenuTrigger>
@@ -158,7 +160,7 @@
                 </DropdownMenuContent>
             </DropdownMenu>
 
-            <Button size="icon-sm" variant="ghost" :disabled="isLoading" @click="refreshAvatars">
+            <Button size="icon-sm" variant="ghost" :disabled="isLoading" @click="refreshAvatars" :ariaLabel="t('view.charts.instance_activity.refresh')">
                 <RefreshCw :class="{ 'animate-spin': isLoading }" />
             </Button>
         </div>

--- a/src/views/Notifications/Notification.vue
+++ b/src/views/Notifications/Notification.vue
@@ -65,6 +65,7 @@
                             size="icon-sm"
                             :disabled="isNotificationsLoading"
                             style="flex: none"
+                            :ariaLabel="t('view.notification.refresh_tooltip')"
                             @click="refreshNotifications()">
                             <Spinner v-if="isNotificationsLoading" />
                             <RefreshCw v-else />

--- a/src/views/Notifications/columns.jsx
+++ b/src/views/Notifications/columns.jsx
@@ -610,6 +610,9 @@ export const createColumns = ({
                                             <button
                                                 type="button"
                                                 class="inline-flex h-6 ml-1 items-center justify-center text-muted-foreground hover:text-foreground cursor-pointer"
+                                                aria-label={t(
+                                                    'view.notification.actions.accept'
+                                                )}
                                                 onClick={() =>
                                                     acceptFriendRequestNotification(
                                                         original
@@ -635,6 +638,9 @@ export const createColumns = ({
                                             <button
                                                 type="button"
                                                 class="inline-flex h-6 ml-1 items-center justify-center text-muted-foreground hover:text-foreground cursor-pointer"
+                                                aria-label={t(
+                                                    'view.notification.actions.decline_with_message'
+                                                )}
                                                 onClick={() =>
                                                     showSendInviteResponseDialog(
                                                         original
@@ -662,6 +668,9 @@ export const createColumns = ({
                                                     <button
                                                         type="button"
                                                         class="inline-flex h-6 ml-1 items-center justify-center text-muted-foreground hover:text-foreground cursor-pointer"
+                                                        aria-label={t(
+                                                            'view.notification.actions.invite'
+                                                        )}
                                                         onClick={() =>
                                                             acceptRequestInvite(
                                                                 original
@@ -685,6 +694,9 @@ export const createColumns = ({
                                                 <button
                                                     type="button"
                                                     class="inline-flex h-6 ml-1 items-center justify-center text-muted-foreground hover:text-foreground cursor-pointer"
+                                                    aria-label={t(
+                                                        'view.notification.actions.decline_with_message'
+                                                    )}
                                                     onClick={() =>
                                                         showSendInviteRequestResponseDialog(
                                                             original
@@ -743,6 +755,9 @@ export const createColumns = ({
                                                       <button
                                                           type="button"
                                                           class="inline-flex h-6 ml-1 items-center justify-center text-muted-foreground hover:text-foreground cursor-pointer"
+                                                          aria-label={
+                                                              response.text
+                                                          }
                                                           onClick={onClick}
                                                       >
                                                           <ResponseIcon class="h-4 w-4" />
@@ -764,6 +779,9 @@ export const createColumns = ({
                                             <button
                                                 type="button"
                                                 class="inline-flex h-6 ml-1 items-center justify-center text-muted-foreground hover:text-foreground cursor-pointer"
+                                                aria-label={t(
+                                                    'view.notification.actions.decline'
+                                                )}
                                                 onClick={() =>
                                                     shiftHeld.value
                                                         ? hideNotification(
@@ -799,6 +817,9 @@ export const createColumns = ({
                                             <button
                                                 type="button"
                                                 class="inline-flex h-6 ml-1 items-center justify-center text-muted-foreground hover:text-foreground cursor-pointer"
+                                                aria-label={t(
+                                                    'view.notification.actions.delete_log'
+                                                )}
                                                 onClick={() =>
                                                     shiftHeld.value
                                                         ? deleteNotificationLog(
@@ -833,6 +854,9 @@ export const createColumns = ({
                                     <button
                                         type="button"
                                         class="inline-flex h-6 ml-1 items-center justify-center text-muted-foreground hover:text-foreground cursor-pointer"
+                                        aria-label={t(
+                                            'view.notification.actions.delete_log'
+                                        )}
                                         onClick={() =>
                                             shiftHeld.value
                                                 ? deleteNotificationLog(
@@ -873,3 +897,4 @@ export const createColumns = ({
         }
     ];
 };
+

--- a/src/views/Search/Search.vue
+++ b/src/views/Search/Search.vue
@@ -21,7 +21,7 @@
                         @input="updateSearchText"
                         @keyup.enter="search" />
                     <TooltipWrapper side="bottom" :content="t('view.search.clear_results_tooltip')">
-                        <Button class="rounded-full ml-2" size="icon" variant="ghost" @click="handleClearSearch">
+                        <Button class="rounded-full ml-2" size="icon" variant="ghost" :ariaLabel="t('view.search.clear_results_tooltip')" @click="handleClearSearch">
                             <Trash2 />
                         </Button>
                     </TooltipWrapper>

--- a/src/views/Settings/components/Tabs/AdvancedTab.vue
+++ b/src/views/Settings/components/Tabs/AdvancedTab.vue
@@ -4,25 +4,25 @@
             <SettingsItem
                 :label="t('view.settings.advanced.advanced.relaunch_vrchat.header')"
                 :description="t('view.settings.advanced.advanced.relaunch_vrchat.description')">
-                <Switch :model-value="relaunchVRChatAfterCrash" @update:modelValue="setRelaunchVRChatAfterCrash" />
+                <Switch :model-value="relaunchVRChatAfterCrash" :ariaLabel="t('view.settings.advanced.advanced.relaunch_vrchat.header')" @update:modelValue="setRelaunchVRChatAfterCrash" />
             </SettingsItem>
 
             <SettingsItem
                 :label="t('view.settings.advanced.advanced.vrchat_quit_fix.header')"
                 :description="t('view.settings.advanced.advanced.vrchat_quit_fix.description')">
-                <Switch :model-value="vrcQuitFix" @update:modelValue="setVrcQuitFix" />
+                <Switch :model-value="vrcQuitFix" :ariaLabel="t('view.settings.advanced.advanced.vrchat_quit_fix.header')" @update:modelValue="setVrcQuitFix" />
             </SettingsItem>
 
             <SettingsItem
                 :label="t('view.settings.advanced.advanced.auto_cache_management.header')"
                 :description="t('view.settings.advanced.advanced.auto_cache_management.description')">
-                <Switch :model-value="autoSweepVRChatCache" @update:modelValue="setAutoSweepVRChatCache" />
+                <Switch :model-value="autoSweepVRChatCache" :ariaLabel="t('view.settings.advanced.advanced.auto_cache_management.header')" @update:modelValue="setAutoSweepVRChatCache" />
             </SettingsItem>
 
             <SettingsItem
                 :label="t('view.settings.advanced.advanced.self_invite.header')"
                 :description="t('view.settings.advanced.advanced.self_invite.description')">
-                <Switch :model-value="selfInviteOverride" @update:modelValue="setSelfInviteOverride" />
+                <Switch :model-value="selfInviteOverride" :ariaLabel="t('view.settings.advanced.advanced.self_invite.header')" @update:modelValue="setSelfInviteOverride" />
             </SettingsItem>
         </SettingsGroup>
 
@@ -33,25 +33,26 @@
                 <Switch
                     :model-value="enablePrimaryPassword"
                     :disabled="!enablePrimaryPassword"
+                    :ariaLabel="t('view.settings.advanced.advanced.primary_password.header')"
                     @update:modelValue="enablePrimaryPasswordChange" />
             </SettingsItem>
         </SettingsGroup>
 
         <SettingsGroup :title="t('view.settings.general.logging.header')">
             <SettingsItem :label="t('view.settings.advanced.advanced.cache_debug.udon_exception_logging')">
-                <Switch :model-value="udonExceptionLogging" @update:modelValue="setUdonExceptionLogging" />
+                <Switch :model-value="udonExceptionLogging" :ariaLabel="t('view.settings.advanced.advanced.cache_debug.udon_exception_logging')" @update:modelValue="setUdonExceptionLogging" />
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.general.logging.resource_load')">
-                <Switch :model-value="logResourceLoad" @update:modelValue="setLogResourceLoad" />
+                <Switch :model-value="logResourceLoad" :ariaLabel="t('view.settings.general.logging.resource_load')" @update:modelValue="setLogResourceLoad" />
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.general.logging.empty_avatar')">
-                <Switch :model-value="logEmptyAvatars" @update:modelValue="setLogEmptyAvatars" />
+                <Switch :model-value="logEmptyAvatars" :ariaLabel="t('view.settings.general.logging.empty_avatar')" @update:modelValue="setLogEmptyAvatars" />
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.general.logging.auto_login_delay')">
-                <Switch :model-value="autoLoginDelayEnabled" @update:modelValue="setAutoLoginDelayEnabled" />
+                <Switch :model-value="autoLoginDelayEnabled" :ariaLabel="t('view.settings.general.logging.auto_login_delay')" @update:modelValue="setAutoLoginDelayEnabled" />
             </SettingsItem>
 
             <SettingsItem
@@ -74,18 +75,20 @@
                 <SettingsItem
                     :label="t('view.settings.advanced.advanced.remote_database.enable')"
                     :description="t('view.settings.advanced.advanced.app_launcher.folder_tooltip')">
-                    <Switch :model-value="enableAppLauncher" @update:modelValue="setEnableAppLauncher" />
+                    <Switch :model-value="enableAppLauncher" :ariaLabel="t('view.settings.advanced.advanced.remote_database.enable')" @update:modelValue="setEnableAppLauncher" />
                 </SettingsItem>
 
                 <SettingsItem :label="t('view.settings.advanced.advanced.app_launcher.auto_close')">
                     <Switch
                         :model-value="enableAppLauncherAutoClose"
+                        :ariaLabel="t('view.settings.advanced.advanced.app_launcher.auto_close')"
                         @update:modelValue="setEnableAppLauncherAutoClose" />
                 </SettingsItem>
 
                 <SettingsItem :label="t('view.settings.advanced.advanced.app_launcher.run_process_once')">
                     <Switch
                         :model-value="enableAppLauncherRunProcessOnce"
+                        :ariaLabel="t('view.settings.advanced.advanced.app_launcher.run_process_once')"
                         @update:modelValue="setEnableAppLauncherRunProcessOnce" />
                 </SettingsItem>
             </SettingsGroup>
@@ -99,6 +102,7 @@
                 ">
                 <Switch
                     :model-value="showConfirmationOnSwitchAvatar"
+                    :ariaLabel="t('view.settings.advanced.advanced.launch_commands.show_confirmation_on_switch_avatar_enable')"
                     @update:modelValue="setShowConfirmationOnSwitchAvatar" />
             </SettingsItem>
 
@@ -133,7 +137,7 @@
 
             <SettingsItem
                 :label="`${t('view.settings.advanced.advanced.cache_debug.disable_gamelog')} ${t('view.settings.advanced.advanced.cache_debug.disable_gamelog_notice')}`">
-                <Switch :model-value="gameLogDisabled" @update:modelValue="disableGameLogDialog()" />
+                <Switch :model-value="gameLogDisabled" :ariaLabel="t('view.settings.advanced.advanced.cache_debug.disable_gamelog')" @update:modelValue="disableGameLogDialog()" />
             </SettingsItem>
 
             <div class="flex flex-col gap-1 text-sm">

--- a/src/views/Settings/components/Tabs/IntegrationsTab.vue
+++ b/src/views/Settings/components/Tabs/IntegrationsTab.vue
@@ -12,6 +12,7 @@
             <SettingsItem :label="t('view.settings.discord_presence.discord_presence.enable')">
                 <Switch
                     :model-value="discordActive"
+                    :ariaLabel="t('view.settings.discord_presence.discord_presence.enable')"
                     @update:modelValue="
                         setDiscordActive();
                         saveDiscordOption();
@@ -24,6 +25,7 @@
                 <Switch
                     :model-value="discordWorldIntegration"
                     :disabled="!discordActive"
+                    :ariaLabel="t('view.settings.discord_presence.discord_presence.world_integration')"
                     @update:modelValue="
                         setDiscordWorldIntegration();
                         saveDiscordOption();
@@ -34,6 +36,7 @@
                 <Switch
                     :model-value="discordInstance"
                     :disabled="!discordActive"
+                    :ariaLabel="t('view.settings.discord_presence.discord_presence.instance_type_player_count')"
                     @update:modelValue="
                         setDiscordInstance();
                         saveDiscordOption();
@@ -44,6 +47,7 @@
                 <Switch
                     :model-value="discordShowPlatform"
                     :disabled="!discordActive || !discordInstance"
+                    :ariaLabel="t('view.settings.discord_presence.discord_presence.show_current_platform')"
                     @update:modelValue="
                         setDiscordShowPlatform();
                         saveDiscordOption();
@@ -54,6 +58,7 @@
                 <Switch
                     :model-value="!discordHideInvite"
                     :disabled="!discordActive"
+                    :ariaLabel="t('view.settings.discord_presence.discord_presence.show_details_in_private')"
                     @update:modelValue="
                         setDiscordHideInvite();
                         saveDiscordOption();
@@ -64,6 +69,7 @@
                 <Switch
                     :model-value="discordJoinButton"
                     :disabled="!discordActive"
+                    :ariaLabel="t('view.settings.discord_presence.discord_presence.join_button')"
                     @update:modelValue="
                         setDiscordJoinButton();
                         saveDiscordOption();
@@ -74,6 +80,7 @@
                 <Switch
                     :model-value="!discordHideImage"
                     :disabled="!discordActive"
+                    :ariaLabel="t('view.settings.discord_presence.discord_presence.show_images')"
                     @update:modelValue="
                         setDiscordHideImage();
                         saveDiscordOption();
@@ -85,6 +92,7 @@
                 <Switch
                     :model-value="discordWorldNameAsDiscordStatus"
                     :disabled="!discordActive"
+                    :ariaLabel="t('view.settings.discord_presence.discord_presence.display_world_name_as_discord_status')"
                     @update:modelValue="
                         setDiscordWorldNameAsDiscordStatus();
                         saveDiscordOption();
@@ -99,6 +107,7 @@
                 :description="t('view.settings.advanced.advanced.translation_api.enable_tooltip')">
                 <Switch
                     :model-value="translationApi"
+                    :ariaLabel="t('view.settings.advanced.advanced.translation_api.enable')"
                     @update:modelValue="changeTranslationAPI('VRCX_translationAPI')" />
             </SettingsItem>
 
@@ -115,7 +124,7 @@
             <SettingsItem
                 :label="t('view.settings.advanced.advanced.youtube_api.enable')"
                 :description="t('view.settings.advanced.advanced.youtube_api.enable_tooltip')">
-                <Switch :model-value="youTubeApi" @update:modelValue="changeYouTubeApi('VRCX_youtubeAPI')" />
+                <Switch :model-value="youTubeApi" :ariaLabel="t('view.settings.advanced.advanced.youtube_api.enable')" @update:modelValue="changeYouTubeApi('VRCX_youtubeAPI')" />
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.advanced.advanced.youtube_api.youtube_api_key')">
@@ -132,6 +141,7 @@
                 :description="t('view.settings.advanced.advanced.remote_database.enable_description')">
                 <Switch
                     :model-value="avatarRemoteDatabase"
+                    :ariaLabel="t('view.settings.advanced.advanced.remote_database.enable')"
                     @update:modelValue="setAvatarRemoteDatabase(!avatarRemoteDatabase)" />
             </SettingsItem>
 

--- a/src/views/Settings/components/Tabs/InterfaceTab.vue
+++ b/src/views/Settings/components/Tabs/InterfaceTab.vue
@@ -89,6 +89,7 @@
             <SettingsItem :label="t('view.settings.appearance.appearance.show_notification_icon_dot')">
                 <Switch
                     :model-value="notificationIconDot"
+                    :ariaLabel="t('view.settings.appearance.appearance.show_notification_icon_dot')"
                     @update:modelValue="
                         setNotificationIconDot();
                         saveOpenVROption();
@@ -100,6 +101,7 @@
                 :description="t('view.settings.appearance.appearance.vrcplus_profile_icons_description')">
                 <Switch
                     :model-value="displayVRCPlusIconsAsAvatar"
+                    :ariaLabel="t('view.settings.appearance.appearance.vrcplus_profile_icons')"
                     @update:modelValue="
                         setDisplayVRCPlusIconsAsAvatar();
                         saveOpenVROption();
@@ -109,7 +111,7 @@
 
         <SettingsGroup :title="t('view.settings.appearance.display.header')">
             <SettingsItem :label="t('view.settings.appearance.appearance.show_instance_id')">
-                <Switch :model-value="showInstanceIdInLocation" @update:modelValue="setShowInstanceIdInLocation" />
+                <Switch :model-value="showInstanceIdInLocation" :ariaLabel="t('view.settings.appearance.appearance.show_instance_id')" @update:modelValue="setShowInstanceIdInLocation" />
             </SettingsItem>
 
             <SettingsItem
@@ -117,6 +119,7 @@
                 :description="t('view.settings.appearance.appearance.nicknames_description')">
                 <Switch
                     :model-value="!hideNicknames"
+                    :ariaLabel="t('view.settings.appearance.appearance.nicknames')"
                     @update:modelValue="
                         setHideNicknames();
                         saveOpenVROption();
@@ -126,11 +129,11 @@
             <SettingsItem
                 :label="t('view.settings.appearance.appearance.age_gated_instances')"
                 :description="t('view.settings.appearance.appearance.age_gated_instances_description')">
-                <Switch :model-value="isAgeGatedInstancesVisible" @update:modelValue="setIsAgeGatedInstancesVisible" />
+                <Switch :model-value="isAgeGatedInstancesVisible" :ariaLabel="t('view.settings.appearance.appearance.age_gated_instances')" @update:modelValue="setIsAgeGatedInstancesVisible" />
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.appearance.appearance.striped_data_table_mode')">
-                <Switch :model-value="isDataTableStriped" @update:modelValue="toggleStripedDataTable" />
+                <Switch :model-value="isDataTableStriped" :ariaLabel="t('view.settings.appearance.appearance.striped_data_table_mode')" @update:modelValue="toggleStripedDataTable" />
             </SettingsItem>
 
             <SettingsItem
@@ -138,19 +141,20 @@
                 :description="t('view.settings.appearance.appearance.accessible_status_indicators_description')">
                 <Switch
                     :model-value="accessibleStatusIndicators"
+                    :ariaLabel="t('view.settings.appearance.appearance.accessible_status_indicators')"
                     @update:modelValue="toggleAccessibleStatusIndicators" />
             </SettingsItem>
 
             <SettingsItem
                 :label="t('view.settings.appearance.appearance.use_official_status_colors')"
                 :description="t('view.settings.appearance.appearance.use_official_status_colors_description')">
-                <Switch :model-value="useOfficialStatusColors" @update:modelValue="toggleOfficialStatusColors" />
+                <Switch :model-value="useOfficialStatusColors" :ariaLabel="t('view.settings.appearance.appearance.use_official_status_colors')" @update:modelValue="toggleOfficialStatusColors" />
             </SettingsItem>
         </SettingsGroup>
 
         <SettingsGroup :title="t('view.settings.interface.navigation.header')">
             <SettingsItem :label="t('view.settings.interface.navigation.show_new_dashboard_button')">
-                <Switch :model-value="showNewDashboardButton" @update:modelValue="setShowNewDashboardButton" />
+                <Switch :model-value="showNewDashboardButton" :ariaLabel="t('view.settings.interface.navigation.show_new_dashboard_button')" @update:modelValue="setShowNewDashboardButton" />
             </SettingsItem>
         </SettingsGroup>
 
@@ -190,7 +194,7 @@
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.appearance.appearance.table_page_sizes')">
-                <Button size="sm" variant="outline" @click="tablePageSizesDialogOpen = true">{{
+                <Button size="sm" variant="outline" :ariaLabel="t('view.settings.appearance.appearance.table_page_sizes')" @click="tablePageSizesDialogOpen = true">{{
                     t('common.actions.configure')
                 }}</Button>
 
@@ -294,7 +298,7 @@
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.appearance.timedate.force_iso_date_format')">
-                <Switch :model-value="dtIsoFormat" @update:modelValue="setDtIsoFormat" />
+                <Switch :model-value="dtIsoFormat" :ariaLabel="t('view.settings.appearance.timedate.force_iso_date_format')" @update:modelValue="setDtIsoFormat" />
             </SettingsItem>
 
             <SettingsItem
@@ -317,19 +321,19 @@
             <SettingsItem
                 :label="t('view.settings.appearance.user_dialog.vrchat_notes')"
                 :description="t('view.settings.appearance.user_dialog.vrchat_notes_description')">
-                <Switch :model-value="!hideUserNotes" @update:modelValue="setHideUserNotes" />
+                <Switch :model-value="!hideUserNotes" :ariaLabel="t('view.settings.appearance.user_dialog.vrchat_notes')" @update:modelValue="setHideUserNotes" />
             </SettingsItem>
 
             <SettingsItem
                 :label="t('view.settings.appearance.user_dialog.vrcx_memos')"
                 :description="t('view.settings.appearance.user_dialog.vrcx_memos_description')">
-                <Switch :model-value="!hideUserMemos" @update:modelValue="setHideUserMemos" />
+                <Switch :model-value="!hideUserMemos" :ariaLabel="t('view.settings.appearance.user_dialog.vrcx_memos')" @update:modelValue="setHideUserMemos" />
             </SettingsItem>
         </SettingsGroup>
 
         <SettingsGroup :title="t('view.settings.appearance.friend_log.header')">
             <SettingsItem :label="t('view.settings.appearance.friend_log.hide_unfriends')">
-                <Switch :model-value="hideUnfriends" @update:modelValue="setHideUnfriends" />
+                <Switch :model-value="hideUnfriends" :ariaLabel="t('view.settings.appearance.friend_log.hide_unfriends')" @update:modelValue="setHideUnfriends" />
             </SettingsItem>
         </SettingsGroup>
 
@@ -337,7 +341,7 @@
             <SettingsItem
                 :label="t('view.settings.appearance.user_colors.random_colors_from_user_id')"
                 :description="t('view.settings.appearance.user_colors.random_colors_from_user_id_description')">
-                <Switch :model-value="randomUserColours" @update:modelValue="updateTrustColor('', '', true)" />
+                <Switch :model-value="randomUserColours" :ariaLabel="t('view.settings.appearance.user_colors.random_colors_from_user_id')" @update:modelValue="updateTrustColor('', '', true)" />
             </SettingsItem>
             <div class="settings-item">
                 <div class="flex flex-col gap-2 py-2">

--- a/src/views/Settings/components/Tabs/MediaTab.vue
+++ b/src/views/Settings/components/Tabs/MediaTab.vue
@@ -9,7 +9,7 @@
             <SettingsItem
                 :label="t('view.settings.advanced.advanced.screenshot_helper.enable')"
                 :description="t('view.settings.advanced.advanced.screenshot_helper.description_tooltip')">
-                <Switch :model-value="screenshotHelper" @update:modelValue="setScreenshotHelper()" />
+                <Switch :model-value="screenshotHelper" :ariaLabel="t('view.settings.advanced.advanced.screenshot_helper.enable')" @update:modelValue="setScreenshotHelper()" />
             </SettingsItem>
 
             <SettingsItem
@@ -18,17 +18,19 @@
                 <Switch
                     :model-value="screenshotHelperModifyFilename"
                     :disabled="!screenshotHelper"
+                    :ariaLabel="t('view.settings.advanced.advanced.screenshot_helper.modify_filename')"
                     @update:modelValue="setScreenshotHelperModifyFilename()" />
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.advanced.advanced.screenshot_helper.copy_to_clipboard')">
                 <Switch
                     :model-value="screenshotHelperCopyToClipboard"
+                    :ariaLabel="t('view.settings.advanced.advanced.screenshot_helper.copy_to_clipboard')"
                     @update:modelValue="setScreenshotHelperCopyToClipboard()" />
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.advanced.advanced.delete_all_screenshot_metadata.button')">
-                <Button size="sm" variant="outline" @click="askDeleteAllScreenshotMetadata()">{{
+                <Button size="sm" variant="outline" :ariaLabel="t('view.settings.advanced.advanced.delete_all_screenshot_metadata.button')" @click="askDeleteAllScreenshotMetadata()">{{
                     t('view.settings.advanced.advanced.delete_all_screenshot_metadata.button')
                 }}</Button>
             </SettingsItem>
@@ -36,7 +38,7 @@
 
         <SettingsGroup :title="t('view.settings.pictures.pictures.auto_delete_old_prints')">
             <SettingsItem :label="t('view.settings.pictures.pictures.auto_delete_prints_from_vrc')">
-                <Switch :model-value="autoDeleteOldPrints" @update:modelValue="setAutoDeleteOldPrints()" />
+                <Switch :model-value="autoDeleteOldPrints" :ariaLabel="t('view.settings.pictures.pictures.auto_delete_prints_from_vrc')" @update:modelValue="setAutoDeleteOldPrints()" />
             </SettingsItem>
         </SettingsGroup>
 
@@ -65,17 +67,17 @@
             </template>
 
             <SettingsItem :label="t('view.settings.advanced.advanced.save_instance_prints_to_file.description')">
-                <Switch :model-value="saveInstancePrints" @update:modelValue="setSaveInstancePrints()" />
+                <Switch :model-value="saveInstancePrints" :ariaLabel="t('view.settings.advanced.advanced.save_instance_prints_to_file.description')" @update:modelValue="setSaveInstancePrints()" />
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.advanced.advanced.save_instance_prints_to_file.crop')">
-                <Switch :model-value="cropInstancePrints" @update:modelValue="setCropInstancePrints()" />
+                <Switch :model-value="cropInstancePrints" :ariaLabel="t('view.settings.advanced.advanced.save_instance_prints_to_file.crop')" @update:modelValue="setCropInstancePrints()" />
             </SettingsItem>
         </SettingsGroup>
 
         <SettingsGroup :title="t('view.settings.advanced.advanced.save_instance_stickers_to_file.header')">
             <SettingsItem :label="t('view.settings.advanced.advanced.save_instance_stickers_to_file.description')">
-                <Switch :model-value="saveInstanceStickers" @update:modelValue="setSaveInstanceStickers()" />
+                <Switch :model-value="saveInstanceStickers" :ariaLabel="t('view.settings.advanced.advanced.save_instance_stickers_to_file.description')" @update:modelValue="setSaveInstanceStickers()" />
             </SettingsItem>
         </SettingsGroup>
 
@@ -85,7 +87,7 @@
             </template>
 
             <SettingsItem :label="t('view.settings.advanced.advanced.save_instance_emoji_to_file.description')">
-                <Switch :model-value="saveInstanceEmoji" @update:modelValue="setSaveInstanceEmoji()" />
+                <Switch :model-value="saveInstanceEmoji" :ariaLabel="t('view.settings.advanced.advanced.save_instance_emoji_to_file.description')" @update:modelValue="setSaveInstanceEmoji()" />
             </SettingsItem>
         </SettingsGroup>
     </div>

--- a/src/views/Settings/components/Tabs/NotificationsTab.vue
+++ b/src/views/Settings/components/Tabs/NotificationsTab.vue
@@ -67,7 +67,7 @@
                 :label="
                     t('view.settings.notifications.notifications.desktop_notifications.desktop_notification_while_afk')
                 ">
-                <Switch :model-value="afkDesktopToast" @update:modelValue="setAfkDesktopToast" />
+                <Switch :model-value="afkDesktopToast" :ariaLabel="t('view.settings.notifications.notifications.desktop_notifications.desktop_notification_while_afk')" @update:modelValue="setAfkDesktopToast" />
             </SettingsItem>
         </SettingsGroup>
 
@@ -120,11 +120,12 @@
                 <Switch
                     :model-value="notificationTTSNickName"
                     :disabled="notificationTTS === 'Never'"
+                    :ariaLabel="t('view.settings.notifications.notifications.text_to_speech.use_memo_nicknames')"
                     @update:modelValue="setNotificationTTSNickName" />
             </SettingsItem>
 
             <SettingsItem :label="t('view.settings.notifications.notifications.text_to_speech.tts_test_placeholder')">
-                <Switch :model-value="isTestTTSVisible" @update:modelValue="isTestTTSVisible = !isTestTTSVisible" />
+                <Switch :model-value="isTestTTSVisible" :ariaLabel="t('view.settings.notifications.notifications.text_to_speech.tts_test_placeholder')" @update:modelValue="isTestTTSVisible = !isTestTTSVisible" />
             </SettingsItem>
 
             <div v-if="isTestTTSVisible" class="flex items-center gap-2 mt-1">

--- a/src/views/Settings/components/Tabs/SocialTab.vue
+++ b/src/views/Settings/components/Tabs/SocialTab.vue
@@ -6,6 +6,7 @@
                 :description="t('view.settings.appearance.user_dialog.recent_action_cooldown_description')">
                 <Switch
                     :model-value="recentActionCooldownEnabled"
+                    :ariaLabel="t('view.settings.appearance.user_dialog.recent_action_cooldown')"
                     @update:modelValue="setRecentActionCooldownEnabled" />
             </SettingsItem>
 

--- a/src/views/Settings/components/Tabs/SystemTab.vue
+++ b/src/views/Settings/components/Tabs/SystemTab.vue
@@ -81,28 +81,28 @@
 
         <SettingsGroup :title="t('view.settings.general.application.header')">
             <SettingsItem v-if="!isLinux" :label="t('view.settings.general.application.startup')">
-                <Switch :model-value="isStartAtWindowsStartup" @update:modelValue="setIsStartAtWindowsStartup" />
+                <Switch :model-value="isStartAtWindowsStartup" :ariaLabel="t('view.settings.general.application.startup')" @update:modelValue="setIsStartAtWindowsStartup" />
             </SettingsItem>
 
             <SettingsItem v-if="!isLinux" :label="t('view.settings.general.application.minimized')">
-                <Switch :model-value="isStartAsMinimizedState" @update:modelValue="setIsStartAsMinimizedState" />
+                <Switch :model-value="isStartAsMinimizedState" :ariaLabel="t('view.settings.general.application.minimized')" @update:modelValue="setIsStartAsMinimizedState" />
             </SettingsItem>
             <SettingsItem
                 v-else
                 :label="t('view.settings.general.application.minimized')"
                 :description="t('view.settings.general.application.startup_linux')">
-                <Switch :model-value="isStartAsMinimizedState" @update:modelValue="setIsStartAsMinimizedState" />
+                <Switch :model-value="isStartAsMinimizedState" :ariaLabel="t('view.settings.general.application.minimized')" @update:modelValue="setIsStartAsMinimizedState" />
             </SettingsItem>
 
             <SettingsItem v-if="!isMacOS" :label="t('view.settings.general.application.tray')">
-                <Switch :model-value="isCloseToTray" @update:modelValue="setIsCloseToTray" />
+                <Switch :model-value="isCloseToTray" :ariaLabel="t('view.settings.general.application.tray')" @update:modelValue="setIsCloseToTray" />
             </SettingsItem>
 
             <SettingsItem
                 v-if="!isLinux"
                 :label="t('view.settings.general.application.disable_gpu_acceleration')"
                 :description="t('view.settings.general.application.disable_gpu_acceleration_tooltip')">
-                <Switch :model-value="disableGpuAcceleration" @update:modelValue="setDisableGpuAcceleration" />
+                <Switch :model-value="disableGpuAcceleration" :ariaLabel="t('view.settings.general.application.disable_gpu_acceleration')" @update:modelValue="setDisableGpuAcceleration" />
             </SettingsItem>
 
             <SettingsItem

--- a/src/views/Settings/components/Tabs/VrTab.vue
+++ b/src/views/Settings/components/Tabs/VrTab.vue
@@ -5,6 +5,7 @@
             <SettingsItem :label="t('view.settings.notifications.notifications.steamvr_notifications.steamvr_overlay')">
                 <Switch
                     :model-value="openVR"
+                    :ariaLabel="t('view.settings.notifications.notifications.steamvr_notifications.steamvr_overlay')"
                     @update:modelValue="
                         setOpenVR();
                         saveOpenVROption();
@@ -15,6 +16,7 @@
                 <Select
                     :model-value="openVRAlways ? 'true' : 'false'"
                     :disabled="!openVR"
+                    :ariaLabel="t('view.settings.wrist_overlay.steamvr_wrist_overlay.start_overlay_with')"
                     @update:modelValue="handleOpenVRAlwaysRadio">
                     <SelectTrigger size="sm">
                         <SelectValue />
@@ -33,6 +35,7 @@
                     ">
                     <Switch
                         :model-value="xsNotifications"
+                        :ariaLabel="t('view.settings.notifications.notifications.steamvr_notifications.xsoverlay_notifications')"
                         @update:modelValue="
                             setXsNotifications();
                             saveOpenVROption();
@@ -44,6 +47,7 @@
                     :label="t('view.settings.notifications.notifications.steamvr_notifications.wayvr_notifications')">
                     <Switch
                         :model-value="xsNotifications"
+                        :ariaLabel="t('view.settings.notifications.notifications.steamvr_notifications.wayvr_notifications')"
                         @update:modelValue="
                             setXsNotifications();
                             saveOpenVROption();
@@ -60,6 +64,7 @@
                     ">
                     <Switch
                         :model-value="ovrtHudNotifications"
+                        :ariaLabel="t('view.settings.notifications.notifications.steamvr_notifications.ovrtoolkit_hud_notifications')"
                         @update:modelValue="
                             setOvrtHudNotifications();
                             saveOpenVROption();
@@ -74,6 +79,7 @@
                     ">
                     <Switch
                         :model-value="ovrtWristNotifications"
+                        :ariaLabel="t('view.settings.notifications.notifications.steamvr_notifications.ovrtoolkit_wrist_notifications')"
                         @update:modelValue="
                             setOvrtWristNotifications();
                             saveOpenVROption();
@@ -122,6 +128,7 @@
                 <Switch
                     :model-value="overlayNotifications"
                     :disabled="!openVR"
+                    :ariaLabel="t('view.settings.notifications.notifications.steamvr_notifications.overlay_notifications')"
                     @update:modelValue="
                         setOverlayNotifications();
                         saveOpenVROption();
@@ -173,6 +180,7 @@
                 ">
                 <Switch
                     :model-value="imageNotifications"
+                    :ariaLabel="t('view.settings.notifications.notifications.steamvr_notifications.user_images')"
                     @update:modelValue="
                         setImageNotifications();
                         saveOpenVROption();
@@ -191,6 +199,7 @@
                 <Switch
                     :model-value="progressPie"
                     :disabled="!openVR"
+                    :ariaLabel="t('view.settings.advanced.advanced.video_progress_pie.header')"
                     @update:modelValue="changeYouTubeApi('VRCX_progressPie')" />
             </SettingsItem>
 
@@ -198,6 +207,7 @@
                 <Switch
                     :model-value="progressPieFilter"
                     :disabled="!openVR"
+                    :ariaLabel="t('view.settings.advanced.advanced.video_progress_pie.dance_world_only')"
                     @update:modelValue="changeYouTubeApi('VRCX_progressPieFilter')" />
             </SettingsItem>
         </SettingsGroup>

--- a/src/views/Settings/components/WristOverlaySettings.vue
+++ b/src/views/Settings/components/WristOverlaySettings.vue
@@ -12,6 +12,7 @@
                     size="sm"
                     variant="outline"
                     :disabled="!openVR || !overlayWrist"
+                    :ariaLabel="t('view.settings.wrist_overlay.steamvr_wrist_overlay.wrist_feed_filters')"
                     @click="emit('open-feed-filters')"
                     >{{ t('view.settings.wrist_overlay.steamvr_wrist_overlay.wrist_feed_filters') }}</Button
                 >
@@ -21,6 +22,7 @@
                 <Switch
                     :model-value="overlayWrist"
                     :disabled="!openVR"
+                    :ariaLabel="t('view.settings.wrist_overlay.steamvr_wrist_overlay.wrist_feed_overlay')"
                     @update:modelValue="
                         setOverlayWrist();
                         saveOpenVROption();
@@ -30,6 +32,7 @@
             <SettingsItem :label="t('view.settings.wrist_overlay.steamvr_wrist_overlay.hide_private_worlds')">
                 <Switch
                     :model-value="hidePrivateFromFeed"
+                    :ariaLabel="t('view.settings.wrist_overlay.steamvr_wrist_overlay.hide_private_worlds')"
                     @update:modelValue="
                         setHidePrivateFromFeed();
                         saveOpenVROption();
@@ -83,6 +86,7 @@
                 <Switch
                     :model-value="vrBackgroundEnabled"
                     :disabled="!openVR || !overlayWrist"
+                    :ariaLabel="t('view.settings.wrist_overlay.steamvr_wrist_overlay.grey_background')"
                     @update:modelValue="
                         setVrBackgroundEnabled();
                         saveOpenVROption();
@@ -93,6 +97,7 @@
                 <Switch
                     :model-value="minimalFeed"
                     :disabled="!openVR || !overlayWrist"
+                    :ariaLabel="t('view.settings.wrist_overlay.steamvr_wrist_overlay.minimal_feed_icons')"
                     @update:modelValue="
                         setMinimalFeed();
                         saveOpenVROption();
@@ -103,6 +108,7 @@
                 <Switch
                     :model-value="!hideDevicesFromFeed"
                     :disabled="!openVR || !overlayWrist"
+                    :ariaLabel="t('view.settings.wrist_overlay.steamvr_wrist_overlay.show_vr_devices')"
                     @update:modelValue="
                         setHideDevicesFromFeed();
                         saveOpenVROption();
@@ -113,6 +119,7 @@
                 <Switch
                     :model-value="vrOverlayCpuUsage"
                     :disabled="!openVR || !overlayWrist"
+                    :ariaLabel="t('view.settings.wrist_overlay.steamvr_wrist_overlay.show_cpu_usage')"
                     @update:modelValue="
                         setVrOverlayCpuUsage();
                         saveOpenVROption();
@@ -123,6 +130,7 @@
                 <Switch
                     :model-value="!hideUptimeFromFeed"
                     :disabled="!openVR || !overlayWrist"
+                    :ariaLabel="t('view.settings.wrist_overlay.steamvr_wrist_overlay.show_game_uptime')"
                     @update:modelValue="
                         setHideUptimeFromFeed();
                         saveOpenVROption();
@@ -133,6 +141,7 @@
                 <Switch
                     :model-value="pcUptimeOnFeed"
                     :disabled="!openVR || !overlayWrist"
+                    :ariaLabel="t('view.settings.wrist_overlay.steamvr_wrist_overlay.show_pc_uptime')"
                     @update:modelValue="
                         setPcUptimeOnFeed();
                         saveOpenVROption();

--- a/src/views/Settings/dialogs/VRChatConfigDialog.vue
+++ b/src/views/Settings/dialogs/VRChatConfigDialog.vue
@@ -21,6 +21,7 @@
                         variant="outline"
                         size="icon-sm"
                         :disabled="VRChatCacheSizeLoading"
+                        :ariaLabel="t('dialog.config_json.refresh')"
                         @click="getVRChatCacheSize">
                         <Spinner v-if="VRChatCacheSizeLoading" />
                         <RefreshCw v-else />

--- a/src/views/Sidebar/Sidebar.vue
+++ b/src/views/Sidebar/Sidebar.vue
@@ -21,6 +21,7 @@
                         variant="ghost"
                         size="icon-sm"
                         :disabled="isRefreshFriendsLoading"
+                        :ariaLabel="t('side_panel.refresh_tooltip')"
                         @click="runRefreshFriendsListFlow">
                         <Spinner v-if="isRefreshFriendsLoading" />
                         <RefreshCw v-else />
@@ -34,6 +35,7 @@
                                     class="rounded-full relative"
                                     variant="ghost"
                                     size="icon-sm"
+                                    :ariaLabel="t('side_panel.notification_center.title')"
                                     @click="isNotificationCenterOpen = !isNotificationCenterOpen">
                                     <Bell />
                                     <span class="absolute top-1 right-1.25 size-1.5 rounded-full bg-red-500" />
@@ -51,6 +53,7 @@
                             class="rounded-full relative"
                             variant="ghost"
                             size="icon-sm"
+                            :ariaLabel="t('side_panel.notification_center.title')"
                             @click="isNotificationCenterOpen = !isNotificationCenterOpen"
                             @contextmenu.prevent="
                                 toast.info(t('side_panel.notification_center.no_unseen_notifications'))
@@ -61,7 +64,7 @@
                 </template>
                 <Popover v-model:open="isSettingsPopoverOpen">
                     <PopoverTrigger as-child>
-                        <Button class="rounded-full" variant="ghost" size="icon-sm">
+                        <Button class="rounded-full" variant="ghost" size="icon-sm" :ariaLabel="t('nav_tooltip.settings')">
                             <Settings />
                         </Button>
                     </PopoverTrigger>
@@ -75,24 +78,28 @@
                                 <FieldLabel>{{ t('side_panel.settings.group_by_instance') }}</FieldLabel>
                                 <Switch
                                     :model-value="isSidebarGroupByInstance"
+                                    :ariaLabel="t('side_panel.settings.group_by_instance')"
                                     @update:modelValue="setIsSidebarGroupByInstance" />
                             </Field>
                             <Field v-if="isSidebarGroupByInstance" orientation="horizontal">
                                 <FieldLabel>{{ t('side_panel.settings.hide_friends_in_same_instance') }}</FieldLabel>
                                 <Switch
                                     :model-value="isHideFriendsInSameInstance"
+                                    :ariaLabel="t('side_panel.settings.hide_friends_in_same_instance')"
                                     @update:modelValue="setIsHideFriendsInSameInstance" />
                             </Field>
                             <Field v-if="isSidebarGroupByInstance" orientation="horizontal">
                                 <FieldLabel>{{ t('side_panel.settings.same_instance_above_favorites') }}</FieldLabel>
                                 <Switch
                                     :model-value="isSameInstanceAboveFavorites"
+                                    :ariaLabel="t('side_panel.settings.same_instance_above_favorites')"
                                     @update:modelValue="setIsSameInstanceAboveFavorites" />
                             </Field>
                             <Field orientation="horizontal">
                                 <FieldLabel>{{ t('side_panel.settings.split_favorite_friends') }}</FieldLabel>
                                 <Switch
                                     :model-value="isSidebarDivideByFriendGroup"
+                                    :ariaLabel="t('side_panel.settings.split_favorite_friends')"
                                     @update:modelValue="setIsSidebarDivideByFriendGroup" />
                             </Field>
 

--- a/src/views/Sidebar/components/FriendItem.vue
+++ b/src/views/Sidebar/components/FriendItem.vue
@@ -55,7 +55,12 @@
         </template>
         <template v-else-if="!friend.ref && !isRefreshFriendsLoading">
             <span>{{ friend.name || friend.id }}</span>
-            <Button size="sm" variant="ghost" class="mr-1 w-6 h-6 text-xs" @click.stop="confirmDeleteFriend(friend.id)"
+            <Button
+                size="sm"
+                variant="ghost"
+                class="mr-1 w-6 h-6 text-xs"
+                :ariaLabel="t('common.actions.delete')"
+                @click.stop="confirmDeleteFriend(friend.id)"
                 ><Trash2 class="h-4 w-4" />
             </Button>
         </template>
@@ -106,3 +111,4 @@
     const locationProp = computed(() => props.friend.ref?.location || '');
     const travelingProp = computed(() => props.friend.ref?.travelingToLocation || '');
 </script>
+

--- a/src/views/Sidebar/components/NotificationItem.vue
+++ b/src/views/Sidebar/components/NotificationItem.vue
@@ -61,7 +61,8 @@
                                 <button
                                     type="button"
                                     class="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted cursor-pointer"
-                                    @click.stop="notificationStore.acceptFriendRequestNotification(notification)">
+                                    @click.stop="notificationStore.acceptFriendRequestNotification(notification)" 
+                                    :ariaLabel="t('view.notification.actions.accept')">
                                     <Check class="size-3" />
                                 </button>
                             </TooltipWrapper>
@@ -73,7 +74,8 @@
                                 <button
                                     type="button"
                                     class="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted cursor-pointer"
-                                    @click.stop="$emit('show-invite-response', notification)">
+                                    @click.stop="$emit('show-invite-response', notification)"
+                                    :ariaLabel="t('view.notification.actions.decline_with_message')">
                                     <MessageCircle class="size-3" />
                                 </button>
                             </TooltipWrapper>
@@ -86,7 +88,8 @@
                                     <button
                                         type="button"
                                         class="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted cursor-pointer"
-                                        @click.stop="notificationStore.acceptRequestInvite(notification)">
+                                        @click.stop="notificationStore.acceptRequestInvite(notification)"
+                                        :ariaLabel="t('view.notification.actions.invite')">
                                         <Check class="size-3" />
                                     </button>
                                 </TooltipWrapper>
@@ -96,7 +99,8 @@
                                     <button
                                         type="button"
                                         class="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted cursor-pointer"
-                                        @click.stop="$emit('show-invite-request-response', notification)">
+                                        @click.stop="$emit('show-invite-request-response', notification)"
+                                        :ariaLabel="t('view.notification.actions.decline_with_message')">
                                         <MessageCircle class="size-3" />
                                     </button>
                                 </TooltipWrapper>
@@ -124,7 +128,8 @@
                                 <button
                                     type="button"
                                     class="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:text-destructive hover:bg-muted cursor-pointer"
-                                    @click.stop="notificationStore.hideNotificationPrompt(notification)">
+                                    @click.stop="notificationStore.hideNotificationPrompt(notification)"
+                                    :ariaLabel="t('view.notification.actions.decline')">
                                     <X class="size-3" />
                                 </button>
                             </TooltipWrapper>
@@ -137,7 +142,8 @@
                             <button
                                 type="button"
                                 class="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:text-destructive hover:bg-muted cursor-pointer"
-                                @click.stop="notificationStore.deleteNotificationLogPrompt(notification)">
+                                @click.stop="notificationStore.deleteNotificationLogPrompt(notification)"
+                                :ariaLabel="t('view.notification.actions.delete_log')">
                                 <Trash2 class="size-3" />
                             </button>
                         </TooltipWrapper>

--- a/src/views/Sidebar/components/NotificationItem.vue
+++ b/src/views/Sidebar/components/NotificationItem.vue
@@ -61,7 +61,7 @@
                                 <button
                                     type="button"
                                     class="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted cursor-pointer"
-                                    @click.stop="notificationStore.acceptFriendRequestNotification(notification)" 
+                                    @click.stop="notificationStore.acceptFriendRequestNotification(notification)"
                                     :ariaLabel="t('view.notification.actions.accept')">
                                     <Check class="size-3" />
                                 </button>
@@ -115,6 +115,7 @@
                                     <button
                                         type="button"
                                         class="inline-flex size-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted cursor-pointer"
+                                        :ariaLabel="response.text"
                                         @click.stop="handleResponse(response)">
                                         <component :is="getResponseIcon(response)" class="size-3" />
                                     </button>
@@ -497,3 +498,4 @@
         notificationStore.queueMarkAsSeen(props.notification.id, version);
     });
 </script>
+

--- a/src/views/Tools/Tools.vue
+++ b/src/views/Tools/Tools.vue
@@ -34,7 +34,7 @@
                                         variant="secondary"
                                         class="opacity-0 transition-opacity group-hover:opacity-100"
                                         :title="t('nav_menu.custom_nav.unpin_from_nav')"
-                                        :aria-label="t('nav_menu.custom_nav.unpin_from_nav')"
+                                        :ariaLabel="t('nav_menu.custom_nav.unpin_from_nav')"
                                         @click.stop="unpinToolFromNav(tool.key)">
                                         <span class="relative inline-flex size-4">
                                             <i
@@ -57,7 +57,7 @@
                                         variant="ghost"
                                         class="opacity-0 transition-opacity group-hover:opacity-100"
                                         :title="t('nav_menu.custom_nav.pin_to_nav')"
-                                        :aria-label="t('nav_menu.custom_nav.pin_to_nav')"
+                                        :ariaLabel="t('nav_menu.custom_nav.pin_to_nav')"
                                         @click.stop="pinToolToNav(tool.key)">
                                         <span class="relative inline-flex size-4">
                                             <i


### PR DESCRIPTION
This makes the app more usable for screen readers, using aria-labels on buttons that don't have labels. Tested with orca and NVDA.