### PR TITLE
Adds an option to auto decline spam friend requests

### DIFF
--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -749,6 +749,9 @@
                 },
                 "favorites": {
                     "header": "Favorites"
+                },
+                "friend_requests": {
+                    "header": "Friend Reqeusts"
                 }
             },
             "vr": {
@@ -869,6 +872,10 @@
                 },
                 "contributors": {
                     "header": "Contributors"
+                },
+                "friend_requests": {
+                    "header": "Auto-decline Spam Friend Requests",
+                    "header_tooltip": "Auto-decline requests from users you haven't met (never been in the same instance)."
                 }
             },
             "appearance": {

--- a/src/stores/__tests__/notification.test.js
+++ b/src/stores/__tests__/notification.test.js
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+vi.mock('../../services/database', () => ({
+    database: {
+        getJoinCount: vi.fn(),
+        addNotificationToDatabase: vi.fn(),
+        addNotificationV2ToDatabase: vi.fn(),
+        updateNotificationExpired: vi.fn(),
+        seenNotificationV2: vi.fn()
+    },
+    dbVars: {
+        maxTableSize: 1000
+    }
+}));
+
+vi.mock('../../api', () => ({
+    friendRequest: {},
+    instanceRequest: {
+        getInstance: vi.fn()
+    },
+    notificationRequest: {
+        hideNotification: vi.fn(() => Promise.resolve({})),
+        getNotifications: vi.fn(() => Promise.resolve({ json: [] })),
+        getNotificationsV2: vi.fn(() => Promise.resolve({ json: [] })),
+        getHiddenFriendRequests: vi.fn(() => Promise.resolve({ json: [] }))
+    },
+    queryRequest: {
+        fetch: vi.fn()
+    }
+}));
+vi.mock('@/plugins', () => ({
+    i18n: {
+        global: {
+            t: vi.fn((key) => key)
+        }
+    },
+    loadLocalizedStrings: vi.fn(() => Promise.resolve())
+}));
+vi.mock('vue-i18n', () => ({
+    useI18n: () => ({
+        t: vi.fn((key) => key),
+        locale: ref('en')
+    })
+}));
+vi.mock('../../services/config', () => ({
+    default: {
+        getBool: vi.fn((key, defaultValue) => {
+            if (key === 'VRCX_autoDeclineFriendRequests') {
+                return Promise.resolve(true);
+            }
+            return Promise.resolve(defaultValue);
+        }),
+        getInt: vi.fn((_key, defaultValue) =>
+            Promise.resolve(defaultValue)
+        ),
+        getFloat: vi.fn((_key, defaultValue) =>
+            Promise.resolve(defaultValue)
+        ),
+        getString: vi.fn((_key, defaultValue) =>
+            Promise.resolve(defaultValue)
+        ),
+
+        setBool: vi.fn(),
+        setInt: vi.fn(),
+        setFloat: vi.fn(),
+        setString: vi.fn(),
+
+        remove: vi.fn(() => Promise.resolve())
+    }
+}));
+vi.mock('../ui', () => ({
+    useUiStore: () => ({
+        notifyMenu: vi.fn(),
+        removeNotify: vi.fn()
+    })
+}));
+import { ref } from 'vue';
+vi.mock('vue-router', () => ({
+    useRouter: () => ({
+        currentRoute: ref({
+            name: 'test'
+        })
+    })
+}));
+vi.mock('../../plugins/router', () => ({
+    router: {
+        currentRoute: ref({
+            name: 'test'
+        }),
+        push: vi.fn(),
+        replace: vi.fn()
+    }
+}));
+vi.mock('../../shared/utils', async () => {
+    const actual = await vi.importActual('../../shared/utils');
+
+    return {
+        ...(actual ?? {}),
+        loadLocalizedStrings: vi.fn(() => Promise.resolve())
+    };
+});
+
+const { database } = await import('../../services/database');
+const { notificationRequest } = await import('../../api');
+
+const { useNotificationStore } = await import('../notification');
+const { useGeneralSettingsStore } = await import('../settings/general');
+
+describe('notification store - auto decline friend requests', () => {
+    let notificationStore;
+    let generalSettingsStore;
+
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        vi.clearAllMocks();
+
+        notificationStore = useNotificationStore();
+        generalSettingsStore = useGeneralSettingsStore();
+
+        generalSettingsStore.autoDeclineFriendRequests = true;
+    });
+
+    it('declines a friend request when join count is 0', async () => {
+        vi.mocked(database.getJoinCount).mockResolvedValue({
+            joinCount: '0',
+            userId: 'usr_test'
+        });
+
+        const ref = {
+            id: 'not_test',
+            type: 'friendRequest',
+            senderUserId: 'usr_test',
+            senderUsername: 'TestUser'
+        };
+
+        // handleNotification normally runs before handlePipelineNotification,
+        // so put the notification in the local table first.
+        notificationStore.notificationTable.data.push(ref);
+
+        notificationStore.handlePipelineNotification({
+            json: ref,
+            params: {
+                notificationId: ref.id
+            }
+        });
+
+        await vi.waitFor(() => {
+            expect(database.getJoinCount).toHaveBeenCalledWith({
+                id: 'usr_test',
+                displayName: 'TestUser'
+            });
+        });
+
+        await vi.waitFor(() => {
+            expect(notificationRequest.hideNotification).toHaveBeenCalledWith({
+                notificationId: 'not_test'
+            });
+        });
+
+        await vi.waitFor(() => {
+            expect(notificationStore.notificationTable.data).not.toContain(ref);
+        });
+    });
+
+    it('does not decline when join count is greater than 0', async () => {
+        vi.mocked(database.getJoinCount).mockResolvedValue({
+            joinCount: '2',
+            userId: 'usr_test'
+        });
+
+        const ref = {
+            id: 'not_test',
+            type: 'friendRequest',
+            senderUserId: 'usr_test',
+            senderUsername: 'TestUser'
+        };
+
+        notificationStore.notificationTable.data.push(ref);
+
+        notificationStore.handlePipelineNotification({
+            json: ref,
+            params: {
+                notificationId: ref.id
+            }
+        });
+
+        await vi.waitFor(() => {
+            expect(database.getJoinCount).toHaveBeenCalled();
+        });
+
+        expect(notificationRequest.hideNotification).not.toHaveBeenCalled();
+        expect(
+            notificationStore.notificationTable.data.some(
+                (n) => n.id === 'not_test'
+            )
+        ).toBe(true);
+    });
+
+    it('does nothing when auto decline is disabled', async () => {
+        generalSettingsStore.autoDeclineFriendRequests = false;
+
+        const ref = {
+            id: 'not_test',
+            type: 'friendRequest',
+            senderUserId: 'usr_test',
+            senderUsername: 'TestUser'
+        };
+
+        notificationStore.handlePipelineNotification({
+            json: ref,
+            params: {
+                notificationId: ref.id
+            }
+        });
+
+        await Promise.resolve();
+
+        expect(database.getJoinCount).not.toHaveBeenCalled();
+        expect(notificationRequest.hideNotification).not.toHaveBeenCalled();
+    });
+
+    it('does not run auto decline logic for other notification types', async () => {
+        const ref = {
+            id: 'not_test',
+            type: 'invite',
+            senderUserId: 'usr_test',
+            senderUsername: 'TestUser'
+        };
+
+        notificationStore.handlePipelineNotification({
+            json: ref,
+            params: {
+                notificationId: ref.id
+            }
+        });
+
+        await Promise.resolve();
+
+        expect(database.getJoinCount).not.toHaveBeenCalled();
+        expect(notificationRequest.hideNotification).not.toHaveBeenCalled();
+    });
+});

