### PR TITLE
fix: show queue size indicator

### DIFF
--- a/src/components/InstanceActionBar.vue
+++ b/src/components/InstanceActionBar.vue
@@ -346,7 +346,7 @@
     const showLastJoinIndicator = computed(() => props.showLastJoin && lastJoin.value);
     const hasInstanceMetadata = computed(() => {
         return !!(
-            props.instance.value?.queueSize ||
+            props.instance?.queueSize ||
             instanceInfoState.isAgeGated ||
             instanceInfoState.isRoleRestricted ||
             (props.instance.minimumAvatarPerformance && props.instance.minimumAvatarPerformance !== 'None')


### PR DESCRIPTION
`hasInstanceMetadata` reads `props.instance.value?.queueSize`, but `props.instance` is a plain props object rather than a ref, so `.value` is always `undefined`.
The queue term never opens the gate, and instances whose only metadata is a queue render no indicator at all.