### PR TITLE
Fix: show Add  Add Favorite button not shown for non-friend usersFavorite button for non-friend users

### DIFF
--- a/src/components/dialogs/UserDialog/UserActionDropdown.vue
+++ b/src/components/dialogs/UserDialog/UserActionDropdown.vue
@@ -1,6 +1,6 @@
 <template>
     <div style="flex: none" class="flex items-center">
-        <template v-if="(currentUser.id !== userDialog.ref.id && userDialog.isFriend) || userDialog.isFavorite">
+        <template v-if="currentUser.id !== userDialog.ref.id">
             <TooltipWrapper
                 v-if="userDialog.isFavorite"
                 side="top"

--- a/src/components/dialogs/UserDialog/__tests__/UserActionDropdown.test.js
+++ b/src/components/dialogs/UserDialog/__tests__/UserActionDropdown.test.js
@@ -90,4 +90,24 @@ describe('UserActionDropdown.vue', () => {
 
         expect(userDialogCommand).toHaveBeenCalled();
     });
+
+    it('shows the favorite star button for a non-friend, non-favorite user', () => {
+        // mocked userDialog is isFriend: false, isFavorite: false, ref.id !== currentUser.id
+        const wrapper = mount(UserActionDropdown, {
+            props: { userDialogCommand: vi.fn() }
+        });
+
+        expect(wrapper.find('[data-testid="btn"]').exists()).toBe(true);
+    });
+
+    it('sends the Add Favorite command when the star button is clicked', async () => {
+        const userDialogCommand = vi.fn();
+        const wrapper = mount(UserActionDropdown, {
+            props: { userDialogCommand }
+        });
+
+        await wrapper.find('[data-testid="btn"]').trigger('click');
+
+        expect(userDialogCommand).toHaveBeenCalledWith('Add Favorite');
+    });
 });


### PR DESCRIPTION
The favorite star button in the user profile action dropdown
(UserActionDropdown.vue) only rendered when the target was already a
friend or already a local favorite:

    v-if="(currentUser.id !== userDialog.ref.id && userDialog.isFriend) || userDialog.isFavorite"

This meant there was no way to add a non-friend to a local favorite
group from the UI, even though the underlying favorite dialog and the
local-favorites store never required friendship in the first place —
local favorites are meant to work for non-friends (e.g. tracking
join/leave notifications for someone you're not friends with).

Fix: the button now only excludes the current user themself.

    v-if="currentUser.id !== userDialog.ref.id"

Added two tests confirming the button renders for a non-friend/
non-favorite user and that clicking it still sends the Add Favorite
command correctly.