--- a/src/stores/notification/index.js
+++ b/src/stores/notification/index.js
@@ -280,6 +280,12 @@ export const useNotificationStore = defineStore('Notification', () => {
     function handlePipelineNotification(args) {
         const ref = args.json;
         if (
+            ref.type === 'friendRequest' &&
+            generalSettingsStore.autoDeclineFriendRequests
+        ) {
+            handleAutoDeclineFriendRequest(ref);
+        }
+        if (
             ref.type !== 'requestInvite' ||
             generalSettingsStore.autoAcceptInviteRequests === 'Off'
         ) {
@@ -389,6 +395,22 @@ export const useNotificationStore = defineStore('Notification', () => {
                         console.error(err);
                     });
             });
+    }
+
+    async function handleAutoDeclineFriendRequest(ref) {
+        const joinInfo = await database.getJoinCount({
+            id: ref.senderUserId,
+            displayName: ref.senderUsername
+        });
+
+        if (Number(joinInfo.joinCount) !== 0) {
+            return;
+        }
+
+        await notificationRequest.hideNotification({
+            notificationId: ref.id
+        });
+        handleNotificationHide(ref.id);
     }
 
     /**

--- a/src/stores/settings/general.js
+++ b/src/stores/settings/general.js
@@ -44,6 +44,7 @@ export const useGeneralSettingsStore = defineStore('GeneralSettings', () => {
     const autoAcceptInviteGroups = ref([]);
     const recentActionCooldownEnabled = ref(false);
     const recentActionCooldownMinutes = ref(60);
+    const autoDeclineFriendRequests = ref(false);
 
     async function initGeneralSettings() {
         const [
@@ -72,7 +73,8 @@ export const useGeneralSettingsStore = defineStore('GeneralSettings', () => {
             autoAcceptInviteRequestsConfig,
             autoAcceptInviteGroupsStrConfig,
             recentActionCooldownEnabledConfig,
-            recentActionCooldownMinutesConfig
+            recentActionCooldownMinutesConfig,
+            autoDeclineFriendRequestsConfig
         ] = await Promise.all([
             configRepository.getBool('VRCX_StartAtWindowsStartup', false),
             VRCXStorage.Get('VRCX_StartAsMinimizedState'),
@@ -114,7 +116,8 @@ export const useGeneralSettingsStore = defineStore('GeneralSettings', () => {
             configRepository.getString('VRCX_autoAcceptInviteRequests', 'Off'),
             configRepository.getString('VRCX_autoAcceptInviteGroups', '[]'),
             configRepository.getBool('VRCX_recentActionCooldownEnabled', false),
-            configRepository.getInt('VRCX_recentActionCooldownMinutes', 60)
+            configRepository.getInt('VRCX_recentActionCooldownMinutes', 60),
+            configRepository.getBool('VRCX_autoDeclineFriendRequests', false)
         ]);
 
         isStartAtWindowsStartup.value = isStartAtWindowsStartupConfig;
@@ -167,6 +170,7 @@ export const useGeneralSettingsStore = defineStore('GeneralSettings', () => {
         );
         recentActionCooldownEnabled.value = recentActionCooldownEnabledConfig;
         recentActionCooldownMinutes.value = recentActionCooldownMinutesConfig;
+        autoDeclineFriendRequests.value = autoDeclineFriendRequestsConfig;
     }
 
     initGeneralSettings();
@@ -441,6 +445,14 @@ export const useGeneralSettingsStore = defineStore('GeneralSettings', () => {
         );
     }
 
+    function setAutoDeclineFriendRequests() {
+        autoDeclineFriendRequests.value = !autoDeclineFriendRequests.value;
+        configRepository.setBool(
+            'VRCX_autoDeclineFriendRequests',
+             autoDeclineFriendRequests.value
+        );
+    }
+
     return {
         isStartAtWindowsStartup,
         isStartAsMinimizedState,
@@ -467,6 +479,7 @@ export const useGeneralSettingsStore = defineStore('GeneralSettings', () => {
         autoAcceptInviteGroups,
         recentActionCooldownEnabled,
         recentActionCooldownMinutes,
+        autoDeclineFriendRequests,
 
         setIsStartAtWindowsStartup,
         setIsStartAsMinimizedState,
@@ -493,6 +506,7 @@ export const useGeneralSettingsStore = defineStore('GeneralSettings', () => {
         setAutoAcceptInviteGroups,
         promptProxySettings,
         setRecentActionCooldownEnabled,
-        setRecentActionCooldownMinutes
+        setRecentActionCooldownMinutes,
+        setAutoDeclineFriendRequests
     };
 });

--- a/src/views/Settings/components/Tabs/SocialTab.vue
+++ b/src/views/Settings/components/Tabs/SocialTab.vue
@@ -30,6 +30,17 @@
             </SettingsItem>
         </SettingsGroup>
 
+        <SettingsGroup :title="t('view.settings.social.friend_requests.header')">
+            <SettingsItem
+                :label="t('view.settings.general.friend_requests.header')"
+                :description="t('view.settings.general.friend_requests.header_tooltip')">
+                <Switch
+                    :model-value="autoDeclineFriendRequests"
+                    :ariaLabel="t('view.settings.general.friend_requests.header')"
+                    @update:modelValue="setAutoDeclineFriendRequests" />
+            </SettingsItem>
+        </SettingsGroup>
+
         <SettingsGroup :title="t('view.settings.social.favorites.header')">
             <SettingsItem
                 :label="t('view.settings.general.favorites.header')"
@@ -97,11 +108,19 @@
     const generalSettingsStore = useGeneralSettingsStore();
     const favoriteStore = useFavoriteStore();
 
-    const { recentActionCooldownEnabled, recentActionCooldownMinutes, localFavoriteFriendsGroups } =
-        storeToRefs(generalSettingsStore);
+    const {
+        recentActionCooldownEnabled,
+        recentActionCooldownMinutes,
+        localFavoriteFriendsGroups,
+        autoDeclineFriendRequests
+    } = storeToRefs(generalSettingsStore);
 
-    const { setRecentActionCooldownEnabled, setRecentActionCooldownMinutes, setLocalFavoriteFriendsGroups } =
-        generalSettingsStore;
+    const { 
+        setRecentActionCooldownEnabled, 
+        setRecentActionCooldownMinutes,
+        setLocalFavoriteFriendsGroups,
+        setAutoDeclineFriendRequests 
+    } = generalSettingsStore;
 
     const { favoriteFriendGroups, localFriendFavoriteGroups } = storeToRefs(favoriteStore);
 </script>


### PR DESCRIPTION
## Description

Adds an option to automatically decline incoming friend requests from users who have never joined the same instance as the current user. Relates to #1599.

## Changes

- Added an Auto Decline Spam Friend Requests toggle under Settings -> Social, disabled by default.
- Checks the sender's locally cached join history when receiving a friend request and automatically declines the request when the join count is 0.
- Leaves the request unchanged if the user has previously joined the same instance.
- Added tests for the new functionality.
