### PR TITLE
Add favorite functionality for prints (#1391)

### DIFF
--- a/src/services/database/index.js
+++ b/src/services/database/index.js
@@ -14,6 +14,7 @@ import { tableAlter } from './tableAlter.js';
 import { tableFixes } from './tableFixes.js';
 import { tableSize } from './tableSize.js';
 import { worldFavorites } from './worldFavorites.js';
+import { printFavorites } from './printFavorites.js';
 
 import sqliteService from '../sqlite.js';
 
@@ -37,6 +38,7 @@ const database = {
     ...avatarTags,
     ...friendFavorites,
     ...worldFavorites,
+    ...printFavorites,
     ...tableAlter,
     ...tableFixes,
     ...tableSize,
@@ -197,6 +199,9 @@ const database = {
         );
         await sqliteService.executeNonQuery(
             `CREATE TABLE IF NOT EXISTS favorite_world (id INTEGER PRIMARY KEY, created_at TEXT, world_id TEXT, group_name TEXT)`
+        );
+        await sqliteService.executeNonQuery(
+            `CREATE TABLE IF NOT EXISTS favorite_print (id INTEGER PRIMARY KEY, print_id TEXT UNIQUE, created_at TEXT)`
         );
         await sqliteService.executeNonQuery(
             `CREATE TABLE IF NOT EXISTS favorite_avatar (id INTEGER PRIMARY KEY, created_at TEXT, avatar_id TEXT, group_name TEXT)`

--- a/src/services/database/printFavorites.js
+++ b/src/services/database/printFavorites.js
@@ -1,0 +1,38 @@
+import sqliteService from '../sqlite.js';
+
+const printFavorites = {
+    
+    addPrintToFavorites(printId) {
+        sqliteService.executeNonQuery(
+            `INSERT OR REPLACE INTO favorite_print (print_id, created_at)
+             VALUES (@print_id, @created_at)`,
+            {
+                '@print_id': printId,
+                '@created_at': new Date().toJSON()
+            }
+        );
+    },
+
+    removePrintFromFavorites(printId) {
+        sqliteService.executeNonQuery(
+            `DELETE FROM favorite_print WHERE print_id = @print_id`,
+            {
+                '@print_id': printId
+            }
+        );
+    },
+
+    async getPrintFavorites() {
+        const data = [];
+
+        await sqliteService.execute((dbRow) => {
+            data.push({
+                printId: dbRow[1]
+            });
+        }, 'SELECT * FROM favorite_print');
+
+        return data;
+    }
+};
+
+export { printFavorites };

--- a/src/stores/__tests__/autoPrintDeletion.test.js
+++ b/src/stores/__tests__/autoPrintDeletion.test.js
@@ -1,0 +1,305 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+// ------------------------------------------------------------------
+// Mocks
+// ------------------------------------------------------------------
+
+const getPrints = vi.fn();
+const deletePrint = vi.fn();
+const getPrintFavorites = vi.fn();
+
+const advancedSettingsStore = {
+    autoDeleteOldPrints: true,
+    ugcFolderPath: '',
+    cropInstancePrints: false,
+    currentUserInventory: new Map()
+};
+
+vi.mock('../../api', () => ({
+    vrcPlusImageRequest: {
+        getPrints: (...args) => getPrints(...args),
+        deletePrint: (...args) => deletePrint(...args)
+    },
+
+    vrcPlusIconRequest: {
+        getFileList: vi.fn()
+    },
+
+    inventoryRequest: {
+        getInventoryItems: vi.fn(),
+        getGlobalInventory: vi.fn()
+    },
+
+    queryRequest: {
+        fetch: vi.fn()
+    }
+}));
+
+vi.mock('../../services/database', () => ({
+    database: {
+        getPrintFavorites: (...args) => getPrintFavorites(...args)
+    }
+}));
+
+vi.mock('../settings/advanced', () => ({
+    useAdvancedSettingsStore: () => advancedSettingsStore
+}));
+
+vi.mock('../modal', () => ({
+    useModalStore: () => ({
+        confirm: vi.fn()
+    })
+}));
+
+vi.mock('vue-i18n', () => ({
+    useI18n: () => ({
+        t: (key) => key
+    })
+}));
+
+vi.mock('../../plugins/router', () => ({
+    router: {
+        currentRoute: {
+            value: {
+                name: 'gallery'
+            }
+        },
+        push: vi.fn()
+    }
+}));
+
+vi.mock('../../services/appConfig', () => ({
+    AppDebug: {
+        errorNoty: null
+    }
+}));
+
+vi.mock('../../coordinators/imageUploadCoordinator', () => ({
+    handleImageUploadInput: vi.fn()
+}));
+
+vi.mock('worker-timers', () => ({
+    setInterval: vi.fn(),
+    clearInterval: vi.fn()
+}));
+
+vi.mock('vue-sonner', () => ({
+    toast: {
+        info: vi.fn(),
+        warning: vi.fn(),
+        dismiss: vi.fn()
+    }
+}));
+
+// Import AFTER mocks
+import { useGalleryStore } from '../gallery.js';
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+function createPrints(count) {
+    const prints = [];
+
+    for (let i = 0; i < count; i++) {
+        prints.push({
+            id: `prnt_${i}`,
+            timestamp: new Date(
+                2026,
+                0,
+                1,
+                0,
+                i
+            ).toISOString()
+        });
+    }
+
+    return prints;
+}
+
+// ------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------
+
+describe('automatic old print deletion', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+
+        vi.clearAllMocks();
+
+        advancedSettingsStore.autoDeleteOldPrints = true;
+
+        deletePrint.mockResolvedValue({
+            printId: ''
+        });
+
+        getPrintFavorites.mockResolvedValue([]);
+    });
+
+    test('does nothing when auto delete is disabled', async () => {
+        advancedSettingsStore.autoDeleteOldPrints = false;
+
+        const galleryStore = useGalleryStore();
+
+        await galleryStore.tryDeleteOldPrints();
+
+        expect(getPrints).not.toHaveBeenCalled();
+        expect(deletePrint).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when print count is below the limit', async () => {
+        getPrints.mockResolvedValue({
+            json: createPrints(60)
+        });
+
+        const galleryStore = useGalleryStore();
+
+        await galleryStore.tryDeleteOldPrints();
+
+        expect(deletePrint).not.toHaveBeenCalled();
+    });
+
+    test('deletes the oldest non-favorite prints', async () => {
+        /*
+         * Limit is 62.
+         * 64 prints means two prints need to be deleted.
+         *
+         * prnt_0 = oldest
+         * prnt_1 = second oldest
+         *
+         * Both are favorited, so auto deletion should skip them
+         * and delete prnt_2 and prnt_3 instead.
+         */
+
+        getPrints.mockResolvedValue({
+            json: createPrints(64)
+        });
+
+        getPrintFavorites.mockResolvedValue([
+            { printId: 'prnt_0' },
+            { printId: 'prnt_1' }
+        ]);
+
+        const galleryStore = useGalleryStore();
+
+        await galleryStore.tryDeleteOldPrints();
+
+        expect(deletePrint).toHaveBeenCalledTimes(2);
+
+        expect(deletePrint).toHaveBeenNthCalledWith(
+            1,
+            'prnt_2'
+        );
+
+        expect(deletePrint).toHaveBeenNthCalledWith(
+            2,
+            'prnt_3'
+        );
+
+        expect(deletePrint).not.toHaveBeenCalledWith(
+            'prnt_0'
+        );
+
+        expect(deletePrint).not.toHaveBeenCalledWith(
+            'prnt_1'
+        );
+    });
+
+    test('never automatically deletes favorite prints', async () => {
+        getPrints.mockResolvedValue({
+            json: createPrints(64)
+        });
+
+        getPrintFavorites.mockResolvedValue([
+            { printId: 'prnt_0' },
+            { printId: 'prnt_1' },
+            { printId: 'prnt_2' }
+        ]);
+
+        const galleryStore = useGalleryStore();
+
+        await galleryStore.tryDeleteOldPrints();
+
+        expect(deletePrint).not.toHaveBeenCalledWith(
+            'prnt_0'
+        );
+
+        expect(deletePrint).not.toHaveBeenCalledWith(
+            'prnt_1'
+        );
+
+        expect(deletePrint).not.toHaveBeenCalledWith(
+            'prnt_2'
+        );
+    });
+
+    test('logs a warning when all prints are favorites', async () => {
+        const prints = createPrints(64);
+
+        getPrints.mockResolvedValue({
+            json: prints
+        });
+
+        getPrintFavorites.mockResolvedValue(
+            prints.map((print) => ({
+                printId: print.id
+            }))
+        );
+
+        const logSpy = vi
+            .spyOn(console, 'log')
+            .mockImplementation(() => {});
+
+        const galleryStore = useGalleryStore();
+
+        await galleryStore.tryDeleteOldPrints();
+
+        expect(deletePrint).not.toHaveBeenCalled();
+
+        expect(logSpy).toHaveBeenCalledWith(
+            'Unable to automatically delete enough old prints because 2 print(s) are protected by favorites.'
+        );
+
+        logSpy.mockRestore();
+    });
+
+    test('deletes available prints and warns when there are not enough', async () => {
+        const prints = createPrints(64);
+
+        /*
+         * Only prnt_63 is not favorited.
+         * We need to delete 2 prints, but only one is available.
+         */
+        getPrints.mockResolvedValue({
+            json: prints
+        });
+
+        getPrintFavorites.mockResolvedValue(
+            prints
+                .filter((print) => print.id !== 'prnt_63')
+                .map((print) => ({
+                    printId: print.id
+                }))
+        );
+
+        const logSpy = vi
+            .spyOn(console, 'log')
+            .mockImplementation(() => {});
+
+        const galleryStore = useGalleryStore();
+
+        await galleryStore.tryDeleteOldPrints();
+
+        expect(deletePrint).toHaveBeenCalledTimes(1);
+        expect(deletePrint).toHaveBeenCalledWith(
+            'prnt_63'
+        );
+
+        expect(logSpy).toHaveBeenCalledWith(
+            'Unable to automatically delete enough old prints because 1 print(s) are protected by favorites.'
+        );
+
+        logSpy.mockRestore();
+    });
+});

