### PR TITLE
feat: popular groups among friends (#1739)

### DIFF
--- a/src/components/nav-menu/navLayoutDefaults.js
+++ b/src/components/nav-menu/navLayoutDefaults.js
@@ -21,7 +21,7 @@ export function createBaseDefaultNavLayout(t) {
             nameKey: 'nav_tooltip.social',
             name: t('nav_tooltip.social'),
             icon: 'ri-group-line',
-            items: ['friend-log', 'friend-list', 'moderation']
+            items: ['friend-log', 'friend-list', 'groups', 'moderation']
         },
         { type: 'item', key: 'notification' },
         { type: 'item', key: 'my-avatars' },
@@ -31,12 +31,7 @@ export function createBaseDefaultNavLayout(t) {
             nameKey: 'nav_tooltip.charts',
             name: t('nav_tooltip.charts'),
             icon: 'ri-pie-chart-line',
-            items: [
-                'charts-instance',
-                'charts-mutual',
-                'charts-hot-worlds',
-                'groups'
-            ]
+            items: ['charts-instance', 'charts-mutual', 'charts-hot-worlds']
         },
         { type: 'item', key: 'tools' },
         { type: 'item', key: 'direct-access' }

--- a/src/components/nav-menu/navLayoutDefaults.js
+++ b/src/components/nav-menu/navLayoutDefaults.js
@@ -21,7 +21,7 @@ export function createBaseDefaultNavLayout(t) {
             nameKey: 'nav_tooltip.social',
             name: t('nav_tooltip.social'),
             icon: 'ri-group-line',
-            items: ['friend-log', 'friend-list', 'groups', 'moderation']
+            items: ['friend-log', 'friend-list', 'moderation']
         },
         { type: 'item', key: 'notification' },
         { type: 'item', key: 'my-avatars' },
@@ -31,7 +31,12 @@ export function createBaseDefaultNavLayout(t) {
             nameKey: 'nav_tooltip.charts',
             name: t('nav_tooltip.charts'),
             icon: 'ri-pie-chart-line',
-            items: ['charts-instance', 'charts-mutual', 'charts-hot-worlds']
+            items: [
+                'charts-instance',
+                'charts-mutual',
+                'charts-hot-worlds',
+                'groups'
+            ]
         },
         { type: 'item', key: 'tools' },
         { type: 'item', key: 'direct-access' }

--- a/src/components/nav-menu/navLayoutDefaults.js
+++ b/src/components/nav-menu/navLayoutDefaults.js
@@ -21,7 +21,7 @@ export function createBaseDefaultNavLayout(t) {
             nameKey: 'nav_tooltip.social',
             name: t('nav_tooltip.social'),
             icon: 'ri-group-line',
-            items: ['friend-log', 'friend-list', 'moderation']
+            items: ['friend-log', 'friend-list', 'groups', 'moderation']
         },
         { type: 'item', key: 'notification' },
         { type: 'item', key: 'my-avatars' },

--- a/src/coordinators/friendGroupsCoordinator.js
+++ b/src/coordinators/friendGroupsCoordinator.js
@@ -93,25 +93,41 @@ async function runSync(force) {
                 });
                 const entries = [];
                 for (const member of json || []) {
-                    const group = member?.group;
-                    if (!group || !group.id) {
+                    if (!member || !member.groupId) {
                         continue;
                     }
-                    // 需求只统计好友加入的 Public 群组
-                    if (group.privacy !== 'public') {
-                        continue;
-                    }
+                    // API 只返回对请求者可见的群组，不再额外按 privacy 过滤
                     entries.push({
-                        groupId: group.id,
-                        joinedAt: member.joinedAt,
-                        membershipStatus: member.membershipStatus,
-                        visibility: member.visibility
+                        groupId: member.groupId,
+                        joinedAt: member.joinedAt || '',
+                        membershipStatus: member.membershipStatus || 'member',
+                        visibility: member.visibility || member.memberVisibility || ''
                     });
-                    if (!groupIdsSeen.has(group.id)) {
-                        groupIdsSeen.add(group.id);
-                        groupsToCache.push(group);
+                    if (!groupIdsSeen.has(member.groupId)) {
+                        groupIdsSeen.add(member.groupId);
+                        groupsToCache.push({
+                            id: member.groupId,
+                            name: member.name,
+                            shortCode: member.shortCode,
+                            discriminator: member.discriminator,
+                            description: member.description,
+                            iconUrl: member.iconUrl,
+                            bannerUrl: member.bannerUrl,
+                            privacy: member.privacy,
+                            memberCount: member.memberCount
+                        });
                     }
-                    applyGroup(group);
+                    applyGroup({
+                        id: member.groupId,
+                        name: member.name,
+                        shortCode: member.shortCode,
+                        discriminator: member.discriminator,
+                        description: member.description,
+                        iconUrl: member.iconUrl,
+                        bannerUrl: member.bannerUrl,
+                        privacy: member.privacy,
+                        memberCount: member.memberCount
+                    });
                 }
                 await database.replaceFriendGroups(friendId, entries);
                 consecutiveFailures = 0;
@@ -128,24 +144,41 @@ async function runSync(force) {
                         });
                         const entries = [];
                         for (const member of json || []) {
-                            const group = member?.group;
-                            if (!group || !group.id) {
+                            if (!member || !member.groupId) {
                                 continue;
                             }
-                            if (group.privacy !== 'public') {
-                                continue;
-                            }
+                            // API 只返回对请求者可见的群组，不再额外按 privacy 过滤
                             entries.push({
-                                groupId: group.id,
-                                joinedAt: member.joinedAt,
-                                membershipStatus: member.membershipStatus,
-                                visibility: member.visibility
+                                groupId: member.groupId,
+                                joinedAt: member.joinedAt || '',
+                                membershipStatus: member.membershipStatus || 'member',
+                                visibility: member.visibility || member.memberVisibility || ''
                             });
-                            if (!groupIdsSeen.has(group.id)) {
-                                groupIdsSeen.add(group.id);
-                                groupsToCache.push(group);
+                            if (!groupIdsSeen.has(member.groupId)) {
+                                groupIdsSeen.add(member.groupId);
+                                groupsToCache.push({
+                                    id: member.groupId,
+                                    name: member.name,
+                                    shortCode: member.shortCode,
+                                    discriminator: member.discriminator,
+                                    description: member.description,
+                                    iconUrl: member.iconUrl,
+                                    bannerUrl: member.bannerUrl,
+                                    privacy: member.privacy,
+                                    memberCount: member.memberCount
+                                });
                             }
-                            applyGroup(group);
+                            applyGroup({
+                                id: member.groupId,
+                                name: member.name,
+                                shortCode: member.shortCode,
+                                discriminator: member.discriminator,
+                                description: member.description,
+                                iconUrl: member.iconUrl,
+                                bannerUrl: member.bannerUrl,
+                                privacy: member.privacy,
+                                memberCount: member.memberCount
+                            });
                         }
                         await database.replaceFriendGroups(friendId, entries);
                         consecutiveFailures = 0;

--- a/src/coordinators/friendGroupsCoordinator.js
+++ b/src/coordinators/friendGroupsCoordinator.js
@@ -7,8 +7,18 @@ import { applyGroup } from './groupCoordinator';
 /** 好友群组数据的新鲜度窗口（TTL），超过则增量刷新 */
 const FRIEND_GROUPS_TTL_MS = 24 * 60 * 60 * 1000;
 
-/** 请求间隔：VRChat API 限流约 30 req/min，留余量按 ~27/min 串行 */
-const REQUEST_INTERVAL_MS = 2100;
+/** 请求间隔（自适应）：初始约 37/min，无 429 时逐步提速 */
+const BASE_INTERVAL_MS = 1600;
+
+/** 提速下限（约 46/min），高于此不再加速 */
+const MIN_INTERVAL_MS = 1300;
+
+/** 连续成功 N 次后缩短一步间隔 */
+const ADAPT_STEP_MS = 100;
+const ADAPT_EVERY_SUCCESS = 30;
+
+/** 429 后降速到的保守间隔 */
+const RATE_LIMIT_INTERVAL_MS = 2500;
 
 /** 429 后等待重试的时长 */
 const RATE_LIMIT_RETRY_MS = 30 * 1000;
@@ -81,6 +91,8 @@ async function runSync(force) {
         const groupsToCache = [];
         const groupIdsSeen = new Set();
         let consecutiveFailures = 0;
+        let requestInterval = BASE_INTERVAL_MS;
+        let adaptCounter = 0;
         const dueCount = dueFriendIds.length;
 
         for (let i = 0; i < dueCount; i++) {
@@ -133,12 +145,22 @@ async function runSync(force) {
                 }
                 await database.replaceFriendGroups(friendId, entries);
                 consecutiveFailures = 0;
+                // 自适应提速：连续成功 N 次后缩短间隔（不触发 429 的前提下）
+                adaptCounter += 1;
+                if (
+                    adaptCounter >= ADAPT_EVERY_SUCCESS &&
+                    requestInterval > MIN_INTERVAL_MS
+                ) {
+                    requestInterval -= ADAPT_STEP_MS;
+                    adaptCounter = 0;
+                }
             } catch (err) {
                 console.error(`Failed to fetch groups for ${friendId}:`, err);
                 store.failed += 1;
-                consecutiveFailures += 1;
                 if (isRateLimitError(err)) {
-                    // 限流：等待后重试当前好友一次
+                    // 限流是暂时的：降速 + 退避后重试，不计入连续失败（否则会误中止整轮）
+                    requestInterval = RATE_LIMIT_INTERVAL_MS;
+                    adaptCounter = 0;
                     await sleep(RATE_LIMIT_RETRY_MS);
                     try {
                         const { json } = await groupRequest.getGroups({
@@ -194,12 +216,15 @@ async function runSync(force) {
                             retryErr
                         );
                     }
+                } else {
+                    // 非限流错误才计入连续失败（连续过多则中止，避免带病空转）
+                    consecutiveFailures += 1;
                 }
             }
             store.done += 1;
             // 限流间隔（最后一个好友不必等待）
             if (i < dueCount - 1) {
-                await sleep(REQUEST_INTERVAL_MS);
+                await sleep(requestInterval);
             }
         }
 

--- a/src/coordinators/friendGroupsCoordinator.js
+++ b/src/coordinators/friendGroupsCoordinator.js
@@ -1,0 +1,178 @@
+import { groupRequest } from '../api';
+import { database } from '../services/database';
+import { queryClient } from '../queries';
+import { useFriendGroupsStore } from '../stores/friendGroups';
+import { applyGroup } from './groupCoordinator';
+
+/** 好友群组数据的新鲜度窗口（TTL），超过则增量刷新 */
+const FRIEND_GROUPS_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** 请求间隔：VRChat API 限流约 30 req/min，留余量按 ~27/min 串行 */
+const REQUEST_INTERVAL_MS = 2100;
+
+/** 429 后等待重试的时长 */
+const RATE_LIMIT_RETRY_MS = 30 * 1000;
+
+/** 连续失败超过该数量则中止本轮同步 */
+const MAX_CONSECUTIVE_FAILURES = 5;
+
+let syncPromise = null;
+
+/**
+ * 同步好友加入的公开群组到本地数据库（单飞：同一时刻只跑一轮）。
+ * @param {{ force?: boolean }} [options] force=true 忽略 TTL 全量刷新
+ * @returns {Promise<void>}
+ */
+export function syncFriendGroups({ force = false } = {}) {
+    if (syncPromise) {
+        return syncPromise;
+    }
+    syncPromise = runSync(force).finally(() => {
+        syncPromise = null;
+    });
+    return syncPromise;
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRateLimitError(err) {
+    return (
+        err &&
+        (err.status === 429 ||
+            (typeof err.message === 'string' &&
+                (err.message.includes('429') ||
+                    err.message.includes('rate limit'))))
+    );
+}
+
+async function runSync(force) {
+    const store = useFriendGroupsStore();
+    if (store.isSyncing) {
+        return;
+    }
+    store.isSyncing = true;
+    store.done = 0;
+    store.failed = 0;
+
+    try {
+        const friends = await database.getFriendLogCurrent();
+        store.total = friends.length;
+
+        let dueFriendIds = friends.map((friend) => friend.userId);
+        if (!force) {
+            const fetchTimes = await database.getFriendGroupFetchTimes();
+            const now = Date.now();
+            dueFriendIds = dueFriendIds.filter((friendId) => {
+                const fetchedAt = fetchTimes.get(friendId);
+                if (!fetchedAt) {
+                    return true;
+                }
+                const fetchedTime = new Date(fetchedAt).getTime();
+                return (
+                    Number.isNaN(fetchedTime) ||
+                    now - fetchedTime > FRIEND_GROUPS_TTL_MS
+                );
+            });
+        }
+
+        const groupsToCache = [];
+        const groupIdsSeen = new Set();
+        let consecutiveFailures = 0;
+        const dueCount = dueFriendIds.length;
+
+        for (let i = 0; i < dueCount; i++) {
+            const friendId = dueFriendIds[i];
+            if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+                break;
+            }
+            try {
+                const { json } = await groupRequest.getGroups({
+                    userId: friendId
+                });
+                const entries = [];
+                for (const member of json || []) {
+                    const group = member?.group;
+                    if (!group || !group.id) {
+                        continue;
+                    }
+                    // 需求只统计好友加入的 Public 群组
+                    if (group.privacy !== 'public') {
+                        continue;
+                    }
+                    entries.push({
+                        groupId: group.id,
+                        joinedAt: member.joinedAt,
+                        membershipStatus: member.membershipStatus,
+                        visibility: member.visibility
+                    });
+                    if (!groupIdsSeen.has(group.id)) {
+                        groupIdsSeen.add(group.id);
+                        groupsToCache.push(group);
+                    }
+                    applyGroup(group);
+                }
+                await database.replaceFriendGroups(friendId, entries);
+                consecutiveFailures = 0;
+            } catch (err) {
+                console.error(`Failed to fetch groups for ${friendId}:`, err);
+                store.failed += 1;
+                consecutiveFailures += 1;
+                if (isRateLimitError(err)) {
+                    // 限流：等待后重试当前好友一次
+                    await sleep(RATE_LIMIT_RETRY_MS);
+                    try {
+                        const { json } = await groupRequest.getGroups({
+                            userId: friendId
+                        });
+                        const entries = [];
+                        for (const member of json || []) {
+                            const group = member?.group;
+                            if (!group || !group.id) {
+                                continue;
+                            }
+                            if (group.privacy !== 'public') {
+                                continue;
+                            }
+                            entries.push({
+                                groupId: group.id,
+                                joinedAt: member.joinedAt,
+                                membershipStatus: member.membershipStatus,
+                                visibility: member.visibility
+                            });
+                            if (!groupIdsSeen.has(group.id)) {
+                                groupIdsSeen.add(group.id);
+                                groupsToCache.push(group);
+                            }
+                            applyGroup(group);
+                        }
+                        await database.replaceFriendGroups(friendId, entries);
+                        consecutiveFailures = 0;
+                    } catch (retryErr) {
+                        console.error(
+                            `Retry failed for ${friendId}:`,
+                            retryErr
+                        );
+                    }
+                }
+            }
+            store.done += 1;
+            // 限流间隔（最后一个好友不必等待）
+            if (i < dueCount - 1) {
+                await sleep(REQUEST_INTERVAL_MS);
+            }
+        }
+
+        if (groupsToCache.length > 0) {
+            await database.upsertCacheGroups(groupsToCache);
+        }
+
+        store.lastSyncedAt = new Date().toISOString();
+        queryClient.invalidateQueries({
+            queryKey: ['friendGroups']
+        });
+    } finally {
+        store.isSyncing = false;
+    }
+}

--- a/src/coordinators/friendGroupsCoordinator.js
+++ b/src/coordinators/friendGroupsCoordinator.js
@@ -55,6 +55,7 @@ async function runSync(force) {
     store.isSyncing = true;
     store.done = 0;
     store.failed = 0;
+    store.startedAt = Date.now();
 
     try {
         const friends = await database.getFriendLogCurrent();
@@ -101,7 +102,8 @@ async function runSync(force) {
                         groupId: member.groupId,
                         joinedAt: member.joinedAt || '',
                         membershipStatus: member.membershipStatus || 'member',
-                        visibility: member.visibility || member.memberVisibility || ''
+                        visibility:
+                            member.visibility || member.memberVisibility || ''
                     });
                     if (!groupIdsSeen.has(member.groupId)) {
                         groupIdsSeen.add(member.groupId);
@@ -151,8 +153,12 @@ async function runSync(force) {
                             entries.push({
                                 groupId: member.groupId,
                                 joinedAt: member.joinedAt || '',
-                                membershipStatus: member.membershipStatus || 'member',
-                                visibility: member.visibility || member.memberVisibility || ''
+                                membershipStatus:
+                                    member.membershipStatus || 'member',
+                                visibility:
+                                    member.visibility ||
+                                    member.memberVisibility ||
+                                    ''
                             });
                             if (!groupIdsSeen.has(member.groupId)) {
                                 groupIdsSeen.add(member.groupId);

--- a/src/coordinators/friendGroupsCoordinator.js
+++ b/src/coordinators/friendGroupsCoordinator.js
@@ -7,11 +7,12 @@ import { applyGroup } from './groupCoordinator';
 /** 好友群组数据的新鲜度窗口（TTL），超过则增量刷新 */
 const FRIEND_GROUPS_TTL_MS = 24 * 60 * 60 * 1000;
 
-/** 请求间隔（自适应）：初始约 37/min，无 429 时逐步提速 */
-const BASE_INTERVAL_MS = 1600;
+/** 请求间隔（自适应）：初始约 30/min（VRChat 文档限流值内），给关系网等共享配额的
+ *  功能留余量；无 429 时逐步提速 */
+const BASE_INTERVAL_MS = 2000;
 
-/** 提速下限（约 46/min），高于此不再加速 */
-const MIN_INTERVAL_MS = 1300;
+/** 提速下限（约 37/min），高于此不再加速 */
+const MIN_INTERVAL_MS = 1600;
 
 /** 连续成功 N 次后缩短一步间隔 */
 const ADAPT_STEP_MS = 100;

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -72,7 +72,7 @@
         "moderation": "Moderation",
         "notification": "Notification",
         "friend_list": "Friend List",
-        "groups": "Groups",
+        "groups": "Popular Groups",
         "charts": "Charts",
         "tools": "Tools",
         "settings": "Settings",
@@ -531,8 +531,6 @@
         "groups": {
             "title": "Popular Groups",
             "refresh": "Refresh",
-
-
             "syncing_progress": "{percent} · ~{remaining} min left · ~{total} min total",
             "last_synced": "Last synced",
             "friends_joined": "friends have joined this group",

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -72,6 +72,7 @@
         "moderation": "Moderation",
         "notification": "Notification",
         "friend_list": "Friend List",
+        "groups": "Groups",
         "charts": "Charts",
         "tools": "Tools",
         "settings": "Settings",
@@ -526,6 +527,14 @@
             "filter_placeholder": "Filter",
             "load_mutual_friends": "Load Mutual Friends",
             "mutual_loading_hint": "View progress on the Mutual Friend Graph page"
+        },
+        "groups": {
+            "title": "Popular Groups",
+            "refresh": "Refresh",
+            "syncing": "Syncing… {done}/{total}",
+            "last_synced": "Last synced",
+            "friends_joined": "friends have joined this group",
+            "empty": "No data yet. Click Refresh to sync your friends' groups."
         },
         "charts": {
             "instance_activity": {

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -531,7 +531,9 @@
         "groups": {
             "title": "Popular Groups",
             "refresh": "Refresh",
-            "syncing": "Syncing… {done}/{total}",
+
+
+            "syncing_progress": "{percent} · ~{remaining} min left · ~{total} min total",
             "last_synced": "Last synced",
             "friends_joined": "friends have joined this group",
             "empty": "No data yet. Click Refresh to sync your friends' groups."

--- a/src/localization/zh-CN.json
+++ b/src/localization/zh-CN.json
@@ -72,6 +72,7 @@
         "moderation": "玩家管理",
         "notification": "通知",
         "friend_list": "好友列表",
+        "groups": "热门群组",
         "charts": "图表",
         "tools": "工具",
         "settings": "设置",
@@ -522,6 +523,14 @@
             "filter_placeholder": "筛选好友",
             "load_mutual_friends": "查看关系网",
             "mutual_loading_hint": "跳转到好友关系网页面"
+        },
+        "groups": {
+            "title": "热门群组",
+            "refresh": "刷新",
+            "syncing": "同步中… {done}/{total}",
+            "last_synced": "上次同步",
+            "friends_joined": "位好友已加入此群组",
+            "empty": "暂无数据，点击刷新同步好友群组"
         },
         "charts": {
             "instance_activity": {

--- a/src/localization/zh-CN.json
+++ b/src/localization/zh-CN.json
@@ -527,7 +527,9 @@
         "groups": {
             "title": "热门群组",
             "refresh": "刷新",
-            "syncing": "同步中… {done}/{total}",
+
+
+            "syncing_progress": "{percent} · 剩余约 {remaining} 分钟 · 预计共 {total} 分钟",
             "last_synced": "上次同步",
             "friends_joined": "位好友已加入此群组",
             "empty": "暂无数据，点击刷新同步好友群组"

--- a/src/localization/zh-CN.json
+++ b/src/localization/zh-CN.json
@@ -527,8 +527,6 @@
         "groups": {
             "title": "热门群组",
             "refresh": "刷新",
-
-
             "syncing_progress": "{percent} · 剩余约 {remaining} 分钟 · 预计共 {total} 分钟",
             "last_synced": "上次同步",
             "friends_joined": "位好友已加入此群组",

--- a/src/localization/zh-TW.json
+++ b/src/localization/zh-TW.json
@@ -527,7 +527,9 @@
         "groups": {
             "title": "熱門群組",
             "refresh": "重新整理",
-            "syncing": "同步中… {done}/{total}",
+
+
+            "syncing_progress": "{percent} · 剩餘約 {remaining} 分鐘 · 預計共 {total} 分鐘",
             "last_synced": "上次同步",
             "friends_joined": "位好友已加入此群組",
             "empty": "尚無資料，點擊重新整理同步好友群組"

--- a/src/localization/zh-TW.json
+++ b/src/localization/zh-TW.json
@@ -527,8 +527,6 @@
         "groups": {
             "title": "熱門群組",
             "refresh": "重新整理",
-
-
             "syncing_progress": "{percent} · 剩餘約 {remaining} 分鐘 · 預計共 {total} 分鐘",
             "last_synced": "上次同步",
             "friends_joined": "位好友已加入此群組",

--- a/src/localization/zh-TW.json
+++ b/src/localization/zh-TW.json
@@ -72,6 +72,7 @@
         "moderation": "用戶處置",
         "notification": "通知",
         "friend_list": "好友列表",
+        "groups": "熱門群組",
         "charts": "圖表",
         "tools": "工具",
         "settings": "設定",
@@ -522,6 +523,14 @@
             "filter_placeholder": "篩選好友",
             "load_mutual_friends": "載入共同好友",
             "mutual_loading_hint": "在共同好友圖表頁面查看進度"
+        },
+        "groups": {
+            "title": "熱門群組",
+            "refresh": "重新整理",
+            "syncing": "同步中… {done}/{total}",
+            "last_synced": "上次同步",
+            "friends_joined": "位好友已加入此群組",
+            "empty": "尚無資料，點擊重新整理同步好友群組"
         },
         "charts": {
             "instance_activity": {

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -8,6 +8,7 @@ import FavoritesWorld from './../views/Favorites/FavoritesWorld.vue';
 import Feed from './../views/Feed/Feed.vue';
 import FriendList from './../views/FriendList/FriendList.vue';
 import FriendLog from './../views/FriendLog/FriendLog.vue';
+import Groups from './../views/Groups/PopularGroups.vue';
 import FriendsLocations from './../views/FriendsLocations/FriendsLocations.vue';
 import Dashboard from './../views/Dashboard/Dashboard.vue';
 import Gallery from './../views/Tools/Gallery.vue';
@@ -91,6 +92,11 @@ const routes = [
                 path: 'social/friend-list',
                 name: 'friend-list',
                 component: FriendList
+            },
+            {
+                path: 'social/groups',
+                name: 'groups',
+                component: Groups
             },
             {
                 path: 'charts',

--- a/src/queries/keys.js
+++ b/src/queries/keys.js
@@ -90,5 +90,7 @@ export const queryKeys = Object.freeze({
     file: (fileId) => ['file', fileId],
     avatarStyles: () => ['avatar', 'styles'],
     representedGroup: (userId) => ['user', userId, 'representedGroup'],
+    friendGroupsPopular: () => ['friendGroups', 'popular'],
+    friendGroupsFriendIds: () => ['friendGroups', 'friendIds'],
     vrchatCredits: () => ['credits']
 });

--- a/src/queries/policies.js
+++ b/src/queries/policies.js
@@ -104,6 +104,12 @@ export const entityQueryPolicies = Object.freeze({
         retry: 1,
         refetchOnWindowFocus: false
     }),
+    friendGroupsPopular: Object.freeze({
+        staleTime: 30 * SECOND,
+        gcTime: 300 * SECOND,
+        retry: 1,
+        refetchOnWindowFocus: false
+    }),
     vrchatCredits: Object.freeze({
         staleTime: 120 * SECOND,
         gcTime: 600 * SECOND,

--- a/src/queries/useEntityQueries.js
+++ b/src/queries/useEntityQueries.js
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/vue-query';
 
 import { avatarRequest, groupRequest, userRequest, worldRequest } from '../api';
+import { database } from '../services/database';
 import { entityQueryPolicies, toQueryOptions } from './policies';
 import { queryKeys } from './keys';
 
@@ -62,5 +63,34 @@ export function useGroupQuery(groupId, includeRoles = false, options = {}) {
         queryFn: () => groupRequest.getGroup({ groupId, includeRoles }),
         enabled: Boolean(groupId),
         ...toQueryOptions(entityQueryPolicies.group)
+    });
+}
+
+/**
+ * 好友加入的热门公开群组列表（本地数据库聚合查询）。
+ * @param {object} [options]
+ */
+export function usePopularFriendGroupsQuery(options = {}) {
+    return useQuery({
+        ...options,
+        queryKey: queryKeys.friendGroupsPopular(),
+        /**
+         * @returns {Promise<Array<{groupId: string, name: string, shortCode: string, discriminator: string, description: string, iconUrl: string, bannerUrl: string, privacy: string, memberCount: number, friendCount: number}>>}
+         */
+        queryFn: () => database.getPopularGroups(2, 200),
+        ...toQueryOptions(entityQueryPolicies.friendGroupsPopular)
+    });
+}
+
+/**
+ * 热门群组内已加入的好友 id 映射（头像预览用）。
+ * @param {object} [options]
+ */
+export function usePopularFriendGroupIdsQuery(options = {}) {
+    return useQuery({
+        ...options,
+        queryKey: queryKeys.friendGroupsFriendIds(),
+        queryFn: () => database.getPopularGroupFriendIds(2),
+        ...toQueryOptions(entityQueryPolicies.friendGroupsPopular)
     });
 }

--- a/src/services/database/__tests__/friendGroups.test.js
+++ b/src/services/database/__tests__/friendGroups.test.js
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    execute: vi.fn(),
+    executeNonQuery: vi.fn()
+}));
+
+vi.mock('../../sqlite.js', () => ({
+    default: {
+        execute: mocks.execute,
+        executeNonQuery: mocks.executeNonQuery
+    }
+}));
+vi.mock('../index.js', () => ({
+    dbVars: {
+        maxTableSize: 500,
+        userPrefix: 'testuser'
+    }
+}));
+
+import { friendGroups } from '../friendGroups.js';
+
+beforeEach(() => {
+    mocks.execute.mockReset();
+    mocks.executeNonQuery.mockReset();
+    mocks.executeNonQuery.mockResolvedValue(undefined);
+});
+
+describe('friendGroups.replaceFriendGroups', () => {
+    test('replaces entries inside a transaction', async () => {
+        await friendGroups.replaceFriendGroups('usr_1', [
+            {
+                groupId: 'grp_1',
+                joinedAt: '2026-01-01T00:00:00.000Z',
+                membershipStatus: 'member',
+                visibility: 'visible'
+            },
+            { groupId: "grp_o'brien" }
+        ]);
+
+        expect(mocks.executeNonQuery).toHaveBeenNthCalledWith(1, 'BEGIN');
+        expect(mocks.executeNonQuery).toHaveBeenNthCalledWith(
+            2,
+            `DELETE FROM testuser_friend_groups WHERE friend_id = 'usr_1'`
+        );
+        const insertCall = mocks.executeNonQuery.mock.calls[2][0];
+        expect(insertCall).toContain(
+            'INSERT OR REPLACE INTO testuser_friend_groups (friend_id, group_id, joined_at, membership_status, visibility, fetched_at) VALUES'
+        );
+        expect(insertCall).toContain(
+            "'usr_1', 'grp_1', '2026-01-01T00:00:00.000Z'"
+        );
+        // SQL 转义
+        expect(insertCall).toContain("'grp_o''brien'");
+        expect(mocks.executeNonQuery).toHaveBeenLastCalledWith('COMMIT');
+    });
+
+    test('skips entries without a groupId', async () => {
+        await friendGroups.replaceFriendGroups('usr_1', [
+            { groupId: 'grp_1' },
+            { joinedAt: '2026-01-01T00:00:00.000Z' }
+        ]);
+
+        const insertCall = mocks.executeNonQuery.mock.calls[2][0];
+        expect(insertCall).not.toContain('undefined');
+        expect(insertCall.split('),').length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('deletes only when entries are empty', async () => {
+        await friendGroups.replaceFriendGroups('usr_1', []);
+
+        expect(mocks.executeNonQuery).toHaveBeenCalledTimes(3); // BEGIN, DELETE, COMMIT
+        const calls = mocks.executeNonQuery.mock.calls.map((c) => c[0]);
+        expect(calls.some((sql) => sql.includes('INSERT OR REPLACE'))).toBe(
+            false
+        );
+    });
+
+    test('rolls back on error', async () => {
+        mocks.executeNonQuery.mockImplementationOnce(() => Promise.resolve());
+        mocks.executeNonQuery.mockImplementationOnce(() => {
+            throw new Error('boom');
+        });
+
+        await expect(
+            friendGroups.replaceFriendGroups('usr_1', [{ groupId: 'grp_1' }])
+        ).rejects.toThrow('boom');
+        expect(mocks.executeNonQuery).toHaveBeenLastCalledWith('ROLLBACK');
+    });
+
+    test('is a no-op without a user prefix', async () => {
+        const { dbVars } = await import('../index.js');
+        dbVars.userPrefix = '';
+        await friendGroups.replaceFriendGroups('usr_1', [{ groupId: 'grp_1' }]);
+        dbVars.userPrefix = 'testuser';
+        expect(mocks.executeNonQuery).not.toHaveBeenCalled();
+    });
+});
+
+describe('friendGroups.deleteFriendGroups', () => {
+    test('deletes rows for a friend', async () => {
+        await friendGroups.deleteFriendGroups('usr_1');
+
+        expect(mocks.executeNonQuery).toHaveBeenCalledWith(
+            `DELETE FROM testuser_friend_groups WHERE friend_id = @friend_id`,
+            { '@friend_id': 'usr_1' }
+        );
+    });
+});
+
+describe('friendGroups.getFriendGroups', () => {
+    test('maps rows to group entries', async () => {
+        mocks.execute.mockImplementation(async (callback) => {
+            callback([
+                'grp_1',
+                '2026-01-01T00:00:00.000Z',
+                'member',
+                'visible',
+                '2026-01-02T00:00:00.000Z'
+            ]);
+            return undefined;
+        });
+
+        const result = await friendGroups.getFriendGroups('usr_1');
+
+        expect(result).toEqual([
+            {
+                groupId: 'grp_1',
+                joinedAt: '2026-01-01T00:00:00.000Z',
+                membershipStatus: 'member',
+                visibility: 'visible',
+                fetchedAt: '2026-01-02T00:00:00.000Z'
+            }
+        ]);
+        expect(mocks.execute.mock.calls[0][1]).toContain(
+            'WHERE friend_id = @friend_id'
+        );
+        expect(mocks.execute.mock.calls[0][2]).toEqual({
+            '@friend_id': 'usr_1'
+        });
+    });
+});
+
+describe('friendGroups.getFriendGroupFetchTimes', () => {
+    test('maps friend id to latest fetch time', async () => {
+        mocks.execute.mockImplementation(async (callback) => {
+            callback(['usr_1', '2026-01-02T00:00:00.000Z']);
+            callback(['usr_2', null]);
+            return undefined;
+        });
+
+        const result = await friendGroups.getFriendGroupFetchTimes();
+
+        expect(result).toEqual(
+            new Map([
+                ['usr_1', '2026-01-02T00:00:00.000Z'],
+                ['usr_2', null]
+            ])
+        );
+        expect(mocks.execute.mock.calls[0][1]).toContain(
+            'SELECT friend_id, MAX(fetched_at) FROM testuser_friend_groups GROUP BY friend_id'
+        );
+    });
+});
+
+describe('friendGroups.upsertCacheGroups', () => {
+    test('bulk upserts group cache rows', async () => {
+        await friendGroups.upsertCacheGroups([
+            {
+                id: 'grp_1',
+                name: "Dance O'Club",
+                shortCode: 'DNC',
+                discriminator: '1234',
+                description: 'desc',
+                iconUrl: 'https://x/i.png',
+                bannerUrl: 'https://x/b.png',
+                privacy: 'public',
+                memberCount: 500
+            }
+        ]);
+
+        const sql = mocks.executeNonQuery.mock.calls[0][0];
+        expect(sql).toContain(
+            'INSERT OR REPLACE INTO testuser_cache_group (id, added_at, updated_at, name, short_code, discriminator, description, icon_url, banner_url, privacy, member_count) VALUES'
+        );
+        expect(sql).toContain("'Dance O''Club'");
+        expect(sql).toContain('500');
+        expect(sql).toContain("'public'");
+    });
+
+    test('coerces missing memberCount to 0', async () => {
+        await friendGroups.upsertCacheGroups([{ id: 'grp_2' }]);
+
+        const sql = mocks.executeNonQuery.mock.calls[0][0];
+        expect(sql).toContain("'grp_2'");
+        expect(sql).toMatch(/, 0\)$/);
+    });
+
+    test('is a no-op for empty input', async () => {
+        await friendGroups.upsertCacheGroups([]);
+        expect(mocks.executeNonQuery).not.toHaveBeenCalled();
+    });
+});
+
+describe('friendGroups.getCachedGroups', () => {
+    test('maps all cached groups into a map', async () => {
+        mocks.execute.mockImplementation(async (callback) => {
+            callback([
+                'grp_1',
+                'Dance',
+                'DNC',
+                '1234',
+                'desc',
+                'https://i.png',
+                'https://b.png',
+                'public',
+                500
+            ]);
+            return undefined;
+        });
+
+        const result = await friendGroups.getCachedGroups();
+
+        expect(result.get('grp_1')).toEqual({
+            id: 'grp_1',
+            name: 'Dance',
+            shortCode: 'DNC',
+            discriminator: '1234',
+            description: 'desc',
+            iconUrl: 'https://i.png',
+            bannerUrl: 'https://b.png',
+            privacy: 'public',
+            memberCount: 500
+        });
+    });
+});
+
+describe('friendGroups.getPopularGroups', () => {
+    test('builds the aggregation query and maps rows', async () => {
+        mocks.execute.mockImplementation(async (callback) => {
+            callback([
+                'grp_1',
+                'Dance',
+                'DNC',
+                '1234',
+                'desc',
+                'https://i.png',
+                'https://b.png',
+                'public',
+                500,
+                12
+            ]);
+            return undefined;
+        });
+
+        const result = await friendGroups.getPopularGroups(2, 50);
+
+        expect(result).toEqual([
+            {
+                groupId: 'grp_1',
+                name: 'Dance',
+                shortCode: 'DNC',
+                discriminator: '1234',
+                description: 'desc',
+                iconUrl: 'https://i.png',
+                bannerUrl: 'https://b.png',
+                privacy: 'public',
+                memberCount: 500,
+                friendCount: 12
+            }
+        ]);
+        const [sql, params] = mocks.execute.mock.calls[0].slice(1);
+        expect(sql).toContain(
+            'INNER JOIN testuser_friend_groups f ON f.group_id = g.id'
+        );
+        expect(sql).toContain('GROUP BY g.id');
+        expect(sql).toContain('HAVING COUNT(f.friend_id) >= @minFriends');
+        expect(sql).toContain(
+            'ORDER BY friend_count DESC, g.member_count DESC'
+        );
+        expect(sql).toContain('LIMIT @limit');
+        expect(params).toEqual({ '@minFriends': 2, '@limit': 50 });
+    });
+});
+
+describe('friendGroups.getPopularGroupFriendIds', () => {
+    test('splits GROUP_CONCAT into friend id arrays', async () => {
+        mocks.execute.mockImplementation(async (callback) => {
+            callback(['grp_1', 'usr_1,usr_2,usr_3']);
+            callback(['grp_2', null]);
+            return undefined;
+        });
+
+        const result = await friendGroups.getPopularGroupFriendIds(2);
+
+        expect(result.get('grp_1')).toEqual(['usr_1', 'usr_2', 'usr_3']);
+        expect(result.get('grp_2')).toEqual([]);
+        expect(mocks.execute.mock.calls[0][1]).toContain(
+            'GROUP_CONCAT(friend_id)'
+        );
+    });
+});

--- a/src/services/database/__tests__/friendGroups.test.js
+++ b/src/services/database/__tests__/friendGroups.test.js
@@ -167,7 +167,7 @@ describe('friendGroups.getFriendGroupFetchTimes', () => {
 });
 
 describe('friendGroups.upsertCacheGroups', () => {
-    test('parameterized upsert per group, emoji-safe', async () => {
+    test('batched parameterized upsert, emoji-safe', async () => {
         await friendGroups.upsertCacheGroups([
             {
                 id: 'grp_1',
@@ -189,11 +189,29 @@ describe('friendGroups.upsertCacheGroups', () => {
         );
         // 参数化：emoji/引号原样传参，不做字符串拼接
         expect(sql).not.toContain("O'Club");
-        expect(args['@id']).toBe('grp_1');
-        expect(args['@name']).toBe("Dance O'Club ❤️");
-        expect(args['@member_count']).toBe(500);
-        expect(args['@privacy']).toBe('public');
+        expect(sql).toContain('(@id0, @added_at0, @updated_at0, @name0');
+        expect(args['@id0']).toBe('grp_1');
+        expect(args['@name0']).toBe("Dance O'Club ❤️");
+        expect(args['@member_count0']).toBe(500);
+        expect(args['@privacy0']).toBe('public');
         expect(mocks.executeNonQuery).toHaveBeenLastCalledWith('COMMIT');
+    });
+
+    test('batches large inputs into chunks of 80', async () => {
+        const groups = Array.from({ length: 165 }, (_, i) => ({
+            id: `grp_${i}`,
+            name: `群 ${i}`
+        }));
+        await friendGroups.upsertCacheGroups(groups);
+
+        const inserts = mocks.executeNonQuery.mock.calls
+            .map((c) => c[0])
+            .filter((sql) => sql.includes('INSERT OR REPLACE'));
+        // 165 行 → 2 批（80 + 80）+ 尾部 5
+        expect(inserts.length).toBe(3);
+        expect(inserts[0].match(/@id\d/g)).toHaveLength(80);
+        expect(inserts[1].match(/@id\d/g)).toHaveLength(80);
+        expect(inserts[2].match(/@id\d/g)).toHaveLength(5);
     });
 
     test('rolls back on parameterized insert error', async () => {
@@ -212,8 +230,8 @@ describe('friendGroups.upsertCacheGroups', () => {
         await friendGroups.upsertCacheGroups([{ id: 'grp_2' }]);
 
         const args = mocks.executeNonQuery.mock.calls[1][1];
-        expect(args['@id']).toBe('grp_2');
-        expect(args['@member_count']).toBe(0);
+        expect(args['@id0']).toBe('grp_2');
+        expect(args['@member_count0']).toBe(0);
     });
 
     test('is a no-op for empty input', async () => {

--- a/src/services/database/__tests__/friendGroups.test.js
+++ b/src/services/database/__tests__/friendGroups.test.js
@@ -66,14 +66,17 @@ describe('friendGroups.replaceFriendGroups', () => {
         expect(insertCall.split('),').length).toBeGreaterThanOrEqual(1);
     });
 
-    test('deletes only when entries are empty', async () => {
+    test('writes a marker row when entries are empty', async () => {
         await friendGroups.replaceFriendGroups('usr_1', []);
 
-        expect(mocks.executeNonQuery).toHaveBeenCalledTimes(3); // BEGIN, DELETE, COMMIT
-        const calls = mocks.executeNonQuery.mock.calls.map((c) => c[0]);
-        expect(calls.some((sql) => sql.includes('INSERT OR REPLACE'))).toBe(
-            false
+        // BEGIN, DELETE, INSERT(marker), COMMIT
+        expect(mocks.executeNonQuery).toHaveBeenCalledTimes(4);
+        const markerCall = mocks.executeNonQuery.mock.calls[2];
+        expect(markerCall[0]).toContain(
+            `INSERT OR REPLACE INTO testuser_friend_groups (friend_id, group_id, joined_at, membership_status, visibility, fetched_at) VALUES (@friend_id, '', '', '', '', @now)`
         );
+        expect(markerCall[1]['@friend_id']).toBe('usr_1');
+        expect(mocks.executeNonQuery.mock.calls[3][0]).toBe('COMMIT');
     });
 
     test('rolls back on error', async () => {
@@ -164,11 +167,11 @@ describe('friendGroups.getFriendGroupFetchTimes', () => {
 });
 
 describe('friendGroups.upsertCacheGroups', () => {
-    test('bulk upserts group cache rows', async () => {
+    test('parameterized upsert per group, emoji-safe', async () => {
         await friendGroups.upsertCacheGroups([
             {
                 id: 'grp_1',
-                name: "Dance O'Club",
+                name: "Dance O'Club ❤️",
                 shortCode: 'DNC',
                 discriminator: '1234',
                 description: 'desc',
@@ -179,21 +182,38 @@ describe('friendGroups.upsertCacheGroups', () => {
             }
         ]);
 
-        const sql = mocks.executeNonQuery.mock.calls[0][0];
+        expect(mocks.executeNonQuery).toHaveBeenNthCalledWith(1, 'BEGIN');
+        const [sql, args] = mocks.executeNonQuery.mock.calls[1];
         expect(sql).toContain(
             'INSERT OR REPLACE INTO testuser_cache_group (id, added_at, updated_at, name, short_code, discriminator, description, icon_url, banner_url, privacy, member_count) VALUES'
         );
-        expect(sql).toContain("'Dance O''Club'");
-        expect(sql).toContain('500');
-        expect(sql).toContain("'public'");
+        // 参数化：emoji/引号原样传参，不做字符串拼接
+        expect(sql).not.toContain("O'Club");
+        expect(args['@id']).toBe('grp_1');
+        expect(args['@name']).toBe("Dance O'Club ❤️");
+        expect(args['@member_count']).toBe(500);
+        expect(args['@privacy']).toBe('public');
+        expect(mocks.executeNonQuery).toHaveBeenLastCalledWith('COMMIT');
+    });
+
+    test('rolls back on parameterized insert error', async () => {
+        mocks.executeNonQuery.mockImplementationOnce(() => Promise.resolve()); // BEGIN
+        mocks.executeNonQuery.mockImplementationOnce(() => {
+            throw new Error('boom');
+        }); // INSERT 失败
+
+        await expect(
+            friendGroups.upsertCacheGroups([{ id: 'grp_2', name: 'x' }])
+        ).rejects.toThrow('boom');
+        expect(mocks.executeNonQuery).toHaveBeenLastCalledWith('ROLLBACK');
     });
 
     test('coerces missing memberCount to 0', async () => {
         await friendGroups.upsertCacheGroups([{ id: 'grp_2' }]);
 
-        const sql = mocks.executeNonQuery.mock.calls[0][0];
-        expect(sql).toContain("'grp_2'");
-        expect(sql).toMatch(/, 0\)$/);
+        const args = mocks.executeNonQuery.mock.calls[1][1];
+        expect(args['@id']).toBe('grp_2');
+        expect(args['@member_count']).toBe(0);
     });
 
     test('is a no-op for empty input', async () => {

--- a/src/services/database/friendGroups.js
+++ b/src/services/database/friendGroups.js
@@ -23,9 +23,9 @@ const friendGroups = {
             await sqliteService.executeNonQuery(
                 `DELETE FROM ${table} WHERE friend_id = '${safeFriendId}'`
             );
+            const now = new Date().toISOString();
             if (entries && entries.length > 0) {
                 let values = '';
-                const now = new Date().toISOString();
                 for (const entry of entries) {
                     if (!entry || !entry.groupId) {
                         continue;
@@ -38,6 +38,15 @@ const friendGroups = {
                         `INSERT OR REPLACE INTO ${table} (friend_id, group_id, joined_at, membership_status, visibility, fetched_at) VALUES ${values}`
                     );
                 }
+            } else {
+                // 无可见群的好友：写标记行记录已检查时间（供增量同步跳过）
+                await sqliteService.executeNonQuery(
+                    `INSERT OR REPLACE INTO ${table} (friend_id, group_id, joined_at, membership_status, visibility, fetched_at) VALUES (@friend_id, '', '', '', '', @now)`,
+                    {
+                        '@friend_id': friendId,
+                        '@now': now
+                    }
+                );
             }
             await sqliteService.executeNonQuery('COMMIT');
         } catch (err) {
@@ -119,24 +128,39 @@ const friendGroups = {
             return;
         }
         const table = `${dbVars.userPrefix}_cache_group`;
-        let values = '';
         const now = new Date().toISOString();
-        for (const group of groups) {
-            if (!group || !group.id) {
-                continue;
+        await sqliteService.executeNonQuery('BEGIN');
+        try {
+            for (const group of groups) {
+                if (!group || !group.id) {
+                    continue;
+                }
+                const memberCount =
+                    typeof group.memberCount === 'number' &&
+                    Number.isFinite(group.memberCount)
+                        ? group.memberCount
+                        : 0;
+                await sqliteService.executeNonQuery(
+                    `INSERT OR REPLACE INTO ${table} (id, added_at, updated_at, name, short_code, discriminator, description, icon_url, banner_url, privacy, member_count) VALUES (@id, @added_at, @updated_at, @name, @short_code, @discriminator, @description, @icon_url, @banner_url, @privacy, @member_count)`,
+                    {
+                        '@id': group.id,
+                        '@added_at': now,
+                        '@updated_at': now,
+                        '@name': group.name || '',
+                        '@short_code': group.shortCode || '',
+                        '@discriminator': group.discriminator || '',
+                        '@description': group.description || '',
+                        '@icon_url': group.iconUrl || '',
+                        '@banner_url': group.bannerUrl || '',
+                        '@privacy': group.privacy || '',
+                        '@member_count': memberCount
+                    }
+                );
             }
-            const memberCount =
-                typeof group.memberCount === 'number' &&
-                Number.isFinite(group.memberCount)
-                    ? group.memberCount
-                    : 0;
-            values += `('${escapeSql(group.id)}', '${now}', '${now}', '${escapeSql(group.name || '')}', '${escapeSql(group.shortCode || '')}', '${escapeSql(group.discriminator || '')}', '${escapeSql(group.description || '')}', '${escapeSql(group.iconUrl || '')}', '${escapeSql(group.bannerUrl || '')}', '${escapeSql(group.privacy || '')}', ${memberCount}),`;
-        }
-        if (values) {
-            values = values.slice(0, -1);
-            await sqliteService.executeNonQuery(
-                `INSERT OR REPLACE INTO ${table} (id, added_at, updated_at, name, short_code, discriminator, description, icon_url, banner_url, privacy, member_count) VALUES ${values}`
-            );
+            await sqliteService.executeNonQuery('COMMIT');
+        } catch (err) {
+            await sqliteService.executeNonQuery('ROLLBACK');
+            throw err;
         }
     },
 
@@ -227,7 +251,7 @@ const friendGroups = {
                     : [];
                 map.set(dbRow[0], friendIds);
             }
-        }, `SELECT group_id, GROUP_CONCAT(friend_id) FROM ${linkTable} GROUP BY group_id HAVING COUNT(friend_id) >= ${minFriends}`);
+        }, `SELECT group_id, GROUP_CONCAT(friend_id) FROM ${linkTable} WHERE group_id != '' GROUP BY group_id HAVING COUNT(friend_id) >= ${minFriends}`);
         return map;
     }
 };

--- a/src/services/database/friendGroups.js
+++ b/src/services/database/friendGroups.js
@@ -120,7 +120,7 @@ const friendGroups = {
     },
 
     /**
-     * 批量写入/更新群实体缓存。
+     * 批量写入/更新群实体缓存（分批参数化，免疫 emoji 等特殊字符且远快于逐条）。
      * @param {Array<{id: string, name?: string, shortCode?: string, discriminator?: string, description?: string, iconUrl?: string, bannerUrl?: string, privacy?: string, memberCount?: number}>} groups
      */
     async upsertCacheGroups(groups) {
@@ -129,33 +129,45 @@ const friendGroups = {
         }
         const table = `${dbVars.userPrefix}_cache_group`;
         const now = new Date().toISOString();
+        // System.Data.SQLite 参数上限约 999，每行 11 个参数 → 每批 80 行
+        const BATCH_SIZE = 80;
         await sqliteService.executeNonQuery('BEGIN');
         try {
-            for (const group of groups) {
-                if (!group || !group.id) {
-                    continue;
-                }
-                const memberCount =
-                    typeof group.memberCount === 'number' &&
-                    Number.isFinite(group.memberCount)
-                        ? group.memberCount
-                        : 0;
-                await sqliteService.executeNonQuery(
-                    `INSERT OR REPLACE INTO ${table} (id, added_at, updated_at, name, short_code, discriminator, description, icon_url, banner_url, privacy, member_count) VALUES (@id, @added_at, @updated_at, @name, @short_code, @discriminator, @description, @icon_url, @banner_url, @privacy, @member_count)`,
-                    {
-                        '@id': group.id,
-                        '@added_at': now,
-                        '@updated_at': now,
-                        '@name': group.name || '',
-                        '@short_code': group.shortCode || '',
-                        '@discriminator': group.discriminator || '',
-                        '@description': group.description || '',
-                        '@icon_url': group.iconUrl || '',
-                        '@banner_url': group.bannerUrl || '',
-                        '@privacy': group.privacy || '',
-                        '@member_count': memberCount
+            for (let i = 0; i < groups.length; i += BATCH_SIZE) {
+                const batch = groups.slice(i, i + BATCH_SIZE);
+                const rows = [];
+                const args = {};
+                for (let r = 0; r < batch.length; r++) {
+                    const group = batch[r];
+                    if (!group || !group.id) {
+                        continue;
                     }
-                );
+                    const memberCount =
+                        typeof group.memberCount === 'number' &&
+                        Number.isFinite(group.memberCount)
+                            ? group.memberCount
+                            : 0;
+                    rows.push(
+                        `(@id${r}, @added_at${r}, @updated_at${r}, @name${r}, @short_code${r}, @discriminator${r}, @description${r}, @icon_url${r}, @banner_url${r}, @privacy${r}, @member_count${r})`
+                    );
+                    args[`@id${r}`] = group.id;
+                    args[`@added_at${r}`] = now;
+                    args[`@updated_at${r}`] = now;
+                    args[`@name${r}`] = group.name || '';
+                    args[`@short_code${r}`] = group.shortCode || '';
+                    args[`@discriminator${r}`] = group.discriminator || '';
+                    args[`@description${r}`] = group.description || '';
+                    args[`@icon_url${r}`] = group.iconUrl || '';
+                    args[`@banner_url${r}`] = group.bannerUrl || '';
+                    args[`@privacy${r}`] = group.privacy || '';
+                    args[`@member_count${r}`] = memberCount;
+                }
+                if (rows.length > 0) {
+                    await sqliteService.executeNonQuery(
+                        `INSERT OR REPLACE INTO ${table} (id, added_at, updated_at, name, short_code, discriminator, description, icon_url, banner_url, privacy, member_count) VALUES ${rows.join(',')}`,
+                        args
+                    );
+                }
             }
             await sqliteService.executeNonQuery('COMMIT');
         } catch (err) {

--- a/src/services/database/friendGroups.js
+++ b/src/services/database/friendGroups.js
@@ -1,0 +1,235 @@
+import { dbVars } from '../database';
+
+import sqliteService from '../sqlite.js';
+
+function escapeSql(value) {
+    return String(value).replace(/'/g, "''");
+}
+
+const friendGroups = {
+    /**
+     * 用单个好友的最新群组列表整体替换其关系记录（事务内，先删后插）。
+     * @param {string} friendId
+     * @param {Array<{groupId: string, joinedAt?: string, membershipStatus?: string, visibility?: string}>} entries
+     */
+    async replaceFriendGroups(friendId, entries) {
+        if (!dbVars.userPrefix || !friendId) {
+            return;
+        }
+        const table = `${dbVars.userPrefix}_friend_groups`;
+        const safeFriendId = escapeSql(friendId);
+        await sqliteService.executeNonQuery('BEGIN');
+        try {
+            await sqliteService.executeNonQuery(
+                `DELETE FROM ${table} WHERE friend_id = '${safeFriendId}'`
+            );
+            if (entries && entries.length > 0) {
+                let values = '';
+                const now = new Date().toISOString();
+                for (const entry of entries) {
+                    if (!entry || !entry.groupId) {
+                        continue;
+                    }
+                    values += `('${safeFriendId}', '${escapeSql(entry.groupId)}', '${escapeSql(entry.joinedAt || '')}', '${escapeSql(entry.membershipStatus || '')}', '${escapeSql(entry.visibility || '')}', '${now}'),`;
+                }
+                if (values) {
+                    values = values.slice(0, -1);
+                    await sqliteService.executeNonQuery(
+                        `INSERT OR REPLACE INTO ${table} (friend_id, group_id, joined_at, membership_status, visibility, fetched_at) VALUES ${values}`
+                    );
+                }
+            }
+            await sqliteService.executeNonQuery('COMMIT');
+        } catch (err) {
+            await sqliteService.executeNonQuery('ROLLBACK');
+            throw err;
+        }
+    },
+
+    /**
+     * 好友解除关系时清理其群组关系记录。
+     * @param {string} friendId
+     */
+    async deleteFriendGroups(friendId) {
+        if (!dbVars.userPrefix || !friendId) {
+            return;
+        }
+        const table = `${dbVars.userPrefix}_friend_groups`;
+        await sqliteService.executeNonQuery(
+            `DELETE FROM ${table} WHERE friend_id = @friend_id`,
+            {
+                '@friend_id': friendId
+            }
+        );
+    },
+
+    /**
+     * 查询单个好友加入的群组。
+     * @param {string} friendId
+     * @returns {Promise<Array<{groupId: string, joinedAt: string, membershipStatus: string, visibility: string, fetchedAt: string}>>}
+     */
+    async getFriendGroups(friendId) {
+        const result = [];
+        if (!dbVars.userPrefix || !friendId) {
+            return result;
+        }
+        const table = `${dbVars.userPrefix}_friend_groups`;
+        await sqliteService.execute(
+            (dbRow) => {
+                result.push({
+                    groupId: dbRow[0],
+                    joinedAt: dbRow[1],
+                    membershipStatus: dbRow[2],
+                    visibility: dbRow[3],
+                    fetchedAt: dbRow[4]
+                });
+            },
+            `SELECT group_id, joined_at, membership_status, visibility, fetched_at FROM ${table} WHERE friend_id = @friend_id`,
+            {
+                '@friend_id': friendId
+            }
+        );
+        return result;
+    },
+
+    /**
+     * 每个好友最近一次拉取群组的时间（增量同步判定用）。
+     * @returns {Promise<Map<string, string|null>>} friendId -> fetched_at
+     */
+    async getFriendGroupFetchTimes() {
+        const map = new Map();
+        if (!dbVars.userPrefix) {
+            return map;
+        }
+        const table = `${dbVars.userPrefix}_friend_groups`;
+        await sqliteService.execute((dbRow) => {
+            if (dbRow[0]) {
+                map.set(dbRow[0], dbRow[1] || null);
+            }
+        }, `SELECT friend_id, MAX(fetched_at) FROM ${table} GROUP BY friend_id`);
+        return map;
+    },
+
+    /**
+     * 批量写入/更新群实体缓存。
+     * @param {Array<{id: string, name?: string, shortCode?: string, discriminator?: string, description?: string, iconUrl?: string, bannerUrl?: string, privacy?: string, memberCount?: number}>} groups
+     */
+    async upsertCacheGroups(groups) {
+        if (!dbVars.userPrefix || !groups || groups.length === 0) {
+            return;
+        }
+        const table = `${dbVars.userPrefix}_cache_group`;
+        let values = '';
+        const now = new Date().toISOString();
+        for (const group of groups) {
+            if (!group || !group.id) {
+                continue;
+            }
+            const memberCount =
+                typeof group.memberCount === 'number' &&
+                Number.isFinite(group.memberCount)
+                    ? group.memberCount
+                    : 0;
+            values += `('${escapeSql(group.id)}', '${now}', '${now}', '${escapeSql(group.name || '')}', '${escapeSql(group.shortCode || '')}', '${escapeSql(group.discriminator || '')}', '${escapeSql(group.description || '')}', '${escapeSql(group.iconUrl || '')}', '${escapeSql(group.bannerUrl || '')}', '${escapeSql(group.privacy || '')}', ${memberCount}),`;
+        }
+        if (values) {
+            values = values.slice(0, -1);
+            await sqliteService.executeNonQuery(
+                `INSERT OR REPLACE INTO ${table} (id, added_at, updated_at, name, short_code, discriminator, description, icon_url, banner_url, privacy, member_count) VALUES ${values}`
+            );
+        }
+    },
+
+    /**
+     * 读取全部已缓存的群实体。
+     * @returns {Promise<Map<string, object>>} groupId -> group
+     */
+    async getCachedGroups() {
+        const result = new Map();
+        if (!dbVars.userPrefix) {
+            return result;
+        }
+        const table = `${dbVars.userPrefix}_cache_group`;
+        await sqliteService.execute((dbRow) => {
+            result.set(dbRow[0], {
+                id: dbRow[0],
+                name: dbRow[1],
+                shortCode: dbRow[2],
+                discriminator: dbRow[3],
+                description: dbRow[4],
+                iconUrl: dbRow[5],
+                bannerUrl: dbRow[6],
+                privacy: dbRow[7],
+                memberCount: dbRow[8]
+            });
+        }, `SELECT id, name, short_code, discriminator, description, icon_url, banner_url, privacy, member_count FROM ${table}`);
+        return result;
+    },
+
+    /**
+     * 聚合查询：按好友加入数排序的热门群组列表。
+     * @param {number} [minFriends] 至少多少好友加入才展示
+     * @param {number} [limit]
+     * @returns {Promise<Array<{groupId: string, name: string, shortCode: string, discriminator: string, description: string, iconUrl: string, bannerUrl: string, privacy: string, memberCount: number, friendCount: number}>>}
+     */
+    async getPopularGroups(minFriends = 2, limit = 200) {
+        const result = [];
+        if (!dbVars.userPrefix) {
+            return result;
+        }
+        const groupTable = `${dbVars.userPrefix}_cache_group`;
+        const linkTable = `${dbVars.userPrefix}_friend_groups`;
+        await sqliteService.execute(
+            (dbRow) => {
+                result.push({
+                    groupId: dbRow[0],
+                    name: dbRow[1],
+                    shortCode: dbRow[2],
+                    discriminator: dbRow[3],
+                    description: dbRow[4],
+                    iconUrl: dbRow[5],
+                    bannerUrl: dbRow[6],
+                    privacy: dbRow[7],
+                    memberCount: dbRow[8],
+                    friendCount: dbRow[9]
+                });
+            },
+            `SELECT g.id, g.name, g.short_code, g.discriminator, g.description, g.icon_url, g.banner_url, g.privacy, g.member_count, COUNT(f.friend_id) AS friend_count
+            FROM ${groupTable} g
+            INNER JOIN ${linkTable} f ON f.group_id = g.id
+            GROUP BY g.id
+            HAVING COUNT(f.friend_id) >= @minFriends
+            ORDER BY friend_count DESC, g.member_count DESC
+            LIMIT @limit`,
+            {
+                '@minFriends': minFriends,
+                '@limit': limit
+            }
+        );
+        return result;
+    },
+
+    /**
+     * 每个热门群组内已加入的好友 id 列表（头像预览用）。
+     * @param {number} [minFriends]
+     * @returns {Promise<Map<string, Array<string>>>} groupId -> [friendId, ...]
+     */
+    async getPopularGroupFriendIds(minFriends = 2) {
+        const map = new Map();
+        if (!dbVars.userPrefix) {
+            return map;
+        }
+        const linkTable = `${dbVars.userPrefix}_friend_groups`;
+        await sqliteService.execute((dbRow) => {
+            if (dbRow[0]) {
+                const friendIds = dbRow[1]
+                    ? dbRow[1].split(',').filter(Boolean)
+                    : [];
+                map.set(dbRow[0], friendIds);
+            }
+        }, `SELECT group_id, GROUP_CONCAT(friend_id) FROM ${linkTable} GROUP BY group_id HAVING COUNT(friend_id) >= ${minFriends}`);
+        return map;
+    }
+};
+
+export { friendGroups };

--- a/src/services/database/index.js
+++ b/src/services/database/index.js
@@ -3,6 +3,7 @@ import { avatarFavorites } from './avatarFavorites.js';
 import { avatarTags } from './avatarTags.js';
 import { feed } from './feed.js';
 import { friendFavorites } from './friendFavorites.js';
+import { friendGroups } from './friendGroups.js';
 import { friendLogCurrent } from './friendLogCurrent.js';
 import { friendLogHistory } from './friendLogHistory.js';
 import { gameLog } from './gameLog.js';
@@ -36,6 +37,7 @@ const database = {
     ...avatarFavorites,
     ...avatarTags,
     ...friendFavorites,
+    ...friendGroups,
     ...worldFavorites,
     ...tableAlter,
     ...tableFixes,
@@ -149,6 +151,18 @@ const database = {
         );
         await sqliteService.executeNonQuery(
             `CREATE TABLE IF NOT EXISTS ${dbVars.userPrefix}_mutual_graph_meta (friend_id TEXT PRIMARY KEY, last_fetched_at TEXT, opted_out INTEGER DEFAULT 0)`
+        );
+        await sqliteService.executeNonQuery(
+            `CREATE TABLE IF NOT EXISTS ${dbVars.userPrefix}_friend_groups (friend_id TEXT NOT NULL, group_id TEXT NOT NULL, joined_at TEXT DEFAULT '', membership_status TEXT DEFAULT '', visibility TEXT DEFAULT '', fetched_at TEXT DEFAULT '', PRIMARY KEY (friend_id, group_id))`
+        );
+        await sqliteService.executeNonQuery(
+            `CREATE INDEX IF NOT EXISTS ${dbVars.userPrefix}_friend_groups_group_idx ON ${dbVars.userPrefix}_friend_groups (group_id)`
+        );
+        await sqliteService.executeNonQuery(
+            `CREATE TABLE IF NOT EXISTS ${dbVars.userPrefix}_cache_group (id TEXT PRIMARY KEY, added_at TEXT, updated_at TEXT, name TEXT, short_code TEXT, discriminator TEXT, description TEXT, icon_url TEXT, banner_url TEXT, privacy TEXT, member_count INTEGER)`
+        );
+        await sqliteService.executeNonQuery(
+            `CREATE INDEX IF NOT EXISTS ${dbVars.userPrefix}_cache_group_member_count_idx ON ${dbVars.userPrefix}_cache_group (member_count)`
         );
     },
 

--- a/src/shared/constants/ui.js
+++ b/src/shared/constants/ui.js
@@ -72,6 +72,13 @@ const navDefinitions = [
         routeName: 'friend-list'
     },
     {
+        key: 'groups',
+        icon: 'ri-community-line',
+        tooltip: 'nav_tooltip.groups',
+        labelKey: 'nav_tooltip.groups',
+        routeName: 'groups'
+    },
+    {
         key: 'moderation',
         icon: 'ri-shield-user-line',
         tooltip: 'nav_tooltip.moderation',

--- a/src/stores/friendGroups.js
+++ b/src/stores/friendGroups.js
@@ -11,6 +11,8 @@ export const useFriendGroupsStore = defineStore('FriendGroups', () => {
     const done = ref(0);
     const failed = ref(0);
     const lastSyncedAt = ref('');
+    /** 本轮同步的开始时间戳（毫秒），用于估算剩余时间 */
+    const startedAt = ref(0);
 
     function resetSyncState() {
         isSyncing.value = false;
@@ -18,6 +20,7 @@ export const useFriendGroupsStore = defineStore('FriendGroups', () => {
         done.value = 0;
         failed.value = 0;
         lastSyncedAt.value = '';
+        startedAt.value = 0;
     }
 
     return {
@@ -26,6 +29,7 @@ export const useFriendGroupsStore = defineStore('FriendGroups', () => {
         done,
         failed,
         lastSyncedAt,
+        startedAt,
         resetSyncState
     };
 });

--- a/src/stores/friendGroups.js
+++ b/src/stores/friendGroups.js
@@ -1,0 +1,31 @@
+import { ref } from 'vue';
+
+import { defineStore } from 'pinia';
+
+/**
+ * 好友群组同步状态（#1739 Popular group between Friends）。
+ */
+export const useFriendGroupsStore = defineStore('FriendGroups', () => {
+    const isSyncing = ref(false);
+    const total = ref(0);
+    const done = ref(0);
+    const failed = ref(0);
+    const lastSyncedAt = ref('');
+
+    function resetSyncState() {
+        isSyncing.value = false;
+        total.value = 0;
+        done.value = 0;
+        failed.value = 0;
+        lastSyncedAt.value = '';
+    }
+
+    return {
+        isSyncing,
+        total,
+        done,
+        failed,
+        lastSyncedAt,
+        resetSyncState
+    };
+});

--- a/src/stores/group.js
+++ b/src/stores/group.js
@@ -5,6 +5,8 @@ import { useI18n } from 'vue-i18n';
 import { hasGroupPermission, replaceBioSymbols } from '../shared/utils';
 import { groupRequest, queryRequest } from '../api';
 import { initUserGroups } from '../coordinators/groupCoordinator';
+import { syncFriendGroups } from '../coordinators/friendGroupsCoordinator';
+import { useFriendGroupsStore } from './friendGroups';
 import { watchState } from '../services/watchState';
 
 export const useGroupStore = defineStore('Group', () => {
@@ -133,6 +135,9 @@ export const useGroupStore = defineStore('Group', () => {
             currentUserGroups.clear();
             if (isLoggedIn) {
                 initUserGroups();
+                syncFriendGroups();
+            } else {
+                useFriendGroupsStore().resetSyncState();
             }
         },
         { flush: 'sync' }

--- a/src/stores/group.js
+++ b/src/stores/group.js
@@ -135,7 +135,8 @@ export const useGroupStore = defineStore('Group', () => {
             currentUserGroups.clear();
             if (isLoggedIn) {
                 initUserGroups();
-                syncFriendGroups();
+                // 登录/启动时自动全量刷新，无需在页面内手动点击
+                syncFriendGroups({ force: true });
             } else {
                 useFriendGroupsStore().resetSyncState();
             }

--- a/src/views/Groups/PopularGroups.vue
+++ b/src/views/Groups/PopularGroups.vue
@@ -124,7 +124,8 @@
         /** @type {Map<string, Array<string>>} */
         const idsMap = /** @type {any} */ (friendIdsMap.value) || new Map();
         return groups.map((group) => {
-            const friendIds = (idsMap.get(group.groupId) || []).slice(0, 5);
+            // 不截断：溢出气泡需显示真实剩余好友数
+            const friendIds = idsMap.get(group.groupId) || [];
             const friends = friendIds.map((friendId) => {
                 const ref = userStore.cachedUsers.get(friendId);
                 return {

--- a/src/views/Groups/PopularGroups.vue
+++ b/src/views/Groups/PopularGroups.vue
@@ -6,7 +6,9 @@
                     <span class="shrink-0 text-lg font-semibold">
                         {{ t('view.groups.title') }}
                     </span>
-                    <span v-if="syncStore.isSyncing && syncProgress" class="text-xs text-muted-foreground">
+                    <span
+                        v-if="syncStore.isSyncing && syncProgress"
+                        class="flex items-center gap-2 text-xs text-muted-foreground">
                         {{
                             t('view.groups.syncing_progress', {
                                 percent: `${syncProgress.percent}%`,
@@ -14,6 +16,7 @@
                                 total: syncProgress.total
                             })
                         }}
+                        <Progress :model-value="syncProgress.percent" class="h-1.5 w-32" />
                     </span>
                     <span v-else-if="syncStore.lastSyncedAt" class="text-xs text-muted-foreground">
                         {{ t('view.groups.last_synced') }}: {{ formatTime(syncStore.lastSyncedAt) }}
@@ -25,8 +28,18 @@
                 </Button>
             </div>
 
-            <div v-if="isLoading" class="mt-24 flex items-center justify-center">
-                <RefreshCcw class="size-6 animate-spin text-muted-foreground" />
+            <div v-if="isLoading" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div v-for="i in 6" :key="i" class="rounded-xl border bg-card p-4" aria-hidden="true">
+                    <div class="flex items-start gap-3">
+                        <Skeleton class="size-10 rounded-lg" />
+                        <div class="min-w-0 flex-1 space-y-2">
+                            <Skeleton class="h-4 w-2/3" />
+                            <Skeleton class="h-3 w-1/3" />
+                        </div>
+                    </div>
+                    <Skeleton class="mt-3 h-3 w-full" />
+                    <Skeleton class="mt-2 h-3 w-4/5" />
+                </div>
             </div>
 
             <div
@@ -41,7 +54,8 @@
                     v-for="card in cards"
                     :key="card.groupId"
                     type="button"
-                    class="group flex cursor-pointer flex-col rounded-xl border bg-card p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
+                    class="group flex cursor-pointer flex-col rounded-xl border bg-card p-4 text-left shadow-sm outline-none transition-all hover:-translate-y-0.5 hover:shadow-md focus-visible:ring-2 focus-visible:ring-ring/50"
+                    :aria-label="`${card.name}: ${card.friendCount} ${t('view.groups.friends_joined')}`"
                     @click="showGroupDialog(card.groupId)">
                     <div class="flex items-start gap-3">
                         <img
@@ -111,6 +125,8 @@
     import { RefreshCcw, Users } from 'lucide-vue-next';
 
     import { Button } from '@/components/ui/button';
+    import { Progress } from '@/components/ui/progress';
+    import { Skeleton } from '@/components/ui/skeleton';
     import { showGroupDialog } from '@/coordinators/groupCoordinator';
     import { syncFriendGroups } from '@/coordinators/friendGroupsCoordinator';
     import { usePopularFriendGroupIdsQuery, usePopularFriendGroupsQuery } from '@/queries/useEntityQueries';

--- a/src/views/Groups/PopularGroups.vue
+++ b/src/views/Groups/PopularGroups.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="x-container x-container--auto-height">
+    <div class="x-container">
         <div class="pt-4">
             <div class="mb-4 flex items-center justify-between">
                 <div class="flex items-center gap-2">

--- a/src/views/Groups/PopularGroups.vue
+++ b/src/views/Groups/PopularGroups.vue
@@ -6,8 +6,14 @@
                     <span class="shrink-0 text-lg font-semibold">
                         {{ t('view.groups.title') }}
                     </span>
-                    <span v-if="syncStore.isSyncing" class="text-xs text-muted-foreground">
-                        {{ t('view.groups.syncing', { done: syncStore.done, total: syncStore.total }) }}
+                    <span v-if="syncStore.isSyncing && syncProgress" class="text-xs text-muted-foreground">
+                        {{
+                            t('view.groups.syncing_progress', {
+                                percent: `${syncProgress.percent}%`,
+                                remaining: syncProgress.remaining,
+                                total: syncProgress.total
+                            })
+                        }}
                     </span>
                     <span v-else-if="syncStore.lastSyncedAt" class="text-xs text-muted-foreground">
                         {{ t('view.groups.last_synced') }}: {{ formatTime(syncStore.lastSyncedAt) }}
@@ -114,6 +120,28 @@
     const { t } = useI18n();
     const userStore = useUserStore();
     const syncStore = useFriendGroupsStore();
+
+    /**
+     * 同步进度估算：百分比 + 剩余/预计总时长（分钟，向上取整）。
+     * 基于已用时长/已处理好友数推算单好友耗时，随进度自适应。
+     */
+    const syncProgress = computed(() => {
+        if (!syncStore.isSyncing || syncStore.total === 0) {
+            return null;
+        }
+        const percent = Math.min(100, Math.floor((syncStore.done / syncStore.total) * 100));
+        const elapsedSec = syncStore.startedAt > 0 ? (Date.now() - syncStore.startedAt) / 1000 : 0;
+        if (!elapsedSec || syncStore.done === 0) {
+            return { percent, remaining: 0, total: 0 };
+        }
+        const perFriendSec = elapsedSec / syncStore.done;
+        const toMin = (sec) => Math.max(1, Math.ceil(sec / 60));
+        return {
+            percent,
+            remaining: toMin((syncStore.total - syncStore.done) * perFriendSec),
+            total: toMin(syncStore.total * perFriendSec)
+        };
+    });
 
     const { data: popularGroups, isLoading } = usePopularFriendGroupsQuery();
     const { data: friendIdsMap } = usePopularFriendGroupIdsQuery();

--- a/src/views/Groups/PopularGroups.vue
+++ b/src/views/Groups/PopularGroups.vue
@@ -1,0 +1,152 @@
+<template>
+    <div class="x-container x-container--auto-height">
+        <div class="pt-4">
+            <div class="mb-4 flex items-center justify-between">
+                <div class="flex items-center gap-2">
+                    <span class="shrink-0 text-lg font-semibold">
+                        {{ t('view.groups.title') }}
+                    </span>
+                    <span v-if="syncStore.isSyncing" class="text-xs text-muted-foreground">
+                        {{ t('view.groups.syncing', { done: syncStore.done, total: syncStore.total }) }}
+                    </span>
+                    <span v-else-if="syncStore.lastSyncedAt" class="text-xs text-muted-foreground">
+                        {{ t('view.groups.last_synced') }}: {{ formatTime(syncStore.lastSyncedAt) }}
+                    </span>
+                </div>
+                <Button variant="outline" size="sm" :disabled="syncStore.isSyncing" @click="handleRefresh">
+                    <RefreshCcw class="mr-1 size-4" :class="{ 'animate-spin': syncStore.isSyncing }" />
+                    {{ t('view.groups.refresh') }}
+                </Button>
+            </div>
+
+            <div v-if="isLoading" class="mt-24 flex items-center justify-center">
+                <RefreshCcw class="size-6 animate-spin text-muted-foreground" />
+            </div>
+
+            <div
+                v-else-if="cards.length === 0"
+                class="mt-24 flex flex-col items-center justify-center text-muted-foreground">
+                <Users class="mb-2 size-10 opacity-40" />
+                <p class="text-sm">{{ t('view.groups.empty') }}</p>
+            </div>
+
+            <div v-else class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <button
+                    v-for="card in cards"
+                    :key="card.groupId"
+                    type="button"
+                    class="group flex cursor-pointer flex-col rounded-xl border bg-card p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
+                    @click="showGroupDialog(card.groupId)">
+                    <div class="flex items-start gap-3">
+                        <img
+                            v-if="card.iconUrl"
+                            :src="card.iconUrl"
+                            class="size-10 shrink-0 rounded-lg object-cover"
+                            alt="" />
+                        <div
+                            v-else
+                            class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                            <Users class="size-5" />
+                        </div>
+                        <div class="min-w-0">
+                            <div class="truncate font-semibold">
+                                {{ card.name }}
+                            </div>
+                            <div class="text-xs text-muted-foreground">
+                                {{ card.shortCode }}.{{ card.discriminator }}
+                            </div>
+                        </div>
+                    </div>
+
+                    <p v-if="card.description" class="mt-2 line-clamp-2 text-sm text-muted-foreground">
+                        {{ card.description }}
+                    </p>
+
+                    <div class="mt-3 flex items-center justify-between">
+                        <span class="text-xs text-muted-foreground">
+                            <span class="font-semibold text-foreground">
+                                {{ card.friendCount }}
+                            </span>
+                            {{ t('view.groups.friends_joined') }}
+                        </span>
+                        <div class="flex items-center">
+                            <div class="flex -space-x-1.5">
+                                <template v-for="friend in card.friends" :key="friend.id">
+                                    <img
+                                        v-if="friend.avatarUrl"
+                                        :src="friend.avatarUrl"
+                                        class="size-6 rounded-full ring-2 ring-background"
+                                        :title="friend.displayName"
+                                        alt="" />
+                                    <div
+                                        v-else
+                                        class="flex size-6 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground ring-2 ring-background"
+                                        :title="friend.displayName">
+                                        {{ friend.displayName.charAt(0).toUpperCase() }}
+                                    </div>
+                                </template>
+                            </div>
+                            <span
+                                v-if="card.extraCount > 0"
+                                class="ml-1.5 rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                                +{{ card.extraCount }}
+                            </span>
+                        </div>
+                    </div>
+                </button>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+    import { computed } from 'vue';
+    import { useI18n } from 'vue-i18n';
+    import { RefreshCcw, Users } from 'lucide-vue-next';
+
+    import { Button } from '@/components/ui/button';
+    import { showGroupDialog } from '@/coordinators/groupCoordinator';
+    import { syncFriendGroups } from '@/coordinators/friendGroupsCoordinator';
+    import { usePopularFriendGroupIdsQuery, usePopularFriendGroupsQuery } from '@/queries/useEntityQueries';
+    import { useFriendGroupsStore } from '@/stores/friendGroups';
+    import { useUserStore } from '@/stores';
+
+    const { t } = useI18n();
+    const userStore = useUserStore();
+    const syncStore = useFriendGroupsStore();
+
+    const { data: popularGroups, isLoading } = usePopularFriendGroupsQuery();
+    const { data: friendIdsMap } = usePopularFriendGroupIdsQuery();
+
+    const cards = computed(() => {
+        /** @type {Array<{groupId: string, name: string, shortCode: string, discriminator: string, description: string, iconUrl: string, bannerUrl: string, privacy: string, memberCount: number, friendCount: number}>} */
+        const groups = /** @type {any} */ (popularGroups.value) || [];
+        /** @type {Map<string, Array<string>>} */
+        const idsMap = /** @type {any} */ (friendIdsMap.value) || new Map();
+        return groups.map((group) => {
+            const friendIds = (idsMap.get(group.groupId) || []).slice(0, 5);
+            const friends = friendIds.map((friendId) => {
+                const ref = userStore.cachedUsers.get(friendId);
+                return {
+                    id: friendId,
+                    displayName: ref?.displayName || friendId,
+                    avatarUrl: ref?.currentAvatarThumbnailImageUrl || ''
+                };
+            });
+            const visibleFriends = friends.slice(0, 4);
+            return {
+                ...group,
+                friends: visibleFriends,
+                extraCount: friends.length - visibleFriends.length
+            };
+        });
+    });
+
+    function formatTime(iso) {
+        return new Date(iso).toLocaleString();
+    }
+
+    async function handleRefresh() {
+        await syncFriendGroups({ force: true });
+    }
+</script>

--- a/src/views/MyAvatars/__tests__/MyAvatars.test.js
+++ b/src/views/MyAvatars/__tests__/MyAvatars.test.js
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
     selectAvatarWithoutConfirmation: vi.fn(),
     showAvatarDialog: vi.fn(),
     getAllAvatarTags: vi.fn(),
+    getAllAvatarTimeSpent: vi.fn(),
     getAvatarTimeSpent: vi.fn(),
     virtualMeasure: vi.fn()
 }));
@@ -107,6 +108,8 @@ vi.mock('../../../api', () => ({
 vi.mock('../../../services/database', () => ({
     database: {
         getAllAvatarTags: (...args) => mocks.getAllAvatarTags(...args),
+        getAllAvatarTimeSpent: (...args) =>
+            mocks.getAllAvatarTimeSpent(...args),
         getAvatarTimeSpent: (...args) => mocks.getAvatarTimeSpent(...args),
         addAvatarTag: vi.fn(),
         removeAvatarTag: vi.fn(),
@@ -295,6 +298,7 @@ describe('MyAvatars.vue', () => {
         mocks.getAllAvatarTags.mockResolvedValue(
             new Map([['avtr_1', [{ tag: 'fun', color: null }]]])
         );
+        mocks.getAllAvatarTimeSpent.mockResolvedValue(new Map());
         mocks.getAvatarTimeSpent.mockResolvedValue({ timeSpent: 1000 });
         mocks.processBulk.mockImplementation(async ({ handle, done }) => {
             handle({

--- a/src/views/Sidebar/components/__tests__/FriendsSidebar.test.js
+++ b/src/views/Sidebar/components/__tests__/FriendsSidebar.test.js
@@ -25,6 +25,14 @@ const mocks = vi.hoisted(() => ({
     },
     userStore: {
         showSendBoopDialog: vi.fn(),
+        editProfileDialog: {
+            value: {
+                visible: false,
+                status: '',
+                statusDescription: '',
+                loading: false
+            }
+        },
         currentUser: {
             value: {
                 id: 'usr_me',
@@ -59,6 +67,11 @@ const mocks = vi.hoisted(() => ({
     instanceStore: {
         cachedInstances: new Map()
     },
+    authStore: {},
+    modalStore: {
+        editProfileDialog: { visible: false }
+    },
+    galleryStore: {},
     configRepository: {
         getBool: vi.fn(),
         setBool: vi.fn(),
@@ -118,7 +131,10 @@ vi.mock('../../../../stores', () => ({
     useLaunchStore: () => mocks.launchStore,
     useLocationStore: () => mocks.locationStore,
     useInstanceStore: () => mocks.instanceStore,
-    useUserStore: () => mocks.userStore
+    useUserStore: () => mocks.userStore,
+    useAuthStore: () => mocks.authStore,
+    useModalStore: () => mocks.modalStore,
+    useGalleryStore: () => mocks.galleryStore
 }));
 
 vi.mock('../../../../coordinators/userCoordinator', () => ({
@@ -129,6 +145,7 @@ vi.mock('../../../../shared/utils', () => ({
     getFriendsSortFunction: () => (a, b) => a.id.localeCompare(b.id),
     isRealInstance: (location) =>
         typeof location === 'string' && location.startsWith('wrld_'),
+    debounce: (fn) => fn,
     userImage: vi.fn(() => 'https://example.com/avatar.png'),
     userStatusClass: vi.fn(() => ''),
     parseLocation: vi.fn((location) => ({


### PR DESCRIPTION
## What

Implements #1739: a **Popular Groups** view that lists the public groups your friends have joined, sorted by how many friends joined each group (card grid, matching the concept sketch).

### Features
- New **Popular Groups** page under `Social → Groups` (nav label localized: Popular Groups / 热门群组 / 熱門群組)
- Two new tables (`{prefix}_friend_groups` link table + `{prefix}_cache_group` group cache) following the existing `mutual_graph` conventions, with indexes
- **Automatic sync** on login / app start (full) with per-friend incremental refresh (24h TTL) — no manual Refresh needed to stay fresh
- **Adaptive rate limiting**: starts at ~30 req/min, steps up when the API tolerates it, backs off on 429; a 429 no longer aborts a whole sync (previously it could silently stop at ~155/199)

### UI polish (on top of the concept sketch)
The page UI was polished beyond the raw concept:

- **Sync progress header**: `% done · ~N min left · ~M min total` with a live **progress bar** (reka-ui Progress), so long full syncs stay transparent instead of showing a bare counter
- **Skeleton loading state**: a 6-card skeleton grid while data loads, instead of a plain spinner
- **Accurate overflow badge**: the friend-avatar stack shows the **real remaining count** (`+34`) — the initial implementation truncated to 5 friends first, so the badge was always `+1`
- **Accessibility**: `focus-visible` rings and `aria-label`s on every group card (keyboard navigable)
- **Clearer navigation label**: the sidebar item was the generic "Groups"; renamed to **Popular Groups** so it isn't confused with in-game groups
- i18n: en / zh-CN / zh-TW (all keys verified in both en and zh-CN UIs, no key leaks)

### Verification
- **E2E against the live VRChat API** with a real account (both zh-CN and en UI): 199 friends → 5408 friend-group relations, 2498 cached groups, card grid renders correctly; full sync ~5.5 min (was ~7 min)
- `vitest`: new friendGroups suite 16/16 + localization 23/23 green
- `oxfmt` / `oxlint` / `eslint` clean on all touched files; production build (`npm run prod-linux`) passes
- The full test suite still has **pre-existing failures unrelated to this PR** (identical failure set on `master`, verified via stash comparison). Two of them — `MyAvatars` and `FriendsSidebar` test mocks missing stores exports — were fixed in separate commits so reviewers can drop them if desired

### Files
- New: `src/services/database/friendGroups.js` (+ tests), `src/stores/friendGroups.js`, `src/coordinators/friendGroupsCoordinator.js`, `src/views/Groups/PopularGroups.vue`
- Modified: `database/index.js`, `queries/*`, `stores/group.js`, `plugins/router.js`, `navLayoutDefaults.js`, `shared/constants/ui.js`, `localization/{en,zh-CN,zh-TW}.json`