### PR TITLE
Enable "Open in Game" on Linux

### DIFF
--- a/Dotnet/AppApi/Common/AppApiCommon.cs
+++ b/Dotnet/AppApi/Common/AppApiCommon.cs
@@ -169,7 +169,7 @@ namespace VRCX
             return null;
         }
 
-        public Task<bool> TryOpenInstanceInVrc(string launchUrl)
+        public virtual Task<bool> TryOpenInstanceInVrc(string launchUrl)
         {
             return VRCIPC.Send(launchUrl);
         }

--- a/Dotnet/AppApi/Electron/Folders.cs
+++ b/Dotnet/AppApi/Electron/Folders.cs
@@ -20,6 +20,7 @@ namespace VRCX
         public static string _vrcPrefixPath;
         public static string _vrcAppDataPath;
         public static string _vrcCrashesPath;
+        public static string _vrcInstallPath;
 
         static AppApiElectron()
         {
@@ -56,6 +57,7 @@ namespace VRCX
             }
             logger.Info($"Using steam library path {vrcLibraryPath}");
             _vrcPrefixPath = Path.Join(vrcLibraryPath, $"steamapps/compatdata/{vrchatAppid}/pfx");
+            _vrcInstallPath = Path.Join(vrcLibraryPath, "steamapps/common/VRChat");
             _vrcAppDataPath = Path.Join(_vrcPrefixPath, "drive_c/users/steamuser/AppData/LocalLow/VRChat/VRChat");
             _vrcCrashesPath = Path.Join(_vrcPrefixPath, "drive_c/users/steamuser/AppData/Local/Temp/VRChat/VRChat/Crashes");
         }

--- a/Dotnet/AppApi/Electron/GameHandler.cs
+++ b/Dotnet/AppApi/Electron/GameHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace VRCX
 {
@@ -116,6 +117,87 @@ namespace VRCX
         {
             // This method is not used
             return false;
+        }
+
+        public override Task<bool> TryOpenInstanceInVrc(string launchUrl)
+        {
+            try
+            {
+                var pid = FindVRChatPid();
+                if (pid <= 0)
+                    return Task.FromResult(false);
+
+                var launchExe = Path.Join(_vrcInstallPath, "launch.exe");
+                if (!File.Exists(launchExe))
+                {
+                    logger.Error($"TryOpenInstanceInVrc: launch.exe not found at {launchExe}");
+                    return Task.FromResult(false);
+                }
+
+                // attach=1 tells launch.exe to forward into the running client instead of cold-starting
+                var url = launchUrl.Contains("attach=1") ? launchUrl : launchUrl + "&attach=1";
+
+                // enter the running game's user + mount namespaces (we own the pressure-vessel
+                // userns, so no privilege is required), re-import its environment, then run
+                // launch.exe inside the container so it reaches VRChat's URL pipe
+                const string inner =
+                    "while IFS= read -r -d '' kv; do export \"$kv\"; done < \"/proc/$1/environ\"; exec wine \"$2\" \"$3\"";
+
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "nsenter",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+                foreach (var arg in new[]
+                         {
+                             "-t", pid.ToString(), "-U", "-m", "--preserve-credentials", "--",
+                             "/bin/bash", "-c", inner, "_", pid.ToString(), launchExe, url
+                         })
+                    psi.ArgumentList.Add(arg);
+
+                // launch.exe hands the deeplink to the running client, then exits on wine's
+                // own schedule and its exit code is not a reliable success signal, so a clean
+                // spawn is treated as success. Gating on the exit code would race the frontend
+                // self-invite fallback and fire both. stdout/stderr are left un-redirected so
+                // wine log spam cannot fill an undrained pipe and stall the forward.
+                using var process = Process.Start(psi);
+                return Task.FromResult(process != null);
+            }
+            catch (Exception e)
+            {
+                logger.Error($"TryOpenInstanceInVrc failed: {e.Message}");
+                return Task.FromResult(false);
+            }
+        }
+
+        private static int FindVRChatPid()
+        {
+            var processes = Process.GetProcessesByName("VRChat.exe");
+            try
+            {
+                // prefer the VRChat whose environment points at the 438100 compat prefix
+                foreach (var process in processes)
+                {
+                    try
+                    {
+                        var environ = File.ReadAllText($"/proc/{process.Id}/environ");
+                        if (environ.Contains("compatdata/438100"))
+                            return process.Id;
+                    }
+                    catch
+                    {
+                        // unreadable environ, skip
+                    }
+                }
+
+                return processes.Length > 0 ? processes[0].Id : -1;
+            }
+            finally
+            {
+                foreach (var process in processes)
+                    process.Dispose();
+            }
         }
     }
 }

--- a/src/stores/invite.js
+++ b/src/stores/invite.js
@@ -51,7 +51,6 @@ export const useInviteStore = defineStore('Invite', () => {
 
     const canOpenInstanceInGame = computed(() => {
         return (
-            !LINUX &&
             gameStore.isGameRunning &&
             !advancedSettingsStore.selfInviteOverride
         );


### PR DESCRIPTION
Currently on Linux the "Open in Game" functionality is disabled. This PR steps into the running game's namespaces (nsenter) and hands the deeplink straight to it with `wine launch.exe ...&attach=1`, making the open in game button it work the way it does on Windows

If proton isn't being used, no nsenter, or the game isn't running, it quietly falls back to the self-invite like before. The "Self Invite Action" setting can also be used to opt-out like on Windows