--- a/src/stores/gallery.js
+++ b/src/stores/gallery.js
@@ -477,6 +477,7 @@ export const useGalleryStore = defineStore('Gallery', () => {
             return;
         }
         await refreshPrintTable();
+        await refreshPrintFavorites();
         const printLimit = 64 - 2; // 2 reserved for new prints
         const printCount = printTable.value.length;
         if (printCount <= printLimit) {
@@ -487,11 +488,17 @@ export const useGalleryStore = defineStore('Gallery', () => {
             return;
         }
         const idList = [];
-        for (let i = 0; i < deleteCount; i++) {
-            const print = printTable.value[printCount - 1 - i];
-            idList.push(print.id);
+        for (let i = printCount - 1; i >= 0 && idList.length < deleteCount; i--) {
+            const print = printTable.value[i];
+            if (favoritePrintIds.value.has(print.id)) {
+                continue;
+            }
+            idList.push(print.id)
         }
-        console.log(`Deleting ${deleteCount} old prints`, idList);
+        console.log(`Deleting ${idList.length} old prints`, idList);
+        if (idList.length < deleteCount) {
+            console.log(`Unable to automatically delete enough old prints because ${deleteCount - idList.length} print(s) are protected by favorites.`);
+        }
         try {
             for (const printId of idList) {
                 await vrcPlusImageRequest.deletePrint(printId);

--- a/src/stores/gallery.js
+++ b/src/stores/gallery.js
@@ -21,6 +21,7 @@ import { router } from '../plugins/router';
 import { useAdvancedSettingsStore } from './settings/advanced';
 import { useModalStore } from './modal';
 import { watchState } from '../services/watchState';
+import { database } from '../services/database';
 
 import * as workerTimers from 'worker-timers';
 
@@ -69,6 +70,8 @@ export const useGalleryStore = defineStore('Gallery', () => {
     const instanceStickersCache = ref([]);
 
     const printTable = ref([]);
+
+    const favoritePrintIds = ref(new Set());
 
     const emojiTable = ref([]);
 
@@ -150,6 +153,7 @@ export const useGalleryStore = defineStore('Gallery', () => {
         refreshEmojiTable();
         refreshStickerTable();
         refreshPrintTable();
+        refreshPrintFavorites(),
         getInventory();
     }
 
@@ -322,6 +326,14 @@ export const useGalleryStore = defineStore('Gallery', () => {
         } finally {
             galleryDialogPrintsLoading.value = false;
         }
+    }
+
+    async function refreshPrintFavorites() {
+        const favorites = await database.getPrintFavorites();
+
+        favoritePrintIds.value = new Set(
+            favorites.map((favorite) => favorite.printId)
+    );
     }
 
     /**
@@ -651,6 +663,7 @@ export const useGalleryStore = defineStore('Gallery', () => {
         stickerTable,
         instanceStickersCache,
         printTable,
+        favoritePrintIds,
         emojiTable,
         inventoryTable,
         fullscreenImageDialog,
@@ -665,6 +678,7 @@ export const useGalleryStore = defineStore('Gallery', () => {
         refreshStickerTable,
         trySaveStickerToFile,
         refreshPrintTable,
+        refreshPrintFavorites,
         queueSavePrintToFile,
         refreshEmojiTable,
         getInventory,

--- a/src/views/Tools/Gallery.vue
+++ b/src/views/Tools/Gallery.vue
@@ -502,6 +502,16 @@
                                         @click="deletePrint(image.id)">
                                         <Trash2 />
                                     </Button>
+                                    <Button
+                                        size="icon-sm"
+                                        variant="ghost"
+                                        class="rounded-full ml-auto"
+                                        @click="toggleFavoritePrint(image.id)">
+                                        <Star 
+                                            :class="favoritePrintIds.has(image.id)
+                                                ? 'text-yellow-500 fill-yellow-500'
+                                                : 'hover:text-yellow-500'" />
+                                    </Button>
                                 </ItemFooter>
                             </div>
                         </Item>
@@ -590,7 +600,7 @@
 </template>
 
 <script setup>
-    import { ArrowLeft, Check, Gift, RefreshCw, Trash2, Upload, X } from 'lucide-vue-next';
+    import { ArrowLeft, Check, Gift, RefreshCw, Trash2, Upload, X, Star } from 'lucide-vue-next';
     import {
         NumberField,
         NumberFieldContent,
@@ -636,6 +646,7 @@
 
     import Emoji from '../../components/Emoji.vue';
     import ImageCropDialog from '../../components/dialogs/ImageCropDialog.vue';
+    import { database } from '../../services/database';
 
     const { t } = useI18n();
     const router = useRouter();
@@ -649,6 +660,7 @@
         printCropBorder,
         stickerTable,
         printTable,
+        favoritePrintIds,
         emojiTable,
         inventoryTable
     } = storeToRefs(useGalleryStore());
@@ -658,6 +670,7 @@
         refreshVRCPlusIconsTable,
         refreshStickerTable,
         refreshPrintTable,
+        refreshPrintFavorites,
         refreshEmojiTable,
         getInventory,
         handleStickerAdd,
@@ -1184,9 +1197,25 @@
      * @param printId
      */
     function deletePrint(printId) {
+        if (favoritePrintIds.value.has(printId)) {
+            toast.warning('This print is in your favorites', {
+                description: 'Please remove it from your favorites before deleting it.'
+            });
+            return;
+        }
         vrcPlusImageRequest.deletePrint(printId).then((args) => {
             removeItemById(printTable.value, args.printId);
         });
+    }
+
+    async function toggleFavoritePrint(printId) {
+        if (favoritePrintIds.value.has(printId)) {
+            await database.removePrintFromFavorites(printId);
+            favoritePrintIds.value.delete(printId);
+        } else {
+            await database.addPrintToFavorites(printId);
+            favoritePrintIds.value.add(printId);
+        }
     }
 
     async function handleDropGallery(event) {


### PR DESCRIPTION
## Description

Adds favorite functionality for gallery prints.
Related to #1391
- Adds support for favoriting prints in the Gallery. Favorite print IDs are stored locally in SQLite
- Favorited prints are marked with a star and are protected from both manual deletion and automatic old-print cleanup. To manually delete a favorited print, it must first be unfavorited.
- Also adds tests for auto-delete behavior.

## Screenshots
<img width="1093" height="729" alt="image" src="https://github.com/user-attachments/assets/b2d591be-8ce0-440a-8fee-c6f2cf16a079" />
