### PR TITLE
Fix group reordering when the saved order is incomplete

### DIFF
--- a/src/components/dialogs/UserDialog/UserDialogGroupsTab.vue
+++ b/src/components/dialogs/UserDialog/UserDialogGroupsTab.vue
@@ -375,6 +375,7 @@
     import { groupRequest } from '../../../api';
     import { useOptionKeySelect } from '../../../composables/useOptionKeySelect';
     import { userDialogGroupSortingOptions } from '../../../shared/constants';
+    import { moveGroupInOrder, normalizeGroupOrder } from './groupOrderUtils';
 
     const { t } = useI18n();
 
@@ -547,6 +548,10 @@
     async function editModeCurrentUserGroups() {
         await updateInGameGroupOrder();
         userDialogGroupEditGroups.value = Array.from(currentUserGroups.value.values());
+        inGameGroupOrder.value = normalizeGroupOrder(
+            inGameGroupOrder.value,
+            userDialogGroupEditGroups.value.map((group) => group.id)
+        );
         userDialogGroupEditGroups.value.sort(sortGroupsByInGame);
         userDialogGroupEditMode.value = true;
     }
@@ -648,9 +653,7 @@
      */
     function moveGroupUp(groupId) {
         const index = inGameGroupOrder.value.indexOf(groupId);
-        if (index > 0) {
-            inGameGroupOrder.value.splice(index, 1);
-            inGameGroupOrder.value.splice(index - 1, 0, groupId);
+        if (moveGroupInOrder(inGameGroupOrder.value, groupId, index - 1)) {
             saveInGameGroupOrder();
         }
     }
@@ -661,9 +664,7 @@
      */
     function moveGroupDown(groupId) {
         const index = inGameGroupOrder.value.indexOf(groupId);
-        if (index < inGameGroupOrder.value.length - 1) {
-            inGameGroupOrder.value.splice(index, 1);
-            inGameGroupOrder.value.splice(index + 1, 0, groupId);
+        if (moveGroupInOrder(inGameGroupOrder.value, groupId, index + 1)) {
             saveInGameGroupOrder();
         }
     }
@@ -673,10 +674,7 @@
      * @param groupId
      */
     function moveGroupTop(groupId) {
-        const index = inGameGroupOrder.value.indexOf(groupId);
-        if (index > 0) {
-            inGameGroupOrder.value.splice(index, 1);
-            inGameGroupOrder.value.unshift(groupId);
+        if (moveGroupInOrder(inGameGroupOrder.value, groupId, 0)) {
             saveInGameGroupOrder();
         }
     }
@@ -686,10 +684,7 @@
      * @param groupId
      */
     function moveGroupBottom(groupId) {
-        const index = inGameGroupOrder.value.indexOf(groupId);
-        if (index < inGameGroupOrder.value.length - 1) {
-            inGameGroupOrder.value.splice(index, 1);
-            inGameGroupOrder.value.push(groupId);
+        if (moveGroupInOrder(inGameGroupOrder.value, groupId, inGameGroupOrder.value.length - 1)) {
             saveInGameGroupOrder();
         }
     }

--- a/src/components/dialogs/UserDialog/__tests__/groupOrderUtils.test.js
+++ b/src/components/dialogs/UserDialog/__tests__/groupOrderUtils.test.js
@@ -1,0 +1,54 @@
+import { moveGroupInOrder, normalizeGroupOrder } from '../groupOrderUtils';
+
+describe('groupOrderUtils', () => {
+    describe('normalizeGroupOrder', () => {
+        test('appends groups missing from the saved registry order', () => {
+            expect(
+                normalizeGroupOrder(
+                    ['group-b'],
+                    ['group-a', 'group-b', 'group-c']
+                )
+            ).toEqual(['group-b', 'group-a', 'group-c']);
+        });
+
+        test('removes stale and duplicate group IDs', () => {
+            expect(
+                normalizeGroupOrder(
+                    ['stale', 'group-b', 'group-b', 'group-a'],
+                    ['group-a', 'group-b']
+                )
+            ).toEqual(['group-b', 'group-a']);
+        });
+    });
+
+    describe('moveGroupInOrder', () => {
+        test('preserves every group when moving one missing from the saved order', () => {
+            const order = normalizeGroupOrder(
+                ['group-a', 'group-b'],
+                ['group-a', 'group-b', 'group-new', 'group-c']
+            );
+
+            expect(moveGroupInOrder(order, 'group-new', 3)).toBe(true);
+            expect(order).toEqual([
+                'group-a',
+                'group-b',
+                'group-c',
+                'group-new'
+            ]);
+        });
+
+        test('moves a known group to the requested index', () => {
+            const order = ['group-a', 'group-b', 'group-c'];
+
+            expect(moveGroupInOrder(order, 'group-c', 0)).toBe(true);
+            expect(order).toEqual(['group-c', 'group-a', 'group-b']);
+        });
+
+        test('does not corrupt the order when the group ID is missing', () => {
+            const order = ['group-a', 'group-b'];
+
+            expect(moveGroupInOrder(order, 'group-new', 0)).toBe(false);
+            expect(order).toEqual(['group-a', 'group-b']);
+        });
+    });
+});

--- a/src/components/dialogs/UserDialog/groupOrderUtils.js
+++ b/src/components/dialogs/UserDialog/groupOrderUtils.js
@@ -1,0 +1,51 @@
+import { moveArrayItem } from '../../../shared/utils/base/array';
+
+/**
+ * Keep valid saved group IDs in their existing order, then append groups that
+ * are not present in the saved VRChat registry value.
+ *
+ * @param {Array<string>} order
+ * @param {Array<string>} groupIds
+ * @returns {Array<string>}
+ */
+export function normalizeGroupOrder(order, groupIds) {
+    const validGroupIds = new Set(groupIds);
+    const seen = new Set();
+    const normalized = [];
+
+    for (const groupId of order) {
+        if (validGroupIds.has(groupId) && !seen.has(groupId)) {
+            normalized.push(groupId);
+            seen.add(groupId);
+        }
+    }
+    for (const groupId of groupIds) {
+        if (!seen.has(groupId)) {
+            normalized.push(groupId);
+            seen.add(groupId);
+        }
+    }
+
+    return normalized;
+}
+
+/**
+ * @param {Array<string>} order
+ * @param {string} groupId
+ * @param {number} toIndex
+ * @returns {boolean}
+ */
+export function moveGroupInOrder(order, groupId, toIndex) {
+    const fromIndex = order.indexOf(groupId);
+    if (
+        fromIndex === -1 ||
+        toIndex < 0 ||
+        toIndex >= order.length ||
+        fromIndex === toIndex
+    ) {
+        return false;
+    }
+
+    moveArrayItem(order, fromIndex, toIndex);
+    return true;
+}


### PR DESCRIPTION
## What changed

- Normalize the saved in-game group order against the current group list before entering edit mode.
- Preserve valid saved ordering while removing stale or duplicate entries and appending missing groups.
- Validate group IDs and target indices before moving an item.
- Add regression tests for incomplete, stale, duplicate, and missing group IDs.

## Why

The `VRC_GROUP_ORDER_<userId>` registry value can be incomplete, for example after joining a group while VRChat is closed.

The group still appears in VRCX, but its index in the saved order is `-1`. With the previous logic:

- Move up and move to top did nothing.
- Move down and move to bottom treated `-1` as a valid splice index.
- The last saved group entry could be removed, and the selected group could unexpectedly move to the top.
- The corrupted order was then written back to the registry.

This change normalizes the order before editing and only persists a move when both the source and destination are valid.

This PR does not change the group layout or visual components.

## Reproduction

1. Start VRChat once so the existing group order is saved.
2. Close VRChat.
3. Join a new group through VRCX or the VRChat website.
4. Open your own profile in VRCX and enter group edit mode.
5. Try moving the newly joined group up, down, to the top, or to the bottom.

> Note: The recording below was captured on the latest `master`, which uses the redesigned profile UI. The same behavior was also reproduced in the `2026.07.18` release build with the previous profile layout, confirming that the issue is in the group ordering logic rather than the UI redesign.

### Before


https://github.com/user-attachments/assets/80267353-a90e-4457-b43a-444944d24f1c



### After


https://github.com/user-attachments/assets/71e299cf-7020-481b-8e62-994aa866119d



## Testing

- Reproduced on the latest `master`.
- Verified moving up, down, to the top, and to the bottom with an incomplete saved order.
- 26 targeted unit tests passed.
- ESLint, Oxlint, and formatting checks passed.
- Windows and Linux production builds passed.